### PR TITLE
de-center accuracy as a concept in the evidence threshold computation

### DIFF
--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -43,9 +43,7 @@ def compute_transition_matrix(pst, dt: DecisionTree) -> np.ndarray:
         classify_states_with_decision_tree(
             pst,
             dt.map_over_predicates(
-                lambda p, c=c: TriPredicate(
-                    [[c] + x for x in p.vs], p.evidence_threshold
-                )
+                lambda p, c=c: TriPredicate([[c] + x for x in p.vs], p.evidence_margin)
             ),
         )
         for c in range(pst.alphabet_size)

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -137,10 +137,10 @@ def generate_counterexamples(
     pst, us, oracle, dt, dfa, *, count, suffix_size_counterexample_gen
 ):
     dt_with_reduced_predicates = dt.map_over_predicates(
-        lambda p: TriPredicate(p.vs[:suffix_size_counterexample_gen], 0.5)
+        lambda p: TriPredicate(p.vs[:suffix_size_counterexample_gen], 0)
     )
     dt_with_decisive_predicates = dt.map_over_predicates(
-        lambda p: TriPredicate(p.vs, 0.5)
+        lambda p: TriPredicate(p.vs, 0)
     )
     pbar = tqdm.tqdm(total=count)
     additional_prefixes = []

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -43,7 +43,9 @@ def compute_transition_matrix(pst, dt: DecisionTree) -> np.ndarray:
         classify_states_with_decision_tree(
             pst,
             dt.map_over_predicates(
-                lambda p, c=c: TriPredicate([[c] + x for x in p.vs], p.evidence_margin)
+                lambda p, c=c: TriPredicate(
+                    [[c] + x for x in p.vs], p.accept_threshold, p.reject_threshold
+                )
             ),
         )
         for c in range(pst.alphabet_size)
@@ -137,10 +139,10 @@ def generate_counterexamples(
     pst, us, oracle, dt, dfa, *, count, suffix_size_counterexample_gen
 ):
     dt_with_reduced_predicates = dt.map_over_predicates(
-        lambda p: TriPredicate(p.vs[:suffix_size_counterexample_gen], 0)
+        lambda p: TriPredicate(p.vs[:suffix_size_counterexample_gen], 0.5, 0.5)
     )
     dt_with_decisive_predicates = dt.map_over_predicates(
-        lambda p: TriPredicate(p.vs, 0)
+        lambda p: TriPredicate(p.vs, 0.5, 0.5)
     )
     pbar = tqdm.tqdm(total=count)
     additional_prefixes = []

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -17,7 +17,7 @@ def compute_mask(for_state, oracle, v):
 @dataclass
 class SearchConfig:
     suffix_family_size: int
-    evidence_thresh: float
+    evidence_margin: float
     decision_rule_fpr: float
     suffix_size_counterexample_gen: int
     num_addtl_prefixes: Optional[int] = None
@@ -126,8 +126,8 @@ class PrefixSuffixTracker:
         decision = self.compute_decision_from_strings(vs)
         return np.array(
             [
-                decision < 1 - self.config.evidence_thresh,
-                decision >= self.config.evidence_thresh,
+                decision < 0.5 - self.config.evidence_margin,
+                decision >= 0.5 + self.config.evidence_margin,
             ]
         )
 

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -40,6 +40,14 @@ class PrefixSuffixTracker:
     def alphabet_size(self) -> int:
         return self.oracle.alphabet_size
 
+    @property
+    def accept_thresh(self) -> float:
+        return 0.5 + self.config.evidence_margin
+
+    @property
+    def reject_thresh(self) -> float:
+        return 0.5 - self.config.evidence_margin
+
     @classmethod
     def create(
         cls,
@@ -126,8 +134,8 @@ class PrefixSuffixTracker:
         decision = self.compute_decision_from_strings(vs)
         return np.array(
             [
-                decision < 0.5 - self.config.evidence_margin,
-                decision >= 0.5 + self.config.evidence_margin,
+                decision < self.reject_thresh,
+                decision >= self.accept_thresh,
             ]
         )
 

--- a/orthogonal_dfa/l_star/state_discovery.py
+++ b/orthogonal_dfa/l_star/state_discovery.py
@@ -40,24 +40,31 @@ class StateTracker:
         return [path for path, _ in self.states]
 
     @staticmethod
-    def _extend_path(path, vs_actual, evidence_margin, accepted):
-        return path + [(TriPredicate(vs_actual, evidence_margin), accepted)]
+    def _extend_path(path, vs_actual, accept_thresh, reject_thresh, accepted):
+        return path + [
+            (TriPredicate(vs_actual, accept_thresh, reject_thresh), accepted)
+        ]
 
     def split(self, pst, state_indices, vs):
         states_to_split = [self.states.pop(i) for i in reversed(sorted(state_indices))]
         for path, mask in states_to_split:
             decision = pst.compute_decision(vs, mask)
             vs_actual = [pst.suffix_bank[v] for v in vs]
-            margin = pst.config.evidence_margin
+            accept_thresh = 0.5 + pst.config.evidence_margin
+            reject_thresh = 0.5 - pst.config.evidence_margin
             self.states.extend(
                 [
                     (
-                        self._extend_path(path, vs_actual, margin, True),
-                        cascade(mask, decision >= 0.5 + margin),
+                        self._extend_path(
+                            path, vs_actual, accept_thresh, reject_thresh, True
+                        ),
+                        cascade(mask, decision >= accept_thresh),
                     ),
                     (
-                        self._extend_path(path, vs_actual, margin, False),
-                        cascade(mask, decision < 0.5 - margin),
+                        self._extend_path(
+                            path, vs_actual, accept_thresh, reject_thresh, False
+                        ),
+                        cascade(mask, decision < reject_thresh),
                     ),
                 ]
             )

--- a/orthogonal_dfa/l_star/state_discovery.py
+++ b/orthogonal_dfa/l_star/state_discovery.py
@@ -50,8 +50,8 @@ class StateTracker:
         for path, mask in states_to_split:
             decision = pst.compute_decision(vs, mask)
             vs_actual = [pst.suffix_bank[v] for v in vs]
-            accept_thresh = 0.5 + pst.config.evidence_margin
-            reject_thresh = 0.5 - pst.config.evidence_margin
+            accept_thresh = pst.accept_thresh
+            reject_thresh = pst.reject_thresh
             self.states.extend(
                 [
                     (
@@ -116,8 +116,8 @@ def overlapping_states(pst, tracker, vs):
     decision = pst.compute_decision(vs, np.ones(pst.num_prefixes, dtype=bool))
     masks = np.array(
         [
-            decision > 0.5 + pst.config.evidence_margin,
-            decision < 0.5 - pst.config.evidence_margin,
+            decision >= pst.accept_thresh,
+            decision < pst.reject_thresh,
         ]
     )
     existing_states = tracker.state_masks

--- a/orthogonal_dfa/l_star/state_discovery.py
+++ b/orthogonal_dfa/l_star/state_discovery.py
@@ -40,24 +40,24 @@ class StateTracker:
         return [path for path, _ in self.states]
 
     @staticmethod
-    def _extend_path(path, vs_actual, evidence_thresh, accepted):
-        return path + [(TriPredicate(vs_actual, evidence_thresh), accepted)]
+    def _extend_path(path, vs_actual, evidence_margin, accepted):
+        return path + [(TriPredicate(vs_actual, evidence_margin), accepted)]
 
     def split(self, pst, state_indices, vs):
         states_to_split = [self.states.pop(i) for i in reversed(sorted(state_indices))]
         for path, mask in states_to_split:
             decision = pst.compute_decision(vs, mask)
             vs_actual = [pst.suffix_bank[v] for v in vs]
-            thresh = pst.config.evidence_thresh
+            margin = pst.config.evidence_margin
             self.states.extend(
                 [
                     (
-                        self._extend_path(path, vs_actual, thresh, True),
-                        cascade(mask, decision >= thresh),
+                        self._extend_path(path, vs_actual, margin, True),
+                        cascade(mask, decision >= 0.5 + margin),
                     ),
                     (
-                        self._extend_path(path, vs_actual, thresh, False),
-                        cascade(mask, decision < 1 - thresh),
+                        self._extend_path(path, vs_actual, margin, False),
+                        cascade(mask, decision < 0.5 - margin),
                     ),
                 ]
             )
@@ -109,8 +109,8 @@ def overlapping_states(pst, tracker, vs):
     decision = pst.compute_decision(vs, np.ones(pst.num_prefixes, dtype=bool))
     masks = np.array(
         [
-            decision > pst.config.evidence_thresh,
-            decision < 1 - pst.config.evidence_thresh,
+            decision > 0.5 + pst.config.evidence_margin,
+            decision < 0.5 - pst.config.evidence_margin,
         ]
     )
     existing_states = tracker.state_masks

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -6,7 +6,7 @@ import scipy
 
 
 def population_size_and_evidence_thresh(
-    p_acc, acceptable_fpr, acceptable_fnr, *, relative_eps=0.5
+    p_acc, acceptable_fpr, acceptable_fnr
 ) -> Tuple[int, float]:
     """
     Decisions will be made by taking N samples and seeing if the proportion is outside
@@ -30,21 +30,21 @@ def population_size_and_evidence_thresh(
         else:
             N_try = (N_low + N_high) // 2
         result = evidence_thresh_for_population_size(
-            p_acc, acceptable_fpr, acceptable_fnr, N_try, relative_eps=relative_eps
+            p_acc, acceptable_fpr, acceptable_fnr, N_try
         )
         if result is None:
             N_low = N_try + 1
         else:
             N_high = N_try
     res = evidence_thresh_for_population_size(
-        p_acc, acceptable_fpr, acceptable_fnr, N_high, relative_eps=relative_eps
+        p_acc, acceptable_fpr, acceptable_fnr, N_high
     )
     assert res is not None
     return res
 
 
 def evidence_thresh_for_population_size(
-    p_acc, acceptable_fpr, acceptable_fnr, N, *, relative_eps
+    p_acc, acceptable_fpr, acceptable_fnr, N
 ) -> Optional[Tuple[int, float]]:
     """
     See population_size_and_evidence_thresh for context.
@@ -56,7 +56,7 @@ def evidence_thresh_for_population_size(
             1 - scipy.stats.binom.cdf(k_high - 1, N, 0.5)
         )
         fnr = scipy.stats.binom.cdf(
-            k_high - 1, N, 0.5 + (p_acc - 0.5) * relative_eps
+            k_high - 1, N, p_acc
         ) - scipy.stats.binom.cdf(k_low, N, p_acc)
         if fpr <= acceptable_fpr and fnr <= acceptable_fnr:
             return N, eps

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -6,22 +6,17 @@ import scipy
 
 
 def population_size_and_evidence_thresh(
-    p_acc, acceptable_fpr, acceptable_fnr
+    signal_strength, acceptable_fpr, acceptable_fnr
 ) -> Tuple[int, float]:
     """
     Decisions will be made by taking N samples and seeing if the proportion is outside
-    (0.5 - epsilon, 0.5 + epsilon). The true distribution is assumed to be B(p_acc) when
-    the underlying value is 1 and B(1 - p_acc) when it is 0. We would like it to be the
-    case that when samples are drawn from the null distribution B(0.5), we have a false
-    positive rate of at most acceptable_fpr, and when samples are drawn from the true
-    distribution we have a false negative rate of at most acceptable_fnr.
+    (center - epsilon, center + epsilon). The true distribution has accept rate
+    center + signal_strength and reject rate center - signal_strength.
 
-    In other words, the conditions are
-
-    - BinomCDF(N, N(0.5 - eps), 0.5) <= acceptable_fpr/2
-    - BinomCDF(N, N(0.5 + eps), p_acc) <= acceptable_fnr
+    We want FPR (under the null B(center)) at most acceptable_fpr, and FNR (under
+    the true distribution) at most acceptable_fnr.
     """
-    assert 0.5 < p_acc < 1.0
+    assert signal_strength > 0
     N_low = 1
     N_high = None
     while N_high is None or N_low < N_high:
@@ -30,30 +25,34 @@ def population_size_and_evidence_thresh(
         else:
             N_try = (N_low + N_high) // 2
         result = evidence_thresh_for_population_size(
-            p_acc, acceptable_fpr, acceptable_fnr, N_try
+            signal_strength, acceptable_fpr, acceptable_fnr, N_try
         )
         if result is None:
             N_low = N_try + 1
         else:
             N_high = N_try
     res = evidence_thresh_for_population_size(
-        p_acc, acceptable_fpr, acceptable_fnr, N_high
+        signal_strength, acceptable_fpr, acceptable_fnr, N_high
     )
     assert res is not None
     return res
 
 
 def evidence_thresh_for_population_size(
-    p_acc, acceptable_fpr, acceptable_fnr, N
+    signal_strength, acceptable_fpr, acceptable_fnr, N, *, center=0.5
 ) -> Optional[Tuple[int, float]]:
     """
     See population_size_and_evidence_thresh for context.
+
+    signal_strength: half the gap between accept and reject rates.
+    center: the decision boundary (null hypothesis center). Defaults to 0.5.
     """
-    for eps in np.linspace(0.01, p_acc - 0.5, 100):
-        k_low = int(np.floor(N * (0.5 - eps)))
-        k_high = int(np.ceil(N * (0.5 + eps)))
-        fpr = scipy.stats.binom.cdf(k_low, N, 0.5) + (
-            1 - scipy.stats.binom.cdf(k_high - 1, N, 0.5)
+    p_acc = center + signal_strength
+    for eps in np.linspace(0.01, signal_strength, 100):
+        k_low = int(np.floor(N * (center - eps)))
+        k_high = int(np.ceil(N * (center + eps)))
+        fpr = scipy.stats.binom.cdf(k_low, N, center) + (
+            1 - scipy.stats.binom.cdf(k_high - 1, N, center)
         )
         fnr = scipy.stats.binom.cdf(k_high - 1, N, p_acc) - scipy.stats.binom.cdf(
             k_low, N, p_acc

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -39,24 +39,20 @@ def population_size_and_evidence_thresh(
 
 
 def evidence_thresh_for_population_size(
-    signal_strength, acceptable_fpr, acceptable_fnr, N, *, center=0.5
+    signal_strength, acceptable_fpr, acceptable_fnr, N
 ) -> Optional[Tuple[int, float]]:
     """
     See population_size_and_evidence_thresh for context.
-
-    signal_strength: half the gap between accept and reject rates.
-    center: the decision boundary (null hypothesis center). Defaults to 0.5.
     """
-    p_acc = center + signal_strength
     for eps in np.linspace(0.01, signal_strength, 100):
-        k_low = int(np.floor(N * (center - eps)))
-        k_high = int(np.ceil(N * (center + eps)))
-        fpr = scipy.stats.binom.cdf(k_low, N, center) + (
-            1 - scipy.stats.binom.cdf(k_high - 1, N, center)
+        k_low = int(np.floor(N * (0.5 - eps)))
+        k_high = int(np.ceil(N * (0.5 + eps)))
+        fpr = scipy.stats.binom.cdf(k_low, N, 0.5) + (
+            1 - scipy.stats.binom.cdf(k_high - 1, N, 0.5)
         )
-        fnr = scipy.stats.binom.cdf(k_high - 1, N, p_acc) - scipy.stats.binom.cdf(
-            k_low, N, p_acc
-        )
+        fnr = scipy.stats.binom.cdf(
+            k_high - 1, N, signal_strength + 0.5
+        ) - scipy.stats.binom.cdf(k_low, N, signal_strength + 0.5)
         if fpr <= acceptable_fpr and fnr <= acceptable_fnr:
             return N, eps
     return None

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -55,9 +55,9 @@ def evidence_thresh_for_population_size(
         fpr = scipy.stats.binom.cdf(k_low, N, 0.5) + (
             1 - scipy.stats.binom.cdf(k_high - 1, N, 0.5)
         )
-        fnr = scipy.stats.binom.cdf(
-            k_high - 1, N, p_acc
-        ) - scipy.stats.binom.cdf(k_low, N, p_acc)
+        fnr = scipy.stats.binom.cdf(k_high - 1, N, p_acc) - scipy.stats.binom.cdf(
+            k_low, N, p_acc
+        )
         if fpr <= acceptable_fpr and fnr <= acceptable_fnr:
             return N, eps
     return None

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy
 
 
-def population_size_and_evidence_thresh(
+def population_size_and_evidence_margin(
     signal_strength, acceptable_fpr, acceptable_fnr
 ) -> Tuple[int, float]:
     """
@@ -24,25 +24,25 @@ def population_size_and_evidence_thresh(
             N_try = N_low * 2
         else:
             N_try = (N_low + N_high) // 2
-        result = evidence_thresh_for_population_size(
+        result = evidence_margin_for_population_size(
             signal_strength, acceptable_fpr, acceptable_fnr, N_try
         )
         if result is None:
             N_low = N_try + 1
         else:
             N_high = N_try
-    res = evidence_thresh_for_population_size(
+    res = evidence_margin_for_population_size(
         signal_strength, acceptable_fpr, acceptable_fnr, N_high
     )
     assert res is not None
     return res
 
 
-def evidence_thresh_for_population_size(
+def evidence_margin_for_population_size(
     signal_strength, acceptable_fpr, acceptable_fnr, N
 ) -> Optional[Tuple[int, float]]:
     """
-    See population_size_and_evidence_thresh for context.
+    See population_size_and_evidence_margin for context.
     """
     for eps in np.linspace(0.01, signal_strength, 100):
         k_low = int(np.floor(N * (0.5 - eps)))

--- a/orthogonal_dfa/l_star/structures.py
+++ b/orthogonal_dfa/l_star/structures.py
@@ -183,18 +183,18 @@ class DecisionTreeLeafNode(DecisionTree):
 @dataclass
 class TriPredicate:
     vs: List[List[int]]
-    evidence_threshold: float
+    evidence_margin: float
 
     def predict(self, x: List[int], oracle: Oracle) -> float:
         return np.mean([oracle.membership_query(x + v) for v in self.vs])
 
     def __call__(self, x: List[int], oracle: Oracle) -> Union[bool, None]:
         f = self.predict(x, oracle)
-        if f > self.evidence_threshold:
+        if f > 0.5 + self.evidence_margin:
             return True
-        if f < 1 - self.evidence_threshold:
+        if f < 0.5 - self.evidence_margin:
             return False
         return None
 
     def __hash__(self):
-        return hash((tuple(tuple(v) for v in self.vs), self.evidence_threshold))
+        return hash((tuple(tuple(v) for v in self.vs), self.evidence_margin))

--- a/orthogonal_dfa/l_star/structures.py
+++ b/orthogonal_dfa/l_star/structures.py
@@ -183,18 +183,25 @@ class DecisionTreeLeafNode(DecisionTree):
 @dataclass
 class TriPredicate:
     vs: List[List[int]]
-    evidence_margin: float
+    accept_threshold: float
+    reject_threshold: float
 
     def predict(self, x: List[int], oracle: Oracle) -> float:
         return np.mean([oracle.membership_query(x + v) for v in self.vs])
 
     def __call__(self, x: List[int], oracle: Oracle) -> Union[bool, None]:
         f = self.predict(x, oracle)
-        if f > 0.5 + self.evidence_margin:
+        if f > self.accept_threshold:
             return True
-        if f < 0.5 - self.evidence_margin:
+        if f < self.reject_threshold:
             return False
         return None
 
     def __hash__(self):
-        return hash((tuple(tuple(v) for v in self.vs), self.evidence_margin))
+        return hash(
+            (
+                tuple(tuple(v) for v in self.vs),
+                self.accept_threshold,
+                self.reject_threshold,
+            )
+        )

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -252,9 +252,9 @@ class TestLStarAsymmetric(unittest.TestCase):
             noise_model, seed, regex=r".*1010101.*"
         )
         noise_model = AsymmetricBernoulli(p_0=0.15, p_1=0.7)
-        # signal = (0.7 - 0.15) / 2 = 0.275
+        # signal = (0.7 - 0.15) / 2 = 0.275, but for now we're using 0.2 to be safe.
         _, dfa, _ = compute_dfa_for_oracle(
-            oracle_creator, min_signal_strength=0.275, seed=0, noise_model=noise_model
+            oracle_creator, min_signal_strength=0.2, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
 

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -17,7 +17,7 @@ from orthogonal_dfa.l_star.sampler import UniformSampler
 from orthogonal_dfa.l_star.statistics import (
     compute_prefix_set_size,
     compute_suffix_size_counterexample_gen,
-    population_size_and_evidence_thresh,
+    population_size_and_evidence_margin,
 )
 from orthogonal_dfa.l_star.structures import AsymmetricBernoulli, SymmetricBernoulli
 
@@ -77,7 +77,7 @@ def compute_pst(
     if noise_model is None:
         noise_model = SymmetricBernoulli(p_correct=effective_p_acc)
     oracle = oracle_creator(noise_model, seed)
-    n, eps = population_size_and_evidence_thresh(
+    n, eps = population_size_and_evidence_margin(
         signal_strength=min_signal_strength, acceptable_fpr=0.01, acceptable_fnr=0.01
     )
     k = compute_prefix_set_size(0.05, effective_p_acc, 0.05)
@@ -85,7 +85,7 @@ def compute_pst(
     num_prefixes = 200 if use_dynamic else k
     config = SearchConfig(
         suffix_family_size=n,
-        evidence_thresh=0.50 + eps,
+        evidence_margin=eps,
         decision_rule_fpr=0.01,
         suffix_size_counterexample_gen=suffix_size,
         num_addtl_prefixes=200 if use_dynamic else None,

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -58,23 +58,28 @@ def assertDFA(
         )
 
 
-def compute_dfa_for_oracle(oracle_creator, *, accuracy, seed, noise_model=None):
-    pst = compute_pst(oracle_creator, accuracy, seed, noise_model=noise_model)
+def compute_dfa_for_oracle(oracle_creator, *, min_signal_strength, seed, noise_model=None):
+    pst = compute_pst(
+        oracle_creator, min_signal_strength, seed, noise_model=noise_model
+    )
     dfa, dt = do_counterexample_driven_synthesis(
         pst, additional_counterexamples=200, acc_threshold=1 - allowed_error
     )
     return pst, dfa, dt
 
 
-def compute_pst(oracle_creator, accuracy, seed, *, use_dynamic=True, noise_model):
+def compute_pst(
+    oracle_creator, min_signal_strength, seed, *, use_dynamic=True, noise_model=None
+):
+    effective_p_acc = 0.5 + min_signal_strength
     if noise_model is None:
-        noise_model = SymmetricBernoulli(p_correct=accuracy)
+        noise_model = SymmetricBernoulli(p_correct=effective_p_acc)
     oracle = oracle_creator(noise_model, seed)
     n, eps = population_size_and_evidence_thresh(
-        p_acc=accuracy, acceptable_fpr=0.01, acceptable_fnr=0.01, relative_eps=1
+        p_acc=effective_p_acc, acceptable_fpr=0.01, acceptable_fnr=0.01, relative_eps=1
     )
-    k = compute_prefix_set_size(0.05, accuracy, 0.05)
-    suffix_size = compute_suffix_size_counterexample_gen(0.01, accuracy)
+    k = compute_prefix_set_size(0.05, effective_p_acc, 0.05)
+    suffix_size = compute_suffix_size_counterexample_gen(0.01, effective_p_acc)
     num_prefixes = 200 if use_dynamic else k
     config = SearchConfig(
         suffix_family_size=n,
@@ -83,7 +88,10 @@ def compute_pst(oracle_creator, accuracy, seed, *, use_dynamic=True, noise_model
         suffix_size_counterexample_gen=suffix_size,
         num_addtl_prefixes=200 if use_dynamic else None,
     )
-    print(f"Using suffix population size {n}, eps {eps}, and {k} prefixes.")
+    print(
+        f"Using suffix population size {n}, eps {eps}, and {k} prefixes "
+        f"(signal strength {min_signal_strength})."
+    )
     pst = PrefixSuffixTracker.create(
         us,
         np.random.default_rng(0),
@@ -121,56 +129,72 @@ class TestLStar(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        _, dfa, _ = compute_dfa_for_oracle(oracle_creator, accuracy=0.8, seed=0)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=0.3, seed=0
+        )
         assertDFA(self, dfa, oracle_creator)
 
     def test_modulo_harder(self):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        _, dfa, _ = compute_dfa_for_oracle(oracle_creator, accuracy=0.7, seed=0)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=0.2, seed=0
+        )
         assertDFA(self, dfa, oracle_creator)
 
     def test_modulo_even_harder(self):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        _, dfa, _ = compute_dfa_for_oracle(oracle_creator, accuracy=0.6, seed=0)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=0.1, seed=0
+        )
         assertDFA(self, dfa, oracle_creator)
 
     def test_specific_subsequence(self):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*1010101.*"
         )
-        _, dfa, _ = compute_dfa_for_oracle(oracle_creator, accuracy=0.8, seed=0)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=0.3, seed=0
+        )
         assertDFA(self, dfa, oracle_creator)
 
     def test_two_subsequences(self):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*1111.*1111.*"
         )
-        _, dfa, _ = compute_dfa_for_oracle(oracle_creator, accuracy=0.8, seed=0)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=0.3, seed=0
+        )
         assertDFA(self, dfa, oracle_creator)
 
     def test_two_subsequences_with_alternation(self):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*1111.*(1111|0000)11.*"
         )
-        _, dfa, _ = compute_dfa_for_oracle(oracle_creator, accuracy=0.8, seed=0)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=0.3, seed=0
+        )
         assertDFA(self, dfa, oracle_creator)
 
     def test_specific_alternation(self):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*(1111|0000)11.*"
         )
-        _, dfa, _ = compute_dfa_for_oracle(oracle_creator, accuracy=0.8, seed=0)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=0.3, seed=0
+        )
         assertDFA(self, dfa, oracle_creator, exclude_pattern=lambda s: s[:5] == [1] * 5)
 
     def test_specific_alternation_with_nothing_at_end_3_syms(self):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*(111|000).*", alphabet_size=3
         )
-        _, dfa, _ = compute_dfa_for_oracle(oracle_creator, accuracy=0.8, seed=0)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=0.3, seed=0
+        )
         assertDFA(self, dfa, oracle_creator, symbols=3)
 
     def test_specific_alternation_with_nothing_at_end_does_not_meet_property(self):
@@ -203,10 +227,10 @@ class TestLStarAsymmetric(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        # effective accuracy ~ min(1 - 0.05, 0.85) = 0.85
         noise_model = AsymmetricBernoulli(p_0=0.05, p_1=0.85)
+        # signal = (0.85 - 0.05) / 2 = 0.4
         _, dfa, _ = compute_dfa_for_oracle(
-            oracle_creator, accuracy=0.85, seed=0, noise_model=noise_model
+            oracle_creator, min_signal_strength=0.4, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
 
@@ -214,10 +238,10 @@ class TestLStarAsymmetric(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        # effective accuracy ~ min(1 - 0.25, 0.95) = 0.95
         noise_model = AsymmetricBernoulli(p_0=0.25, p_1=0.95)
+        # signal = (0.95 - 0.25) / 2 = 0.35
         _, dfa, _ = compute_dfa_for_oracle(
-            oracle_creator, accuracy=0.75, seed=0, noise_model=noise_model
+            oracle_creator, min_signal_strength=0.35, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
 
@@ -225,17 +249,19 @@ class TestLStarAsymmetric(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*1010101.*"
         )
-        # effective accuracy ~ min(1 - 0.15, 0.7) = 0.7
         noise_model = AsymmetricBernoulli(p_0=0.15, p_1=0.7)
+        # signal = (0.7 - 0.15) / 2 = 0.275
         _, dfa, _ = compute_dfa_for_oracle(
-            oracle_creator, accuracy=0.7, seed=0, noise_model=noise_model
+            oracle_creator, min_signal_strength=0.275, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
 
 
 class TestLStarORF(unittest.TestCase):
-    @parameterized.expand([(accuracy,) for accuracy in (0.8, 0.7)])
-    def test_no_orf(self, accuracy):
+    @parameterized.expand([(signal,) for signal in (0.3, 0.2)])
+    def test_no_orf(self, signal):
         oracle_creator = AllFramesClosedOracle
-        _, dfa, _ = compute_dfa_for_oracle(oracle_creator, accuracy=accuracy, seed=0)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=signal, seed=0
+        )
         assertDFA(self, dfa, oracle_creator, symbols=4)

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -58,7 +58,9 @@ def assertDFA(
         )
 
 
-def compute_dfa_for_oracle(oracle_creator, *, min_signal_strength, seed, noise_model=None):
+def compute_dfa_for_oracle(
+    oracle_creator, *, min_signal_strength, seed, noise_model=None
+):
     pst = compute_pst(
         oracle_creator, min_signal_strength, seed, noise_model=noise_model
     )

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -78,7 +78,7 @@ def compute_pst(
         noise_model = SymmetricBernoulli(p_correct=effective_p_acc)
     oracle = oracle_creator(noise_model, seed)
     n, eps = population_size_and_evidence_thresh(
-        p_acc=effective_p_acc, acceptable_fpr=0.01, acceptable_fnr=0.01
+        signal_strength=min_signal_strength, acceptable_fpr=0.01, acceptable_fnr=0.01
     )
     k = compute_prefix_set_size(0.05, effective_p_acc, 0.05)
     suffix_size = compute_suffix_size_counterexample_gen(0.01, effective_p_acc)

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -69,7 +69,7 @@ def compute_dfa_for_oracle(oracle_creator, *, accuracy, seed):
 def compute_pst(oracle_creator, accuracy, seed, *, use_dynamic=True):
     oracle = oracle_creator(SymmetricBernoulli(p_correct=accuracy), seed)
     n, eps = population_size_and_evidence_thresh(
-        p_acc=accuracy, acceptable_fpr=0.01, acceptable_fnr=0.01, relative_eps=1
+        p_acc=accuracy, acceptable_fpr=0.01, acceptable_fnr=0.01
     )
     k = compute_prefix_set_size(0.05, accuracy, 0.05)
     suffix_size = compute_suffix_size_counterexample_gen(0.01, accuracy)

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -230,9 +230,9 @@ class TestLStarAsymmetric(unittest.TestCase):
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
         noise_model = AsymmetricBernoulli(p_0=0.05, p_1=0.85)
-        # signal = (0.85 - 0.05) / 2 = 0.4
+        # signal = (0.85 - 0.05) / 2 = 0.4, but for now we're using 0.35 to be safe.
         _, dfa, _ = compute_dfa_for_oracle(
-            oracle_creator, min_signal_strength=0.4, seed=0, noise_model=noise_model
+            oracle_creator, min_signal_strength=0.35, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
 
@@ -241,9 +241,9 @@ class TestLStarAsymmetric(unittest.TestCase):
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
         noise_model = AsymmetricBernoulli(p_0=0.25, p_1=0.95)
-        # signal = (0.95 - 0.25) / 2 = 0.35
+        # signal = (0.95 - 0.25) / 2 = 0.35, but for now we're using 0.25 to be safe.
         _, dfa, _ = compute_dfa_for_oracle(
-            oracle_creator, min_signal_strength=0.35, seed=0, noise_model=noise_model
+            oracle_creator, min_signal_strength=0.25, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
 


### PR DESCRIPTION
Use signal strength (accuracy - 0.5 for symmetric noise, (p_1 - p_0)/2 for asymmetric) as the primary parameter instead of accuracy. This better captures the actual discriminative power of the oracle regardless of noise model symmetry.