### PR TITLE
start counterexample search from empty string

### DIFF
--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -120,7 +120,7 @@ def locate_incorrect_point(oracle, dt, dfa, x, y):
     if dt.classify(x + y, oracle) == dfa_states_each[-1]:
         return None
     correct_idx = 0
-    incorrect_idx = len(x)
+    incorrect_idx = len(y)
     # binary search for first incorrect index
     while correct_idx < incorrect_idx - 1:
         mid_idx = (correct_idx + incorrect_idx) // 2
@@ -160,13 +160,16 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count):
     pbar = tqdm.tqdm(total=count)
     additional_prefixes = []
     while True:
-        x = us.sample(pst.rng, pst.alphabet_size)
         y = us.sample(pst.rng, pst.alphabet_size)
+        # Start from the empty string so the DT and DFA agree on the
+        # initial state (both use dfa.initial_state).  Using a random x
+        # causes problems when the DT and DFA disagree on x's state,
+        # which corrupts the DFA path used for comparison.
         prefix_and_sym = locate_incorrect_point(
             oracle,
             dt_with_reduced_predicates,
             dfa,
-            x,
+            [],
             y,
         )
         if prefix_and_sym is None:


### PR DESCRIPTION
Using a random x as the prefix caused issues when the DT and DFA disagreed on x's state, corrupting the DFA path comparison.  Starting from [] ensures both always agree on the initial state.

Also fixes incorrect_idx = len(x) -> len(y) in locate_incorrect_point, which was a latent bug (x is the fixed prefix, y is what we binary-search).