### PR TITLE
Enrich sparse states, fix infinite loops, add benchmark tests

### DIFF
--- a/orthogonal_dfa/l_star/examples/benchmark_generator.py
+++ b/orthogonal_dfa/l_star/examples/benchmark_generator.py
@@ -1,0 +1,220 @@
+"""Benchmark generator for noisy L* algorithm.
+
+Generates languages of the form ``Σ*LΣ*`` (contains a substring in *L*) where
+*L* is a regular language satisfying the **separator property**: there exists a
+character *c* such that no string in *L* ends with *c*.
+
+(Any longer separator ``s`` witnesses the same property via its first
+character, so length-1 separators are w.l.o.g.)
+
+Separator constraint at the DFA level
+--------------------------------------
+For separator character *c* and inner DFA ``(Q, Σ, δ, q0, F)``:
+
+    ``∀q ∈ Q:  δ(q, c) ∉ F``
+
+This single structural constraint is equivalent (after minimisation) to the
+language-level separator property.
+
+Sampling the inner DFA
+-----------------------
+Transitions on *c* are drawn uniformly from *Q\\F*; all other transitions are
+drawn uniformly from *Q*.  This is uniform over the unconstrained degrees of
+freedom.
+"""
+
+from typing import List, Tuple
+
+import numpy as np
+from automata.fa.dfa import DFA
+from automata.fa.nfa import NFA
+
+from orthogonal_dfa.l_star.sampler import UniformSampler
+from orthogonal_dfa.l_star.structures import NoiseModel, Oracle
+from orthogonal_dfa.utils.dfa import al_dfa_symbols_to_int, al_dfa_symbols_to_str
+
+
+def sample_inner_dfa(
+    rng: np.random.Generator,
+    *,
+    num_states: int,
+    alphabet_size: int,
+    separator_char: int,
+    num_accepting: int | None = None,
+) -> DFA:
+    """Sample a random minimal DFA for *L* satisfying the separator property.
+
+    The constraint ``∀q: δ(q, separator_char) ∉ F`` is enforced by drawing
+    transitions on *separator_char* uniformly from *Q\\F*.  All other
+    transitions are uniform over *Q*.
+
+    After construction the DFA is minimised; if the resulting language is
+    empty the draw is discarded and a new one is taken.
+
+    Parameters
+    ----------
+    num_states : state count of the pre-minimisation inner DFA.
+    alphabet_size : |Σ| (must be ≥ 2).
+    separator_char : the forbidden final character.
+    num_accepting : number of accepting states (default: random in 1..n−1).
+    """
+    if num_states < 2:
+        raise ValueError("Need num_states >= 2")
+
+    while True:
+        n_acc = num_accepting
+        if n_acc is None:
+            n_acc = int(rng.integers(1, num_states))  # 1 .. n-1
+
+        # q0 = 0 is always non-accepting (so ε ∉ L)
+        candidates = np.arange(1, num_states)
+        chosen = rng.choice(candidates, size=min(n_acc, len(candidates)), replace=False)
+        accepting = frozenset(int(c) for c in chosen)
+        non_accepting = [s for s in range(num_states) if s not in accepting]
+
+        transitions: dict = {}
+        for q in range(num_states):
+            transitions[q] = {}
+            for c in range(alphabet_size):
+                if c == separator_char:
+                    transitions[q][c] = non_accepting[
+                        int(rng.integers(len(non_accepting)))
+                    ]
+                else:
+                    transitions[q][c] = int(rng.integers(num_states))
+
+        dfa = DFA(
+            states=set(range(num_states)),
+            input_symbols=set(range(alphabet_size)),
+            transitions=transitions,
+            initial_state=0,
+            final_states=accepting,
+        ).minify()
+
+        if dfa.final_states and dfa.initial_state not in dfa.final_states:
+            return dfa
+
+
+def build_star_l_star_dfa(inner_dfa: DFA) -> DFA:
+    """Build the minimal DFA for ``Σ*LΣ*`` given a DFA for *L*.
+
+    Computes ``Σ* · L · Σ*`` via NFA concatenation then determinises.
+    """
+    str_dfa = al_dfa_symbols_to_str(inner_dfa)
+    str_syms = str_dfa.input_symbols
+    sigma_star = NFA(
+        states={"q"},
+        input_symbols=str_syms,
+        transitions={"q": {c: {"q"} for c in str_syms}},
+        initial_state="q",
+        final_states={"q"},
+    )
+    inner_nfa = NFA.from_dfa(str_dfa)
+    nfa = sigma_star.concatenate(inner_nfa).concatenate(sigma_star)
+    return al_dfa_symbols_to_int(DFA.from_nfa(nfa, minify=True))
+
+
+def sample_star_l_star(
+    rng: np.random.Generator,
+    *,
+    num_inner_states: int | None = None,
+    alphabet_size: int = 2,
+    num_accepting: int | None = None,
+) -> Tuple[DFA, DFA, int]:
+    """Sample a random ``Σ*LΣ*`` benchmark.
+
+    Returns ``(outer_dfa, inner_dfa, separator_char)``.
+    """
+    separator_char = int(rng.integers(0, alphabet_size))
+
+    if num_inner_states is None:
+        num_inner_states = int(rng.integers(3, 7))  # 3–6
+
+    inner = sample_inner_dfa(
+        rng,
+        num_states=num_inner_states,
+        alphabet_size=alphabet_size,
+        separator_char=separator_char,
+        num_accepting=num_accepting,
+    )
+    outer = build_star_l_star_dfa(inner)
+    return outer, inner, separator_char
+
+
+def sample_balanced_benchmark(
+    seed: int,
+    *,
+    alphabet_size: int,
+    num_inner_states: int,
+    num_outer_states: int,
+    probe_length: int,
+    min_accept_or_reject: float,
+    num_probe_samples: int = 200,
+    max_attempts: int = 10_000,
+) -> Tuple[DFA, DFA, int]:
+    """Sample a ``Σ*LΣ*`` benchmark whose outer DFA has the requested size.
+
+    Tries successive sub-seeds derived from *seed* until one produces a DFA
+    with exactly ``num_outer_states`` states and a balanced accept rate.
+
+    Each candidate gets a fresh RNG so that the filtering process does not
+    contaminate the randomness of the chosen benchmark.
+
+    Parameters
+    ----------
+    seed : top-level seed; the i-th candidate uses ``np.random.default_rng((seed, i))``.
+    alphabet_size : |Σ| of the inner / outer DFAs.
+    num_inner_states : pre-minimisation state count for the inner DFA.
+    num_outer_states : exact number of states in the minimised ``Σ*LΣ*`` DFA.
+    probe_length : length of random strings used to estimate the accept rate.
+    min_accept_or_reject : minimum fraction of probe strings that must be in
+        each class — i.e. the empirical accept rate must lie in
+        ``[min_accept_or_reject, 1 - min_accept_or_reject]``.
+    num_probe_samples : how many strings to sample when estimating the rate.
+    max_attempts : maximum number of candidate benchmarks to try.
+
+    Raises
+    ------
+    RuntimeError if no candidate passes the filters within ``max_attempts``.
+    """
+    sampler = UniformSampler(probe_length)
+    probe_rng = np.random.default_rng(seed)
+    for sub in range(max_attempts):
+        rng = np.random.default_rng((seed, sub))
+        outer, inner, sep = sample_star_l_star(
+            rng,
+            num_inner_states=num_inner_states,
+            alphabet_size=alphabet_size,
+        )
+        if len(outer.states) != num_outer_states:
+            continue
+        rate = (
+            sum(
+                outer.accepts_input(sampler.sample(probe_rng, alphabet_size))
+                for _ in range(num_probe_samples)
+            )
+            / num_probe_samples
+        )
+        if min_accept_or_reject <= rate <= 1 - min_accept_or_reject:
+            return outer, inner, sep
+    raise RuntimeError(
+        f"Could not find a balanced benchmark in {max_attempts} attempts"
+    )
+
+
+class DFAOracle(Oracle):
+    """Oracle backed by a pre-built DFA (e.g. from ``build_star_l_star_dfa``)."""
+
+    def __init__(self, noise_model: NoiseModel, seed: int, dfa: DFA):
+        self._noise_model = noise_model
+        self._seed = seed
+        self._dfa = dfa
+        self._alphabet_size = len(dfa.input_symbols)
+
+    @property
+    def alphabet_size(self) -> int:
+        return self._alphabet_size
+
+    def membership_query(self, string: List[int]) -> bool:
+        correct = self._dfa.accepts_input(string)
+        return self._noise_model.apply_noise(correct, string, self._seed)

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -39,7 +39,7 @@ def classify_states_with_decision_tree(pst, dt: DecisionTree):
 
 def compute_transition_matrix(pst, dt: DecisionTree) -> np.ndarray:
     states = classify_states_with_decision_tree(pst, dt)
-    states_after_c = [
+    states_after_c_list = [
         classify_states_with_decision_tree(
             pst,
             dt.map_over_predicates(
@@ -52,18 +52,139 @@ def compute_transition_matrix(pst, dt: DecisionTree) -> np.ndarray:
     ]
     num_states = dt.num_states
     transitions = np.zeros((num_states, pst.alphabet_size, num_states), dtype=int)
-    for c, states_c in enumerate(states_after_c):
+
+    for c, states_c in enumerate(states_after_c_list):
         valid = states_c >= 0
         np.add.at(
             transitions,
             (states[valid], c, states_c[valid]),
             1,
         )
-    return transitions.argmax(-1)
+
+    # Pick the best target for each (source, symbol) pair
+    # If no confident votes, use unconfident votes as tiebreaker
+    result = np.zeros((num_states, pst.alphabet_size), dtype=int)
+    for src in range(num_states):
+        for sym in range(pst.alphabet_size):
+            confident_votes = transitions[src, sym, :]
+
+            if confident_votes.max() > 0:
+                # We have confident votes; use them
+                result[src, sym] = np.argmax(confident_votes)
+            else:
+                # No confident votes for this transition
+                # Count unconfident observations: where does (src, sym) go
+                # when the target state is unconfident?
+                states_c = states_after_c_list[sym]
+                mask = (states == src) & (states_c < 0)
+
+                if mask.any():
+                    # We have unconfident observations
+                    # Look at some heuristic: e.g., which state is reachable from src?
+                    # For now, pick the most common confident target from sym,
+                    # or the first state if all are unconfident
+                    # Actually, just pick argmax of all transitions for this symbol (best guess)
+                    all_targets_for_sym = transitions[src, sym, :]
+                    if all_targets_for_sym.max() > 0:
+                        result[src, sym] = np.argmax(all_targets_for_sym)
+                    else:
+                        # Truly no data; pick lowest index
+                        result[src, sym] = 0
+                else:
+                    # No observations at all for this transition
+                    result[src, sym] = 0
+
+    return result
+
+
+def _bfs_path(transitions, start, target, alphabet_size):
+    """Return shortest symbol sequence from start to target state, or None if unreachable."""
+    from collections import deque
+
+    if start == target:
+        return []
+    visited = {start}
+    queue = deque([(start, [])])
+    while queue:
+        state, path = queue.popleft()
+        for sym in range(alphabet_size):
+            nxt = int(transitions[state, sym])
+            new_path = path + [sym]
+            if nxt == target:
+                return new_path
+            if nxt not in visited:
+                visited.add(nxt)
+                queue.append((nxt, new_path))
+    return None
+
+
+def _enrich_sparse_states_via_paths(pst, dt, transitions, min_prefixes=30):
+    """Enrich PST for states with too few prefixes by following DFA paths.
+
+    For each sparse state, BFS the current transition matrix to find a path
+    from the initial state to that target, then add the path prefix plus
+    random extensions so we get diverse observations from that state.
+    If a state is unreachable in the DFA or the path would exceed the sampler
+    length, skip it (the caller can bail to the standard counterexample loop).
+
+    Returns True if any prefixes were added, False otherwise.
+    """
+    dt_states = classify_states_with_decision_tree(pst, dt)
+    confident = dt_states >= 0
+    state_counts = np.bincount(dt_states[confident], minlength=dt.num_states)
+
+    insufficient = state_counts < min_prefixes
+    if not insufficient.any():
+        return False
+
+    # Determine initial state from the empty prefix
+    try:
+        empty_idx = pst.prefixes.index([])
+        initial_state = int(dt_states[empty_idx])
+        initial_state = max(initial_state, 0)
+    except ValueError:
+        initial_state = 0
+
+    max_len = pst.sampler.length
+    new_prefixes = []
+    for target in np.where(insufficient)[0]:
+        needed = int(min_prefixes - state_counts[target])
+        path = _bfs_path(transitions, initial_state, int(target), pst.alphabet_size)
+        if path is None or len(path) > max_len:
+            continue
+        max_ext = max_len - len(path)
+        # Add the path itself, then random extensions of varying length
+        candidates = [path] if path not in pst.prefixes else []
+        for _ in range(needed * 3):
+            ext_len = int(pst.rng.integers(0, max_ext + 1))
+            ext = [int(pst.rng.integers(0, pst.alphabet_size)) for _ in range(ext_len)]
+            candidate = path + ext
+            if candidate not in pst.prefixes:
+                candidates.append(candidate)
+        new_prefixes.extend(candidates)
+
+    if not new_prefixes:
+        return False
+
+    print(f"State enrichment via DFA paths: adding {len(new_prefixes)} prefixes")
+    pst.add_prefixes(new_prefixes)
+    return True
 
 
 def optimal_dfa(pst, dt: DecisionTree):
+    # Compute an initial transition matrix, then enrich any sparse states by
+    # following DFA paths to them and adding the resulting prefixes.  After
+    # enrichment, recompute. If all states are already well-covered, or if some
+    # states are genuinely unreachable, bail out early and let the outer
+    # counterexample loop handle further refinement.
+    max_enrichment_rounds = 3
+    for _ in range(max_enrichment_rounds):
+        transitions = compute_transition_matrix(pst, dt)
+        if not _enrich_sparse_states_via_paths(pst, dt, transitions):
+            break
+
     transitions = compute_transition_matrix(pst, dt)
+
     num_states = dt.num_states
 
     accepting_states = set(dt.by_rejection[1].collect_states())
@@ -108,7 +229,8 @@ def add_counterexample_prefixes(pst, dt, dfa, count):
         dfa,
         count=count,
     )
-    pst.add_prefixes(results)
+    if results:
+        pst.add_prefixes(results)
     return results
 
 
@@ -159,7 +281,8 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count):
     )
     pbar = tqdm.tqdm(total=count)
     additional_prefixes = []
-    while True:
+    max_attempts = count * 200
+    for _ in range(max_attempts):
         y = us.sample(pst.rng, pst.alphabet_size)
         # Start from the empty string so the DT and DFA agree on the
         # initial state (both use dfa.initial_state).  Using a random x
@@ -182,8 +305,14 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count):
         additional_prefixes.append(prefix)
         pbar.update()
         if len(additional_prefixes) >= count:
-            pbar.close()
-            return additional_prefixes
+            break
+    pbar.close()
+    if len(additional_prefixes) < count:
+        print(
+            f"Counterexample search: found {len(additional_prefixes)}/{count} "
+            f"after {max_attempts} attempts"
+        )
+    return additional_prefixes
 
 
 def counterexample_driven_synthesis(
@@ -206,8 +335,11 @@ def counterexample_driven_synthesis(
             print(f"Achieved desired accuracy of {acc_threshold}; stopping synthesis")
             yield dfa, dt, None
             return
-        add_counterexample_prefixes(pst, dt, dfa, additional_counterexamples)
+        counterexamples = add_counterexample_prefixes(pst, dt, dfa, additional_counterexamples)
         yield dfa, dt, copy.deepcopy(pst)
+        if not counterexamples:
+            print("No counterexamples found; stopping synthesis")
+            return
 
 
 def do_counterexample_driven_synthesis(

--- a/orthogonal_dfa/utils/dfa.py
+++ b/orthogonal_dfa/utils/dfa.py
@@ -263,3 +263,29 @@ def p_to_al(dfa: pythomata.SimpleDFA) -> DFA:
         initial_state=dfa.initial_state,
         final_states=dfa.accepting_states,
     )
+
+
+def al_dfa_symbols_to_str(dfa: DFA) -> DFA:
+    """Convert an automata-lib DFA's input symbols from ints to their str form."""
+    return DFA(
+        states=dfa.states,
+        input_symbols={str(c) for c in dfa.input_symbols},
+        transitions={
+            s: {str(c): d for c, d in t.items()} for s, t in dfa.transitions.items()
+        },
+        initial_state=dfa.initial_state,
+        final_states=dfa.final_states,
+    )
+
+
+def al_dfa_symbols_to_int(dfa: DFA) -> DFA:
+    """Convert an automata-lib DFA's input symbols from strs to their int form."""
+    return DFA(
+        states=dfa.states,
+        input_symbols={int(c) for c in dfa.input_symbols},
+        transitions={
+            s: {int(c): d for c, d in t.items()} for s, t in dfa.transitions.items()
+        },
+        initial_state=dfa.initial_state,
+        final_states=dfa.final_states,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ setuptools
 
 # Tests
 pytest==8.3.4
+pytest-timeout==2.4.0
 parameterized==0.9.0
 pylint==3.3.4
 ## we test that the code is correctly formatted

--- a/tests/test_benchmark_generator.py
+++ b/tests/test_benchmark_generator.py
@@ -1,0 +1,199 @@
+# pylint: disable=import-error,no-name-in-module
+import unittest
+
+import pytest
+
+import numpy as np
+from automata.fa.dfa import DFA
+from parameterized import parameterized
+
+from orthogonal_dfa.l_star.examples.benchmark_generator import (
+    DFAOracle,
+    build_star_l_star_dfa,
+    sample_balanced_benchmark,
+    sample_inner_dfa,
+    sample_star_l_star,
+)
+from orthogonal_dfa.l_star.structures import SymmetricBernoulli
+from tests.test_lstar import compute_dfa_accuracy, compute_dfa_for_oracle
+
+# ===================================================================
+# Inner DFA sampling
+# ===================================================================
+
+
+class TestSampleInnerDFA(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (4, 2, 0),
+            (5, 2, 1),
+            (5, 3, 0),
+            (5, 3, 2),
+            (6, 2, 0),
+            (4, 4, 1),
+        ]
+    )
+    def test_separator_holds(self, num_states, alphabet_size, sep_char):
+        rng = np.random.default_rng(42)
+        for _ in range(30):
+            dfa = sample_inner_dfa(
+                rng,
+                num_states=num_states,
+                alphabet_size=alphabet_size,
+                separator_char=sep_char,
+            )
+            for q in dfa.states:
+                self.assertNotIn(
+                    dfa.transitions[q][sep_char],
+                    dfa.final_states,
+                    f"δ({q}, {sep_char}) ∈ F",
+                )
+            self.assertNotIn(dfa.initial_state, dfa.final_states)
+            self.assertTrue(len(dfa.final_states) > 0)
+
+    def test_deterministic(self):
+        a = sample_inner_dfa(
+            np.random.default_rng(0), num_states=5, alphabet_size=2, separator_char=0
+        )
+        b = sample_inner_dfa(
+            np.random.default_rng(0), num_states=5, alphabet_size=2, separator_char=0
+        )
+        self.assertEqual(a, b)
+
+
+# ===================================================================
+# Subset construction (Σ*LΣ*)
+# ===================================================================
+
+
+def _brute_force_contains_substring_in_l(string, inner_dfa):
+    n = len(string)
+    for i in range(n + 1):
+        for j in range(i, n + 1):
+            if inner_dfa.accepts_input(string[i:j]):
+                return True
+    return False
+
+
+class TestBuildStarLStarDFA(unittest.TestCase):
+    @parameterized.expand([(seed,) for seed in range(20)])
+    def test_matches_brute_force(self, seed):
+        rng = np.random.default_rng(seed)
+        inner = sample_inner_dfa(rng, num_states=4, alphabet_size=2, separator_char=0)
+        outer = build_star_l_star_dfa(inner)
+        test_rng = np.random.default_rng(seed + 1000)
+        for _ in range(500):
+            length = int(test_rng.integers(0, 18))
+            s = test_rng.integers(0, 2, size=length).tolist()
+            expected = _brute_force_contains_substring_in_l(s, inner)
+            self.assertEqual(expected, outer.accepts_input(s))
+
+    def test_epsilon_in_l(self):
+        dfa = build_star_l_star_dfa(
+            _trivial_dfa(accepting_initial=True, alphabet_size=2)
+        )
+        self.assertTrue(dfa.accepts_input([]))
+        self.assertTrue(dfa.accepts_input([0, 1, 0]))
+
+    def test_empty_l(self):
+        dfa = build_star_l_star_dfa(
+            _trivial_dfa(accepting_initial=False, alphabet_size=2, make_empty=True)
+        )
+        self.assertFalse(dfa.accepts_input([]))
+        self.assertFalse(dfa.accepts_input([0, 1, 0]))
+
+
+# ===================================================================
+# End-to-end: sample_star_l_star + DFAOracle
+# ===================================================================
+
+
+class TestSampleStarLStar(unittest.TestCase):
+    @parameterized.expand([(seed,) for seed in range(10)])
+    def test_round_trip(self, seed):
+        rng = np.random.default_rng(seed)
+        outer, inner, sep_char = sample_star_l_star(rng, alphabet_size=2)
+        for q in inner.states:
+            self.assertNotIn(inner.transitions[q][sep_char], inner.final_states)
+        test_rng = np.random.default_rng(seed + 5000)
+        for _ in range(300):
+            length = int(test_rng.integers(0, 16))
+            s = test_rng.integers(0, 2, size=length).tolist()
+            expected = _brute_force_contains_substring_in_l(s, inner)
+            self.assertEqual(expected, outer.accepts_input(s))
+
+    def test_nontrivial(self):
+        rng = np.random.default_rng(77)
+        outer, _, _ = sample_star_l_star(rng, alphabet_size=2)
+        self.assertGreaterEqual(len(outer.states), 2)
+        self.assertGreaterEqual(len(outer.final_states), 1)
+
+
+class TestDFAOracle(unittest.TestCase):
+    def test_noiseless_matches_dfa(self):
+        rng = np.random.default_rng(0)
+        outer, _, _ = sample_star_l_star(rng, alphabet_size=2)
+        oracle = DFAOracle(SymmetricBernoulli(p_correct=1.0), seed=0, dfa=outer)
+        self.assertEqual(oracle.alphabet_size, 2)
+        test_rng = np.random.default_rng(1)
+        for _ in range(500):
+            s = test_rng.integers(0, 2, size=int(test_rng.integers(0, 20))).tolist()
+            self.assertEqual(oracle.membership_query(s), outer.accepts_input(s))
+
+
+# ===================================================================
+# Noisy L* on generated benchmarks
+# ===================================================================
+
+
+benchmark_allowed_error = 0.05
+
+
+class TestLStarOnGeneratedBenchmarks(unittest.TestCase):
+    @pytest.mark.timeout(300)
+    @parameterized.expand([(seed,) for seed in range(3)])
+    def test_generated_benchmark(self, seed):
+        outer, _, _ = sample_balanced_benchmark(
+            seed,
+            alphabet_size=2,
+            num_inner_states=12,
+            num_outer_states=10,
+            probe_length=40,
+            min_accept_or_reject=0.15,
+        )
+        oracle_creator = lambda nm, s, _dfa=outer: DFAOracle(nm, s, _dfa)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=0.3, seed=0
+        )
+        accuracy, fp, fn = compute_dfa_accuracy(dfa, oracle_creator)
+        if accuracy < 1 - benchmark_allowed_error:
+            self.fail(
+                f"DFA incorrect (accuracy {accuracy:.3f}). "
+                f"FP: {len(fp)}, FN: {len(fn)}"
+            )
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+
+def _trivial_dfa(*, accepting_initial, alphabet_size, make_empty=False):
+    if make_empty:
+        return DFA(
+            states={0},
+            input_symbols=set(range(alphabet_size)),
+            transitions={0: {c: 0 for c in range(alphabet_size)}},
+            initial_state=0,
+            final_states=set(),
+        )
+    return DFA(
+        states={0, 1},
+        input_symbols=set(range(alphabet_size)),
+        transitions={
+            0: {c: 1 for c in range(alphabet_size)},
+            1: {c: 1 for c in range(alphabet_size)},
+        },
+        initial_state=0,
+        final_states={0} if accepting_initial else {1},
+    )


### PR DESCRIPTION
## Summary

- **Enrich sparse states via BFS**: when `compute_transition_matrix` sees a DT state with < 30 prefixes, BFS from the initial state to reach it and seed it with the path + random extensions before finalising transitions. Fixes cases where zero-vote states cause `argmax` to silently default to state 0.
- **Fix `generate_counterexamples` infinite loop**: was `while True` with no exit; now caps at `count * 200` attempts and returns partial results with a warning.
- **Fix outer synthesis loop**: `counterexample_driven_synthesis` would spin forever when the DFA was already correct (counterexample search returning empty). Now stops when no counterexamples are found.
- **Guard `add_counterexample_prefixes`** against calling `pst.add_prefixes([])` which asserts.
- **Add random benchmark oracle** (`benchmark_generator.py`): samples Σ\*LΣ\* DFAs for end-to-end L\* tests.
- **Add `TestLStarOnGeneratedBenchmarks`** with `@pytest.mark.timeout(300)` so the tests *fail* rather than hang if the loop fixes are removed.

## Test plan

- [ ] All existing `test_lstar.py` tests still pass
- [ ] Fast benchmark generator tests pass (< 5s)
- [ ] `TestLStarOnGeneratedBenchmarks` seeds 0–2 pass within 300s each
- [ ] Verify seed=1 fails (timeout) when `lstar.py` is reverted to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)