### PR TITLE
Add larger (18-state) generated-benchmark synthesis tests

### DIFF
--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -535,6 +535,38 @@ class TestLStarOnGeneratedBenchmarks(unittest.TestCase):
             )
 
 
+class TestLStarOnLargeGeneratedBenchmarks(unittest.TestCase):
+    """Like ``TestLStarOnGeneratedBenchmarks`` but with larger 18-state outer
+    DFAs (vs 10). Balanced ``Sigma*LSigma*`` benchmarks of this size are rarer to
+    sample (hence the raised ``max_attempts``) and slower to synthesise (~2-5 min
+    each), yet still learn to >= 1 - assertion_allowed_error accuracy. Guards that
+    counterexample-driven synthesis scales past the 10-state benchmarks.
+    """
+
+    @parameterized.expand([(seed,) for seed in range(5)])
+    def test_large_generated_benchmark(self, seed):
+        outer, _, _ = sample_balanced_benchmark(
+            seed,
+            alphabet_size=2,
+            num_inner_states=20,
+            num_outer_states=18,
+            probe_length=40,
+            min_accept_or_reject=0.15,
+            max_attempts=50000,
+        )
+        print(outer)
+        oracle_creator = lambda nm, s, _dfa=outer: DFAOracle(nm, s, _dfa)
+        _, dfa, _ = compute_dfa_for_oracle(
+            oracle_creator, min_signal_strength=0.3, seed=0
+        )
+        accuracy, fp, fn = compute_dfa_accuracy(dfa, oracle_creator)
+        if accuracy < 1 - assertion_allowed_error:
+            self.fail(
+                f"DFA incorrect (accuracy {accuracy:.3f}). "
+                f"FP: {len(fp)}, FN: {len(fn)}"
+            )
+
+
 class TestLStarDeepCounter(unittest.TestCase):
     """``Sigma* 0^k Sigma*`` — "contains a run of k zeros".
 


### PR DESCRIPTION
## What

Adds `TestLStarOnLargeGeneratedBenchmarks` — the same flow as the existing `TestLStarOnGeneratedBenchmarks`, but at **`num_outer_states=18`** (vs 10), parameterized over seeds 0–4.

## Why

The existing generated-benchmark coverage caps out at 10-state outer DFAs. This guards that counterexample-driven synthesis keeps learning correctly as benchmarks grow.

## Findings while building it

- **Accuracy holds at scale.** All five seeds learn to ≥ 0.97; locally: `1.000 / 0.990 / 1.000 / 0.995 / 0.995` for seeds 0–4. (Earlier worry that accuracy degrades with size didn't hold — 18-state DFAs learn as well as or better than 15-state ones.)
- **Generation gets rarer.** Balanced `Σ*LΣ*` DFAs of this size are harder to sample, so `max_attempts` is raised to 50000 (generation then succeeds 10/10 across seeds, 3–36s each). With the default-ish low budget, ~half the seeds fail to generate.
- **Synthesis is slower but reliable.** ~2–5 min per seed (114–284s locally). Results are deterministic (seeded), so the tests are slow but not flaky. Each parameterized case runs as its own parallel CI matrix job, so wall-clock isn't gated by the sum.

Seeds 0–4 are contiguous and all verified — no cherry-picking of "lucky" seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)