### PR TITLE
Compute the constant empty-prefix classification once in estimate_agreement_rate

### DIFF
--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -195,15 +195,10 @@ def add_counterexample_prefixes(pst, dt, dfa, count, *, expected_acc):
     return results
 
 
-_S0_UNSET = object()
-
-
-def locate_incorrect_point(oracle, dt, dfa, x, y, *, s0=_S0_UNSET):
-    # ``s0`` is ``dt.classify(x)``; callers that hold ``x`` fixed across many calls
-    # (e.g. estimate_agreement_rate, where x is always the empty prefix) can compute
-    # it once and pass it in rather than re-querying the oracle on every call.
-    if s0 is _S0_UNSET:
-        s0 = dt.classify(x, oracle)
+def locate_incorrect_point(oracle, dt, dfa, x, y, *, s0):
+    # ``s0`` is ``dt.classify(x, oracle)``, passed in by the caller: callers that hold
+    # ``x`` fixed across many calls (e.g. estimate_agreement_rate, where x is always
+    # the empty prefix) compute it once instead of re-querying the oracle every call.
     if s0 is None:
         return None, "could not classify initial state"
     dfa_states_each = states_intermediate(s0, y, dfa)
@@ -261,6 +256,7 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count, expected_acc):
             dfa,
             x,
             y,
+            s0=dt_with_reduced_predicates.classify(x, oracle),
         )
         if prefix is None:
             num_agreements += sym == "no inconsistency"

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -187,8 +187,15 @@ def add_counterexample_prefixes(pst, dt, dfa, count, *, expected_acc):
     return results
 
 
-def locate_incorrect_point(oracle, dt, dfa, x, y):
-    s0 = dt.classify(x, oracle)
+_S0_UNSET = object()
+
+
+def locate_incorrect_point(oracle, dt, dfa, x, y, *, s0=_S0_UNSET):
+    # ``s0`` is ``dt.classify(x)``; callers that hold ``x`` fixed across many calls
+    # (e.g. estimate_agreement_rate, where x is always the empty prefix) can compute
+    # it once and pass it in rather than re-querying the oracle on every call.
+    if s0 is _S0_UNSET:
+        s0 = dt.classify(x, oracle)
     if s0 is None:
         return None, "could not classify initial state"
     dfa_states_each = states_intermediate(s0, y, dfa)
@@ -296,9 +303,14 @@ def estimate_agreement_rate(
     min_valid = 30
     agreements = 0
     valid = 0
+    # Every sample classifies from the empty prefix, so dt_decisive.classify([]) is
+    # constant across the loop; compute it once instead of re-querying the oracle on
+    # each sample.  On multi-iteration benchmarks this empty-prefix reclassification
+    # was ~24% of all oracle queries (it recurs on up to num_samples draws per call).
+    s0 = dt_decisive.classify([], oracle)
     for _ in range(num_samples):
         y = us.sample(pst.rng, pst.alphabet_size)
-        prefix, reason = locate_incorrect_point(oracle, dt_decisive, dfa, [], y)
+        prefix, reason = locate_incorrect_point(oracle, dt_decisive, dfa, [], y, s0=s0)
         if prefix is None and reason == "no inconsistency":
             agreements += 1
             valid += 1

--- a/scripts/profile_query_origins.py
+++ b/scripts/profile_query_origins.py
@@ -1,0 +1,144 @@
+"""Attribute every oracle membership query to its origin in the L* pipeline.
+
+Wraps a benchmark oracle and, on each membership_query, walks the call stack to
+bucket the query by (a) its direct call site and (b) the high-level phase driving
+it.  Prints a breakdown so we can see where queries actually come from before
+deciding what else is worth caching.
+
+Usage:
+    python scripts/profile_query_origins.py            # default: subseq
+    python scripts/profile_query_origins.py poor_case
+"""
+
+import sys
+from collections import Counter
+
+from automata.fa.dfa import DFA
+
+from orthogonal_dfa.l_star.examples.benchmark_generator import DFAOracle
+from orthogonal_dfa.l_star.examples.bernoulli_parity import (
+    BernoulliParityOracle,
+    BernoulliRegex,
+)
+from orthogonal_dfa.l_star.structures import Oracle
+from tests.test_lstar import compute_dfa_for_oracle, evaluate_accuracy
+
+_ANOTHER_POOR_DFA = DFA(
+    states=set(range(10)),
+    input_symbols={0, 1},
+    transitions={
+        0: {1: 8, 0: 0}, 1: {1: 1, 0: 1}, 2: {1: 1, 0: 6}, 3: {1: 9, 0: 2},
+        4: {1: 3, 0: 8}, 5: {1: 8, 0: 4}, 6: {1: 3, 0: 9}, 7: {1: 8, 0: 6},
+        8: {1: 8, 0: 5}, 9: {1: 3, 0: 7},
+    },
+    initial_state=0,
+    final_states={1},
+    allow_partial=False,
+)
+
+# name -> (oracle_creator, min_signal_strength, symbols)
+BENCHMARKS = {
+    "modulo": (
+        lambda nm, s: BernoulliParityOracle(nm, s, modulo=9, allowed_moduluses=(3, 6)),
+        0.3, 2,
+    ),
+    "subseq": (
+        lambda nm, s: BernoulliRegex(nm, s, regex=r".*1010101.*"), 0.3, 2,
+    ),
+    "two_subseq": (
+        lambda nm, s: BernoulliRegex(nm, s, regex=r".*1111.*1111.*"), 0.3, 2,
+    ),
+    "poor_case": (
+        lambda nm, s: DFAOracle(nm, s, _ANOTHER_POOR_DFA), 0.3, 2,
+    ),
+}
+
+# Direct call sites: the function whose body contains the membership_query call.
+DIRECT_SITES = {
+    "compute_mask": "matrix col: new suffix over all prefixes (compute_mask)",
+    "add_prefixes": "matrix row: new prefix over all suffixes (add_prefixes)",
+    "relabel": "denoise: fresh samples per state (relabel)",
+    "predict": "DT classify one string (TriPredicate.predict)",
+}
+
+# For predict, the enclosing high-level phase (searched outward, first match wins).
+PREDICT_PHASES = [
+    "estimate_agreement_rate",
+    "generate_counterexamples",
+    "enrich_underrepresented_leaves",
+]
+
+# For compute_mask, what triggered the new suffix (searched outward).
+MASK_TRIGGERS = [
+    "prepend_to_all",          # building child/transition predicates during discovery
+    "sample_more_suffixes",    # growing the suffix family
+    "discover_states",         # the initial empty-suffix / seed recording
+]
+
+
+class ProfilingOracle(Oracle):
+    def __init__(self, inner: Oracle):
+        self._inner = inner
+        self.buckets = Counter()
+        self.total = 0
+
+    @property
+    def alphabet_size(self) -> int:
+        return self._inner.alphabet_size
+
+    def _attribute(self):
+        # Collect (co_name, lineno) on the stack, innermost first, keeping the
+        # locate_incorrect_point frame so predict queries can be sub-attributed to
+        # the exact call site (empty-string s0 vs full-string check vs binary search).
+        names = []
+        locate_line = None
+        frame = sys._getframe(2)  # skip _attribute + membership_query
+        depth = 0
+        while frame is not None and depth < 60:
+            names.append(frame.f_code.co_name)
+            if frame.f_code.co_name == "locate_incorrect_point":
+                locate_line = frame.f_lineno
+            frame = frame.f_back
+            depth += 1
+        name_set = set(names)
+        for site, label in DIRECT_SITES.items():
+            if site in name_set:
+                if site == "predict":
+                    phase = next((p for p in PREDICT_PHASES if p in name_set), "other")
+                    sub = f" [locate L{locate_line}]" if locate_line else ""
+                    return f"{label} <- {phase}{sub}"
+                if site == "compute_mask":
+                    trig = next((t for t in MASK_TRIGGERS if t in name_set), "other")
+                    return f"{label} <- {trig}"
+                return label
+        return f"UNATTRIBUTED ({names[:4]})"
+
+    def membership_query(self, string):
+        self.total += 1
+        self.buckets[self._attribute()] += 1
+        return self._inner.membership_query(string)
+
+
+def main():
+    name = sys.argv[1] if len(sys.argv) > 1 else "subseq"
+    oracle_creator, signal, symbols = BENCHMARKS[name]
+    holder = {}
+
+    def creator(noise_model, s):
+        o = ProfilingOracle(oracle_creator(noise_model, s))
+        holder["o"] = o
+        return o
+
+    _, dfa, _ = compute_dfa_for_oracle(creator, min_signal_strength=signal, seed=0)
+    acc = evaluate_accuracy(dfa, oracle_creator, symbols=symbols)
+    o = holder["o"]
+
+    print(f"\n\n===== QUERY ORIGINS: {name} "
+          f"(states={len(dfa.states)}, acc={acc:.3f}) =====")
+    print(f"total queries: {o.total:,}\n")
+    for label, n in o.buckets.most_common():
+        print(f"{n:>12,}  {100*n/o.total:5.1f}%  {label}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

`estimate_agreement_rate` calls `locate_incorrect_point(..., x=[], y)` on every sample, and the first thing that does is `s0 = dt.classify([])` — the **same empty string**, reclassified on up to `num_samples` draws per call. `s0` is constant within a call (fixed decisive tree, fixed empty string, deterministic oracle), so it only needs computing **once**.

`locate_incorrect_point` now accepts a precomputed `s0`; `estimate_agreement_rate` computes it once before the sampling loop and passes it in.

## Why it's safe

`s0` doesn't touch `pst.rng` and its value is unchanged, so the sample stream, the per-sample agreement decisions, and the output DFA are all identical — this only removes redundant oracle queries. (Behavior-preservation confirmed empirically below: the output DFA and every non-`s0` query bucket are byte-identical.)

## Distinct from #110

#110 added a sample-count early-stop (fewer *samples* drawn). This is orthogonal — it cuts the *per-sample* cost. The empty-prefix reclassification was measured at **~22–24% of all oracle queries** on multi-iteration benchmarks, precisely because the iterations that still draw many samples are the high-agreement ones near the threshold, where each retained sample still re-ran `dt.classify([])`.

## Measured (poor_case, `scripts/profile_query_origins.py`, identical seed)

| | baseline (main) | patched |
|---|---:|---:|
| total queries | 8,238,113 | **6,397,804** (−22.3%) |
| empty-`s0` classification | 1,841,590 | 1,281 (one per call) |
| agreement check / binary search / prepend / add_prefixes | — | **all byte-identical** |
| output DFA | 9 states, acc 0.977 | **9 states, acc 0.977** |

The saved amount (1,840,309) equals the delta exactly.

## Also

Adds `scripts/profile_query_origins.py` — attributes every oracle query to its origin (direct call site + high-level phase, with line-level sub-attribution inside `locate_incorrect_point`), so query-cost changes can be measured precisely. This is the tool that produced the table above.

## Note

Independent of #112 (mask-cache reuse in `enrich`); the two optimizations touch different regions of `lstar.py` and stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)