### PR TITLE
Cut oracle queries with restricted-prepend discovery + resplit fixpoint

### DIFF
--- a/orthogonal_dfa/l_star/cluster.py
+++ b/orthogonal_dfa/l_star/cluster.py
@@ -13,7 +13,14 @@ def identify_cluster_around(
     # statistically-unrepresentative short prefix-closed core.  Suffix (row)
     # indices are unaffected by the column slice, so the returned cluster is
     # still valid against the full prefix set used for state discovery.
-    masks = np.array(pst.corresponding_masks)[:, pst.representative]
+    all_masks = np.array(pst.corresponding_masks)
+    # Exclude partial (NaN) suffix columns: those are prepend distinguishers evaluated
+    # over only part of the prefix set, so their loss against the seed is undefined.
+    # The empty-suffix seed is always full, so it survives the filter.  With no partial
+    # suffixes (the default), ``full`` is all-True and this is a no-op.
+    full_idx = np.flatnonzero(~np.isnan(all_masks).any(axis=1))
+    masks = all_masks[full_idx][:, pst.representative]
+    seed = int(np.searchsorted(full_idx, seed))
     cluster = [seed]
     loss = float("inf")
     while True:
@@ -46,7 +53,7 @@ def identify_cluster_around(
         # symmetric to above
         decision_boundary = reject_mean
 
-    return cluster.tolist(), decision_boundary
+    return full_idx[cluster].tolist(), decision_boundary
 
 
 def recompute_evidence_margin(

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -18,6 +18,7 @@ Evidence thresholds need some work. Currently there's the possibiliy of p-hackin
 
 import copy
 import warnings
+from collections import defaultdict
 
 import numpy as np
 import tqdm.auto as tqdm
@@ -29,7 +30,12 @@ from .dfa_utils import (
     sample_string_reaching_state,
     states_intermediate,
 )
-from .state_discovery import discover_states
+from .state_discovery import (
+    discover_states,
+    discover_tracker,
+    lca_predicate_vs,
+    overlapping_states,
+)
 from .statistics import binomial_side_of_boundary, unlikely_this_many_agreements
 from .structures import DecisionTree, DecisionTreeLeafNode, TriPredicate
 
@@ -52,32 +58,122 @@ def classify_states_with_decision_tree(pst, dt: DecisionTree):
     return results
 
 
-def compute_transition_matrix(pst, dt: DecisionTree) -> np.ndarray:
-    states = classify_states_with_decision_tree(pst, dt)
-    states_after_c = [
-        classify_states_with_decision_tree(
-            pst,
-            dt.map_over_predicates(
-                lambda p, c=c: TriPredicate(
-                    [[c] + x for x in p.vs], p.accept_threshold, p.reject_threshold
-                )
-            ),
-        )
-        for c in range(pst.alphabet_size)
-    ]
+def _prepend_recorded(pst, dt_dec, c, active):
+    """Prepend symbol ``c`` to every predicate in the (decisive) tree, recording each
+    ``[c]+suffix`` into the mask matrix restricted to the ``active`` prefixes.  Returns a
+    tree whose predicates read those now-cached columns.  Because membership(x + [c]+v)
+    is exactly the [c]+v column at x, whoever needs a c-successor next -- the next
+    fixpoint round or the DFA build -- reads the cache instead of re-querying."""
+
+    def prep(p):
+        new_vs = []
+        for v in p.vs:
+            cv = [c] + list(v)
+            pst.record_suffix(cv, active=active)
+            new_vs.append(cv)
+        return TriPredicate(new_vs, p.accept_threshold, p.reject_threshold)
+
+    return dt_dec.map_over_predicates(prep)
+
+
+def _subsample_mask(pst, states, cap):
+    """Deterministic per-state subsample: the first ``cap`` classified prefixes of each
+    state (all of them when ``cap`` is None).  Deterministic so the fixpoint's detection
+    pass and the DFA build hit the *same* cached [c]+suffix cells instead of drawing
+    disjoint random subsamples that can't share."""
+    mask = np.zeros(pst.num_prefixes, dtype=bool)
+    by_state = defaultdict(list)
+    for i, s in enumerate(states.tolist()):
+        if s >= 0:
+            by_state[s].append(i)
+    for idxs in by_state.values():
+        mask[idxs if cap is None else idxs[:cap]] = True
+    return mask
+
+
+def _transition_tensor(pst, dt, states, cap):
+    """(source, symbol, target) vote tensor.  Each source prefix's c-successor is
+    classified *decisively* by reading the cached [c]+suffix columns (populated over the
+    subsample), never oracle-direct -- so the votes are computed once and every later
+    reader reuses them.  A capped subsample keeps only ``cap`` prefixes per state, so we
+    never complete a full [c]+predicate column over all prefixes."""
+    boundary = pst.decision_boundary
+    dt_dec = dt.map_over_predicates(lambda p: TriPredicate(p.vs, boundary, boundary))
+    sample = _subsample_mask(pst, states, cap)
     num_states = dt.num_states
     transitions = np.zeros((num_states, pst.alphabet_size, num_states), dtype=int)
-    for c, states_c in enumerate(states_after_c):
-        valid = states_c >= 0
-        np.add.at(
-            transitions,
-            (states[valid], c, states_c[valid]),
-            1,
-        )
+    for c in range(pst.alphabet_size):
+        prepended = _prepend_recorded(pst, dt_dec, c, sample)
+        succ = classify_states_with_decision_tree(pst, prepended)
+        valid = (succ >= 0) & sample
+        np.add.at(transitions, (states[valid], c, succ[valid]), 1)
+    return transitions
+
+
+def compute_transition_matrix(pst, dt: DecisionTree) -> np.ndarray:
+    states = classify_states_with_decision_tree(pst, dt)
+    transitions = _transition_tensor(pst, dt, states, pst.config.transition_sample_cap)
     print("Transition matrix:")
     print(transitions)
-
     return transitions.argmax(-1)
+
+
+def discover_states_resplit(pst, first_round: bool) -> DecisionTree:
+    """Restricted-prepend discovery, then a transition-informed fixpoint that recovers
+    the cross-branch splits the restriction misses.
+
+    The restriction only queries ``[c]+F`` over the state its parent split, so a state
+    ``T`` whose c-successors actually straddle a split elsewhere in the tree is left
+    merged.  That shows up as ``T``'s sampled c-successors landing on two different
+    states: we take the distinguisher that separates those successors, prepend ``[c]``
+    to it, query it over ``T``'s prefixes only (un-restricting just that edge), and split
+    ``T`` if the family passes the same statistical test discovery uses.  Repeat until no
+    state has a straddling successor -- at which point every real split has been found.
+    """
+    tracker = discover_tracker(pst, first_round)
+    cap = pst.config.transition_sample_cap
+    min_share = pst.config.resplit_min_share
+    tried = set()
+
+    while len(tracker) > 1:
+        dt = tracker.to_decision_tree()
+        # The same cached, subsampled transition votes the DFA build reads: a state
+        # whose row for symbol c puts real mass on two distinct successors is straddling
+        # a split the restriction missed.
+        states = classify_states_with_decision_tree(pst, dt)
+        tensor = _transition_tensor(pst, dt, states, cap)
+        candidate = None
+        for s in range(dt.num_states):
+            key_prefixes = frozenset(np.flatnonzero(tracker.states[s][1]).tolist())
+            for c in range(pst.alphabet_size):
+                row = tensor[s, c]
+                total = int(row.sum())
+                if total == 0:
+                    continue
+                targets = set(np.flatnonzero(row >= max(2, min_share * total)).tolist())
+                if len(targets) < 2 or (key_prefixes, c) in tried:
+                    continue
+                vs_strings = lca_predicate_vs(dt, targets)
+                if vs_strings is None:
+                    continue
+                candidate = (s, c, vs_strings, key_prefixes)
+                break
+            if candidate is not None:
+                break
+        if candidate is None:
+            break
+        s, c, vs_strings, key_prefixes = candidate
+        tried.add((key_prefixes, c))
+        # Un-restrict just this edge: query [c]+distinguisher over the straddling state's
+        # own prefixes, then split it if the family passes discovery's statistical test.
+        mask = tracker.states[s][1]
+        vs_new = [pst.record_suffix([c] + list(v), active=mask)[2] for v in vs_strings]
+        ol = overlapping_states(pst, tracker, vs_new)
+        if s in ol:
+            print(f"Re-split state {s} on symbol {c} (cross-branch split recovered)")
+            tracker.split(pst, [s], vs_new)
+
+    return tracker.to_decision_tree()
 
 
 def optimal_dfa(pst, dt: DecisionTree):
@@ -392,8 +488,13 @@ def counterexample_driven_synthesis(
     first_round = True
     while True:
         print(f"Starting synthesis iteration with {pst.num_prefixes} prefixes")
+        discover = (
+            discover_states_resplit
+            if pst.config.resplit_transitions
+            else discover_states
+        )
         while True:
-            dt = discover_states(pst, first_round=first_round)
+            dt = discover(pst, first_round=first_round)
             first_round = False
             print(f"Extracted flat decision tree with {dt.num_states} states")
             if dt.num_states > 1:

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -170,7 +170,9 @@ def discover_states_resplit(pst, first_round: bool) -> DecisionTree:
                     pst.record_suffix([c] + list(v), active=mask)[2] for v in vs_strings
                 ]
                 if s in overlapping_states(pst, tracker, vs_new):
-                    print(f"Re-split state {s} on symbol {c} (cross-branch split found)")
+                    print(
+                        f"Re-split state {s} on symbol {c} (cross-branch split found)"
+                    )
                     tracker.split(pst, [s], vs_new)
                     split_happened = True
                     break

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -142,36 +142,42 @@ def discover_states_resplit(pst, first_round: bool) -> DecisionTree:
         # a split the restriction missed.
         states = classify_states_with_decision_tree(pst, dt)
         tensor = _transition_tensor(pst, dt, states, cap)
-        candidate = None
+        # A rejected candidate (a noise straddle that fails the split test) leaves the
+        # tree unchanged, so we keep scanning this one tensor and only recompute after an
+        # actual split -- otherwise every rejected candidate would pay for a full tensor.
+        split_happened = False
         for s in range(dt.num_states):
             key_prefixes = frozenset(np.flatnonzero(tracker.states[s][1]).tolist())
             for c in range(pst.alphabet_size):
+                if (key_prefixes, c) in tried:
+                    continue
                 row = tensor[s, c]
                 total = int(row.sum())
                 if total == 0:
                     continue
                 targets = set(np.flatnonzero(row >= max(2, min_share * total)).tolist())
-                if len(targets) < 2 or (key_prefixes, c) in tried:
+                if len(targets) < 2:
                     continue
                 vs_strings = lca_predicate_vs(dt, targets)
                 if vs_strings is None:
                     continue
-                candidate = (s, c, vs_strings, key_prefixes)
+                tried.add((key_prefixes, c))
+                # Un-restrict just this edge: query [c]+distinguisher over the straddling
+                # state's own prefixes, then split it if the family passes discovery's
+                # statistical test.
+                mask = tracker.states[s][1]
+                vs_new = [
+                    pst.record_suffix([c] + list(v), active=mask)[2] for v in vs_strings
+                ]
+                if s in overlapping_states(pst, tracker, vs_new):
+                    print(f"Re-split state {s} on symbol {c} (cross-branch split found)")
+                    tracker.split(pst, [s], vs_new)
+                    split_happened = True
+                    break
+            if split_happened:
                 break
-            if candidate is not None:
-                break
-        if candidate is None:
+        if not split_happened:
             break
-        s, c, vs_strings, key_prefixes = candidate
-        tried.add((key_prefixes, c))
-        # Un-restrict just this edge: query [c]+distinguisher over the straddling state's
-        # own prefixes, then split it if the family passes discovery's statistical test.
-        mask = tracker.states[s][1]
-        vs_new = [pst.record_suffix([c] + list(v), active=mask)[2] for v in vs_strings]
-        ol = overlapping_states(pst, tracker, vs_new)
-        if s in ol:
-            print(f"Re-split state {s} on symbol {c} (cross-branch split recovered)")
-            tracker.split(pst, [s], vs_new)
 
     return tracker.to_decision_tree()
 

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -8,9 +8,19 @@ from .sampler import Sampler
 from .structures import Oracle
 
 
-def compute_mask(for_state, oracle, v):
-    mask = np.array([oracle.membership_query(x + v) for x in for_state], np.float32)
+def compute_mask(for_state, oracle, v, active=None):
+    """Membership of ``x + v`` for each prefix ``x`` in ``for_state``.
 
+    When ``active`` (a boolean mask over ``for_state``) is given, only the active
+    prefixes are queried; the rest are left ``NaN`` ("not evaluated").  A ``NaN`` cell
+    fails both the accept and reject threshold comparisons, so it is naturally
+    excluded from the split test rather than counted as either class.
+    """
+    if active is None:
+        return np.array([oracle.membership_query(x + v) for x in for_state], np.float32)
+    mask = np.full(len(for_state), np.nan, np.float32)
+    for i in np.flatnonzero(active):
+        mask[i] = oracle.membership_query(for_state[i] + v)
     return mask
 
 
@@ -60,6 +70,23 @@ class SearchConfig:
     split_pval: float = 0.001
     min_suffix_frequency: float = 0.05
     min_acc_rej: float = 0.1
+    # When True, a prepended family [c]+vs is queried only over the prefixes of the
+    # states its parent family split (which is where it can produce a split -- see
+    # the prepend-provenance analysis), instead of over all prefixes.  Un-evaluated
+    # cells are left NaN and excluded from the split test.  The transition matrix is
+    # then computed by classifying only a capped subsample of each state's prefixes'
+    # c-successors, rather than re-completing every [c]+predicate over all prefixes.
+    restrict_prepend_queries: bool = False
+    # Max prefixes per state whose c-successor is classified when estimating each
+    # transition (a per-(state, symbol) majority vote); None classifies all of them.
+    transition_sample_cap: Optional[int] = None
+    # After a restricted-prepend discovery, iteratively re-split states whose sampled
+    # c-successors straddle a real split (a cross-branch split the restriction missed),
+    # un-restricting only the offending [c]+distinguisher over that state's prefixes.
+    resplit_transitions: bool = False
+    # Min share of a state's sampled c-successors that must land on a second distinct
+    # successor before it's treated as a candidate cross-branch split.
+    resplit_min_share: float = 0.15
 
 
 @dataclass
@@ -152,11 +179,21 @@ class PrefixSuffixTracker:
                 continue
             return self.record_suffix(v)
 
-    def record_suffix(self, v: List[int]) -> Tuple[List[int], np.ndarray, int]:
+    def record_suffix(
+        self, v: List[int], active=None
+    ) -> Tuple[List[int], np.ndarray, int]:
         if tuple(v) in self.suffixes_seen:
+            _, _, idx = self.suffixes_seen[tuple(v)]
+            if active is not None:
+                # Grow the partial column over the requested prefixes; ``active=None``
+                # leaves it as-is (a partial predicate classifies its own state's
+                # prefixes; the rest fall to "unclassified" and are ignored).
+                live = self.corresponding_masks[idx]
+                for i in np.flatnonzero(active & np.isnan(live)):
+                    live[i] = self.oracle.membership_query(self.prefixes[i] + v)
             return self.suffixes_seen[tuple(v)]
         self.suffix_bank.append(v)
-        mask = compute_mask(self.prefixes, self.oracle, v)
+        mask = compute_mask(self.prefixes, self.oracle, v, active)
         self.corresponding_masks.append(mask)
         self.suffixes_seen[tuple(v)] = v, mask, len(self.suffix_bank) - 1
         return v, mask, len(self.suffix_bank) - 1
@@ -219,12 +256,17 @@ class PrefixSuffixTracker:
         self, vs: List[List[int]], subset_prefixes=None
     ) -> np.ndarray:
         decision = self.compute_decision_from_strings(vs, subset_prefixes)
-        return np.array(
-            [
-                decision < self.reject_thresh,
-                decision >= self.accept_thresh,
-            ]
-        )
+        # NaN (un-evaluated) cells fail both comparisons -> classified as neither
+        # accept nor reject, so a partial column excludes those prefixes rather than
+        # miscounting them.  Such cells only occur for prefixes outside the predicate's
+        # state, which are routed away before the result is used.
+        with np.errstate(invalid="ignore"):
+            return np.array(
+                [
+                    decision < self.reject_thresh,
+                    decision >= self.accept_thresh,
+                ]
+            )
 
     def add_prefixes(self, new_prefixes: List[List[int]]):
 
@@ -233,6 +275,11 @@ class PrefixSuffixTracker:
             set(tuple(p) for p in new_prefixes + self.prefixes)
         ), "Prefixes must be unique"
 
+        # A partial suffix column (some cells NaN) stays partial for new prefixes:
+        # those prefixes lie outside the suffix's discovery state, so evaluating them
+        # would be exactly the wasted work partial columns exist to avoid.  They are
+        # filled lazily by record_suffix if a later round actually needs them.
+        partial = [bool(np.isnan(m).any()) for m in self.corresponding_masks]
         additional_prefixes = []
         additional_masks = []
         for prefix in tqdm.tqdm(new_prefixes, desc="Adding new prefixes", delay=1):
@@ -240,8 +287,12 @@ class PrefixSuffixTracker:
             additional_masks.append(
                 np.array(
                     [
-                        self.oracle.membership_query(prefix + v)
-                        for v in self.suffix_bank
+                        (
+                            np.nan
+                            if partial[i]
+                            else self.oracle.membership_query(prefix + v)
+                        )
+                        for i, v in enumerate(self.suffix_bank)
                     ],
                     np.float32,
                 )

--- a/orthogonal_dfa/l_star/state_discovery.py
+++ b/orthogonal_dfa/l_star/state_discovery.py
@@ -20,10 +20,10 @@ def cascade(mask_1, mask_2):
     return mask_1
 
 
-def prepend_to_all(pst, vs: List[int], prefix: int):
+def prepend_to_all(pst, vs: List[int], prefix: int, active=None):
     vs_new = []
     for v in tqdm.tqdm(vs, desc="Prepending to all suffixes", delay=1):
-        _, _, v_new = pst.record_suffix([prefix] + pst.suffix_bank[v])
+        _, _, v_new = pst.record_suffix([prefix] + pst.suffix_bank[v], active=active)
         vs_new.append(v_new)
     return vs_new
 
@@ -114,12 +114,15 @@ def _locate_mergeable_paths(partial_tree):
 
 def overlapping_states(pst, tracker, vs):
     decision = pst.compute_decision(vs, np.ones(pst.num_prefixes, dtype=bool))
-    masks = np.array(
-        [
-            decision >= pst.accept_thresh,
-            decision < pst.reject_thresh,
-        ]
-    )
+    # NaN (un-evaluated, for a partial prepend family) fails both comparisons, so
+    # such prefixes drop out of ``valid`` below instead of being miscounted.
+    with np.errstate(invalid="ignore"):
+        masks = np.array(
+            [
+                decision >= pst.accept_thresh,
+                decision < pst.reject_thresh,
+            ]
+        )
     existing_states = tracker.state_masks
     assert (
         existing_states.shape[1] == pst.num_prefixes
@@ -146,24 +149,56 @@ def overlapping_states(pst, tracker, vs):
     return split_idxs
 
 
-def discover_states(pst, first_round: bool) -> DecisionTree:
+def discover_tracker(pst, first_round: bool) -> StateTracker:
     _, _, v_idx = pst.record_suffix([])
     vs, decision_boundary = sample_suffix_family(pst, v_idx, first_round=first_round)
     pst.decision_boundary = decision_boundary
-    vs_queue = [([], vs)]
+    restrict = pst.config.restrict_prepend_queries
+    # Each queue item carries the prefix mask the family is defined over.  A prepended
+    # family only ever splits its parent's children, so it is queried only over the
+    # prefixes of the states its parent split; the root family covers all prefixes.
+    all_prefixes = np.ones(len(pst.prefixes), dtype=bool)
+    vs_queue = [([], vs, all_prefixes)]
     tracker = StateTracker(len(pst.prefixes))
 
     while vs_queue:
-        path, vs_current = vs_queue.pop()
+        path, vs_current, _active = vs_queue.pop()
         print(f"Num states: {len(tracker)}; processing {path}")
         ol = overlapping_states(pst, tracker, vs_current)
         if not ol:
             print("Done")
             continue
+        # Prefixes of the states about to be split == the union of their masks; the
+        # children (and everything below them) live inside this set.
+        child_active = np.any(tracker.state_masks[ol], axis=0)
         tracker.split(pst, ol, vs_current)
         vs_queue.extend(
-            ([c] + path, prepend_to_all(pst, vs_current, c))
+            (
+                [c] + path,
+                prepend_to_all(pst, vs_current, c, child_active if restrict else None),
+                child_active,
+            )
             for c in range(pst.alphabet_size)
         )
 
-    return tracker.to_decision_tree()
+    return tracker
+
+
+def discover_states(pst, first_round: bool) -> DecisionTree:
+    return discover_tracker(pst, first_round).to_decision_tree()
+
+
+def lca_predicate_vs(dt: DecisionTree, targets):
+    """Suffix family (``vs`` strings) of the lowest common ancestor node that separates
+    the given leaf ``state_idx`` set.  This is the distinguisher that split those leaves
+    apart during discovery; returns ``None`` if they all fall under one leaf."""
+    node = dt
+    while isinstance(node, DecisionTreeInternalNode):
+        rej = set(node.by_rejection[0].collect_states())
+        if targets <= rej:
+            node = node.by_rejection[0]
+        elif targets <= set(node.by_rejection[1].collect_states()):
+            node = node.by_rejection[1]
+        else:
+            return node.predicate.vs
+    return None

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -138,6 +138,9 @@ def compute_pst(
         min_signal_strength=min_signal_strength,
         num_addtl_prefixes=200 if use_dynamic else None,
         min_suffix_frequency=min_suffix_frequency,
+        restrict_prepend_queries=True,
+        transition_sample_cap=40,
+        resplit_transitions=True,
     )
     print(
         f"Using suffix population size {n}, eps {eps}, and {k} prefixes "


### PR DESCRIPTION
## What

Reduces oracle membership queries (the dominant cost against a neural-net oracle) in the L*-style discovery loop, without changing what's learned.

State discovery prepends `[c]+F` over **every** prefix. Empirically a prepended family almost always only splits the states its parent split — **except** cross-branch splits, where a state's `c`-successor straddles a split elsewhere in the tree (e.g. the parity/`modulo` automaton). Restricting prepend queries to the parent's prefixes alone is therefore *unsound*: it silently loses those splits (measured: 9 states → 6 on `modulo`).

This PR makes the restriction sound and profitable via an opt-in path:

- **Restricted discovery** — `[c]+F` is queried only over the parent state's prefixes; other cells stay `NaN` and drop out of the split test.
- **Transition-informed resplit fixpoint** — a state whose sampled `c`-successors put real mass on two distinct successors is straddling a split. We un-restrict just that `[c]+distinguisher` over that state's prefixes and re-split it if it passes discovery's existing statistical test. Repeat to a fixpoint → every cross-branch split is recovered.
- **Cached successor classification** — successors are classified by reading cached `[c]+suffix` matrix columns (recorded over a deterministic per-state subsample), never oracle-direct. So the fixpoint's detection pass and the DFA transition build **share the cache** instead of each re-querying (`membership(x + [c]+v)` *is* the `[c]+v` column at `x`). This caching was the difference between +74% and −12% on one seed.

Gated behind `SearchConfig.restrict_prepend_queries` / `resplit_transitions` / `transition_sample_cap` (default **off**). `tests/test_lstar.py` runs with them on.

## Validation

Across seeds, by **accuracy against the noiseless oracle** (never DFA-identity — the algorithm must work for any seed). Query delta vs. the unrestricted baseline, 3 seeds each:

| benchmark | seed 0 | seed 1 | seed 2 | accuracy |
|---|---|---|---|---|
| modulo (dense parity) | −14.6% | −13.3% | −14.9% | matches baseline (1.000) |
| subseq | −13.0% | −11.8% | −66.0% | matches baseline (1.000) |
| two_subseq | −23.7% | −24.2% | −24.1% | matches baseline (1.000) |
| poor_case | −9.3% | −19.5% | −43.4% | matches baseline |

Every run saves queries; accuracy matches the baseline everywhere, including the dense `modulo` automaton that the restriction alone could not learn.

## Notes for review

- The optimized path is opt-in. There are no `SearchConfig` constructions in the package outside tests/scripts, so enabling it broadly would mean flipping these three field defaults — deliberately left out of this PR.
- Local run of the 11 slowest tests (all `modulo` variants, subsequences, `poor_case`) passes with the path on; relying on CI for the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)