### PR TITLE
Make the MaskTable lazily observed (resolver finding [1])

### DIFF
--- a/orthogonal_dfa/l_star/cluster.py
+++ b/orthogonal_dfa/l_star/cluster.py
@@ -8,22 +8,25 @@ from .statistics import evidence_margin_for_population_size, give_up_check
 def identify_cluster_around(
     pst, seed: int, count: int, decision_boundary: float
 ) -> Tuple[List[int], float]:
+    # Cluster only over fully-observed suffix columns -- the sampled acceptance-
+    # family suffixes -- to avoid forcing a bunch of additional computation on the
+    # partially-observed transition distinguishers.
+    #
     # Restrict to representative (non-core) prefix columns: the suffix family and
     # the decision boundary are global calibration and must not be biased by the
-    # statistically-unrepresentative short prefix-closed core.  Suffix (row)
-    # indices are unaffected by the column slice, so the returned cluster is
-    # still valid against the full prefix set used for state discovery.
-    masks = pst.table.observed_masks(
-        range(pst.table.num_suffixes), pst.table.representative
-    )
-    cluster = [seed]
+    # statistically-unrepresentative short prefix-closed core.
+    candidate = pst.table.fully_observed()
+    masks = pst.table.observed_masks(candidate, pst.table.representative)
+    seed_local = int(np.searchsorted(candidate, seed))
+    assert candidate[seed_local] == seed, "cluster seed must be fully observed"
+    cluster = [seed_local]
     loss = float("inf")
     while True:
         cluster_center = masks[cluster].mean(0) > decision_boundary
         losses = (masks != cluster_center).sum(1)
         cluster = losses.argsort()[:count]
-        if seed not in cluster:
-            cluster = np.concatenate([[seed], cluster[: count - 1]])
+        if seed_local not in cluster:
+            cluster = np.concatenate([[seed_local], cluster[: count - 1]])
         new_loss = losses[cluster].sum()
         if new_loss >= loss:
             break
@@ -48,7 +51,7 @@ def identify_cluster_around(
         # symmetric to above
         decision_boundary = reject_mean
 
-    return cluster.tolist(), decision_boundary
+    return candidate[cluster].tolist(), decision_boundary
 
 
 def recompute_evidence_margin(
@@ -121,21 +124,26 @@ def _give_up_check(pst, config, seed_mask, empirical_pos):
     rep = pst.table.representative
     seed_mask = seed_mask[rep]
     empirical_pos = float(seed_mask.mean())
+    # The give-up statistic reasons about the sampled acceptance-family suffixes
+    # (their count bounds how many are idempotent), so count the fully-observed
+    # family suffixes -- not every interned row, which would also include
+    # transition distinguishers.
+    candidate = pst.table.fully_observed()
     result = give_up_check(
         config.min_signal_strength,
         int(rep.sum()),
-        pst.table.num_suffixes,
+        len(candidate),
         config.min_suffix_frequency,
         config.min_acc_rej,
         empirical_pos,
     )
     if result is not None:
         k, threshold = result
-        masks = pst.table.observed_masks(range(pst.table.num_suffixes), rep)
+        masks = pst.table.observed_masks(candidate, rep)
         agreements = (masks == seed_mask).mean(axis=1)
         top_k_mean = float(np.sort(agreements)[-k:].mean())
         if top_k_mean <= threshold:
             raise GaveUpOnSuffixSearch(
-                f"Sampled {pst.table.num_suffixes} suffixes. "
+                f"Sampled {len(candidate)} suffixes. "
                 f"Top-{k} mean agreement {top_k_mean:.3f} <= {threshold:.3f}"
             )

--- a/orthogonal_dfa/l_star/mask_table.py
+++ b/orthogonal_dfa/l_star/mask_table.py
@@ -1,17 +1,26 @@
 """The prefix x suffix membership table.
 
-A single object that owns the prefixes, the suffixes, and the membership matrix
-between them.  It is the *only* place the raw table lives; everything else works
-through the small interface below and never touches the underlying arrays.
+A single object that owns the prefixes, the suffixes, and the (lazily observed)
+membership matrix between them.  It is the *only* place the raw table lives;
+everything else works through the small interface below and never touches the
+underlying arrays.
 
-Each cell is ``membership_query(prefix + suffix)`` as a float32 ``0``/``1``.  A
-suffix's whole column is queried when the suffix is interned, and every column is
-extended when new prefixes are added, so the matrix is always fully populated.
+Each cell is int8: ``0`` (reject), ``1`` (accept), or ``UNOBSERVED (-1)`` for a
+``(prefix, suffix)`` pair whose membership query has not been issued yet.  No
+query is ever made preemptively -- ``record``/``add_prefixes`` only reserve
+``UNOBSERVED`` cells, and a cell is filled the first time some read
+(``observed_masks`` / ``column``) actually needs it.  Because the oracle is
+deterministic per string, lazy filling returns exactly the values eager filling
+would, so callers cannot tell the difference except in query count.
 """
 
 from typing import List
 
 import numpy as np
+
+# Sentinel for a not-yet-queried cell.  Private to this module: callers ask about
+# observation through ``fully_observed`` / ``observed_masks`` and never see it.
+UNOBSERVED = np.int8(-1)
 
 
 class MaskTable:
@@ -23,17 +32,13 @@ class MaskTable:
         self._representative = list(representative)
         self._suffixes: List[List[int]] = []
         self._suffix_index = {}  # tuple(suffix) -> row
-        self._masks: List[np.ndarray] = []  # one float32 column per suffix
+        self._masks: List[np.ndarray] = []  # one int8 column per suffix
 
     # -- sizes / prefix side ------------------------------------------------
 
     @property
     def num_prefixes(self) -> int:
         return len(self._prefixes)
-
-    @property
-    def num_suffixes(self) -> int:
-        return len(self._suffixes)
 
     @property
     def prefixes(self) -> tuple:
@@ -53,11 +58,23 @@ class MaskTable:
         assert all(not self.contains_prefix(p) for p in new_prefixes) and len(
             new_prefixes
         ) == len({tuple(p) for p in new_prefixes}), "Prefixes must be unique"
-        # Extend every existing suffix column to cover the new prefixes.
-        self._masks = [
-            np.concatenate([col, self._query(suffix, new_prefixes)])
-            for suffix, col in zip(self._suffixes, self._masks)
-        ]
+        # A column that is already fully observed is a family suffix: keep it
+        # fully observed by querying the new prefixes, so it stays a clustering
+        # candidate.  A partially-observed column (a transition distinguisher)
+        # gets UNOBSERVED cells, filled later on demand only if some read needs
+        # them.
+        pad = np.full(len(new_prefixes), UNOBSERVED, dtype=np.int8)
+        updated = []
+        for suffix, col in zip(self._suffixes, self._masks):
+            if (col != UNOBSERVED).all():
+                add = np.array(
+                    [self._oracle.membership_query(p + suffix) for p in new_prefixes],
+                    dtype=np.int8,
+                )
+            else:
+                add = pad
+            updated.append(np.concatenate([col, add]))
+        self._masks = updated
         self._prefixes.extend(list(p) for p in new_prefixes)
         self._prefix_keys.update(tuple(p) for p in new_prefixes)
         # Prefixes added after construction (counterexamples, leaf enrichment)
@@ -67,14 +84,14 @@ class MaskTable:
     # -- suffix side --------------------------------------------------------
 
     def intern_suffix(self, v: List[int]) -> int:
-        """Return the row index for suffix ``v``, registering it -- and querying
-        its whole column against the oracle -- if it is new."""
+        """Return the row index for suffix ``v``, registering it (with an
+        all-``UNOBSERVED`` column, no queries) if it is new."""
         key = tuple(v)
         if key in self._suffix_index:
             return self._suffix_index[key]
         row = len(self._suffixes)
         self._suffixes.append(list(v))
-        self._masks.append(self._query(v, self._prefixes))
+        self._masks.append(np.full(self.num_prefixes, UNOBSERVED, dtype=np.int8))
         self._suffix_index[key] = row
         return row
 
@@ -84,21 +101,38 @@ class MaskTable:
     def suffix(self, row: int) -> List[int]:
         return self._suffixes[row]
 
-    # -- reads --------------------------------------------------------------
+    # -- observation / reads ------------------------------------------------
+
+    def _ensure(self, rows, prefix_mask) -> None:
+        """Fill any UNOBSERVED cells for ``rows`` over the boolean
+        ``prefix_mask``.  Cells already observed are reused, so no
+        ``(prefix, suffix)`` pair is queried twice."""
+        idx = np.flatnonzero(prefix_mask)
+        for r in rows:
+            col = self._masks[r]
+            suffix = self._suffixes[r]
+            for p in idx[col[idx] == UNOBSERVED]:
+                col[p] = self._oracle.membership_query(self._prefixes[p] + suffix)
 
     def observed_masks(self, rows, prefix_mask) -> np.ndarray:
-        """The ``(len(rows), prefix_mask.sum())`` block for suffix ``rows`` over
-        the prefixes selected by ``prefix_mask``."""
+        """The ``(len(rows), prefix_mask.sum())`` int8 block for ``rows`` over the
+        prefixes selected by ``prefix_mask``, querying any cells not yet
+        observed."""
+        self._ensure(rows, prefix_mask)
         return np.array([self._masks[r][prefix_mask] for r in rows])
 
     def column(self, row: int) -> np.ndarray:
-        """The full membership column of suffix ``row`` over every prefix."""
+        """Fully observe suffix ``row`` over every prefix and return its column.
+        Also used to promote a suffix to "fully observed" (a clustering
+        candidate)."""
+        self._ensure([row], np.ones(self.num_prefixes, dtype=bool))
         return self._masks[row].copy()
 
-    # -- internal -----------------------------------------------------------
-
-    def _query(self, suffix: List[int], prefixes: List[List[int]]) -> np.ndarray:
-        return np.array(
-            [self._oracle.membership_query(p + suffix) for p in prefixes],
-            dtype=np.float32,
-        )
+    def fully_observed(self) -> np.ndarray:
+        """Row indices of the suffixes whose whole column is observed -- the
+        sampled acceptance-family suffixes.  Partially-observed transition
+        distinguishers are excluded."""
+        if not self._masks:
+            return np.array([], dtype=int)
+        matrix = np.array(self._masks)
+        return np.flatnonzero((matrix != UNOBSERVED).all(axis=1))

--- a/orthogonal_dfa/l_star/mask_table.py
+++ b/orthogonal_dfa/l_star/mask_table.py
@@ -6,12 +6,14 @@ everything else works through the small interface below and never touches the
 underlying arrays.
 
 Each cell is int8: ``0`` (reject), ``1`` (accept), or ``UNOBSERVED (-1)`` for a
-``(prefix, suffix)`` pair whose membership query has not been issued yet.  No
-query is ever made preemptively -- ``record``/``add_prefixes`` only reserve
-``UNOBSERVED`` cells, and a cell is filled the first time some read
-(``observed_masks`` / ``column``) actually needs it.  Because the oracle is
-deterministic per string, lazy filling returns exactly the values eager filling
-would, so callers cannot tell the difference except in query count.
+``(prefix, suffix)`` pair whose membership query has not been issued yet.  A new
+suffix (``intern_suffix``) reserves an all-``UNOBSERVED`` column and queries
+nothing; a cell is filled the first time some read (``observed_masks`` /
+``column``) actually needs it.  ``add_prefixes`` reserves ``UNOBSERVED`` cells
+for partially-observed columns but does query the new prefixes for already
+fully-observed (family) columns, to keep them clustering candidates.  Because the
+oracle is deterministic per string, lazy filling returns exactly the values eager
+filling would, so callers cannot tell the difference except in query count.
 """
 
 from typing import List

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -142,10 +142,7 @@ class PrefixSuffixTracker:
             if self.table.contains_suffix(v):
                 continue
             row = self.table.intern_suffix(v)
-            # A sampled suffix is an acceptance-family candidate, so observe it
-            # over the whole prefix pool: that both fills its column for
-            # clustering and marks it (via "fully observed") as a family suffix,
-            # as opposed to the partially-observed transition distinguishers.
+            # Fully observe the new suffix row, so it can be used in clustering
             self.table.column(row)
             return row
 

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -141,7 +141,13 @@ class PrefixSuffixTracker:
             v = self.sampler.sample(rng=self.rng, alphabet_size=self.alphabet_size)
             if self.table.contains_suffix(v):
                 continue
-            return self.table.intern_suffix(v)
+            row = self.table.intern_suffix(v)
+            # A sampled suffix is an acceptance-family candidate, so observe it
+            # over the whole prefix pool: that both fills its column for
+            # clustering and marks it (via "fully observed") as a family suffix,
+            # as opposed to the partially-observed transition distinguishers.
+            self.table.column(row)
+            return row
 
     def compute_fnr(self, vs):
         """
@@ -183,7 +189,7 @@ class PrefixSuffixTracker:
 
     def compute_decision(self, vs, subset_prefixes) -> np.ndarray:
         """Mean over the suffix rows ``vs`` of the membership matrix, restricted
-        to ``subset_prefixes``."""
+        to ``subset_prefixes``; the table fills any cells not yet observed."""
         return self.table.observed_masks(vs, subset_prefixes).mean(0)
 
     def compute_decision_from_strings(

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -20,15 +20,20 @@ This only directly affects state s, so all we need to do at this point is
 to re-enqueue all (s, c') for all symbols c' in the alphabet, as well as every
 edge (s', c') -> s, which needs to be reclassified into one of the newly split states.
 
-Two sources of redundant work at present:
-  [1] Evaluating [c]+w fills its whole mask-matrix column (queries every prefix),
-  because compute_decision_from_strings records the suffix over the full prefix
-  set, even though only s's cells are read here.
-  [2] If it's only going to be all one state its possible this is easy to tell early
-  and bail on the rest of the queries, but we don't do that yet. Only possible
-  if we do [1] first.
+Evaluating a distinguisher [c]+w while resolving (s, c) reads only s's own
+prefixes (the s_mask subset), not the whole mask-matrix column.  The MaskTable
+backing the pst fills cells on demand, so a distinguisher is queried only on the
+prefixes some operation actually reads: cells filled here are reused when the
+edge is re-resolved after a split, when another state sifts through the same
+node, when the hypothesis tree is later classified over the whole prefix pool
+(enrichment), and across rounds.
 
-[1] and [2] will be addressed in future commits.
+One source of redundant work remains:
+  [2] When (s, c) lands coherently in a single leaf -- the common case -- that is
+  often decidable after sifting only a handful of s's prefixes, but we still
+  evaluate every prefix in s_mask before deciding.  The sequential early stop
+  (sift as many of s's prefixes as it takes to settle coherent-vs-split) will be
+  addressed in a future commit.
 """
 
 from collections import deque
@@ -131,6 +136,10 @@ class TransitionResolver:
         while isinstance(node, _Internal):
             prepended = [[c] + list(v) for v in node.predicate.vs]
             with np.errstate(invalid="ignore"):
+                # The pst cache records these distinguishers lazily and queries
+                # only the s_mask cells (finding [1]); cells filled here are
+                # reused when the edge is re-resolved after a split, when another
+                # state sifts this node, and across rounds.
                 decision = pst.compute_decision_from_strings(prepended, s_mask)
                 acc = decision >= pst.accept_thresh
                 rej = decision < pst.reject_thresh

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -20,20 +20,13 @@ This only directly affects state s, so all we need to do at this point is
 to re-enqueue all (s, c') for all symbols c' in the alphabet, as well as every
 edge (s', c') -> s, which needs to be reclassified into one of the newly split states.
 
-Evaluating a distinguisher [c]+w while resolving (s, c) reads only s's own
-prefixes (the s_mask subset), not the whole mask-matrix column.  The MaskTable
-backing the pst fills cells on demand, so a distinguisher is queried only on the
-prefixes some operation actually reads: cells filled here are reused when the
-edge is re-resolved after a split, when another state sifts through the same
-node, when the hypothesis tree is later classified over the whole prefix pool
-(enrichment), and across rounds.
+Evaluating a distinguisher [c]+w while resolving (s, c) only requires
+executing on the prefixes of s, which is a potentially small subset of
+the prefix pool.
 
 One source of redundant work remains:
-  [2] When (s, c) lands coherently in a single leaf -- the common case -- that is
-  often decidable after sifting only a handful of s's prefixes, but we still
-  evaluate every prefix in s_mask before deciding.  The sequential early stop
-  (sift as many of s's prefixes as it takes to settle coherent-vs-split) will be
-  addressed in a future commit.
+  [2] If it's only going to be all one state it's possible this is easy to tell early
+  and bail on the rest of the queries, but we don't do that yet.
 """
 
 from collections import deque
@@ -136,10 +129,6 @@ class TransitionResolver:
         while isinstance(node, _Internal):
             prepended = [[c] + list(v) for v in node.predicate.vs]
             with np.errstate(invalid="ignore"):
-                # The pst cache records these distinguishers lazily and queries
-                # only the s_mask cells (finding [1]); cells filled here are
-                # reused when the edge is re-resolved after a split, when another
-                # state sifts this node, and across rounds.
                 decision = pst.compute_decision_from_strings(prepended, s_mask)
                 acc = decision >= pst.accept_thresh
                 rej = decision < pst.reject_thresh

--- a/scripts/profile_query_origins.py
+++ b/scripts/profile_query_origins.py
@@ -78,15 +78,25 @@ PREDICT_PHASES = [
     "enrich_underrepresented_leaves",
 ]
 
-# For a new-suffix column, what needed the suffix (searched outward, first wins).
+# For a new-suffix column, what needed the suffix: (stack frame -> label), searched
+# outward, first match wins. Ordered most-specific first, because the low-level
+# helpers (compute_decision*) are reached from several distinct phases — matching
+# the outer phase before them splits the otherwise-broad "decision" bucket into
+# clustering / fnr / transition-resolve / classify.
 SUFFIX_TRIGGERS = [
-    "_sample_suffix",                 # growing the suffix family
-    "sample_more_suffixes",           # (its caller, if _sample_suffix is inlined)
-    "compute_decision_from_strings",  # evaluating a candidate suffix set while clustering
-    "compute_decision",               # observed_masks -> clustering decision (lazy layout)
-    "sample_suffix_family",           # the cluster-around growth loop
-    "build",                          # TransitionResolver seeding the empty suffix
-    "discover_states",
+    ("identify_cluster_around", "clustering (pick discriminating family)"),
+    ("compute_fnr", "fnr check on a candidate family"),
+    ("_give_up_check", "give-up check"),
+    ("_resolve", "transition resolve (distinguisher)"),
+    ("_split", "transition split"),
+    ("classify_states_with_decision_tree", "classify / denoise"),
+    ("_sample_suffix", "suffix-family growth"),
+    ("sample_more_suffixes", "suffix-family growth"),
+    ("sample_suffix_family", "suffix-family (other)"),
+    ("build", "resolver build / seed"),
+    ("discover_states", "discovery"),
+    ("compute_decision_from_strings", "decision (other)"),
+    ("compute_decision", "decision (other)"),
 ]
 
 # For a new-prefix row (add_prefixes), what added the prefixes.
@@ -136,8 +146,8 @@ class ProfilingOracle(Oracle):
             trig = next((t for t in ROW_TRIGGERS if t in name_set), "other")
             return f"matrix row: new prefix over all suffixes (add_prefixes) <- {trig}"
         if any(s in name_set for s in COL_SITES):
-            trig = next((t for t in SUFFIX_TRIGGERS if t in name_set), "other")
-            return f"matrix col: new suffix over all prefixes <- {trig}"
+            label = next((lbl for nm, lbl in SUFFIX_TRIGGERS if nm in name_set), "other")
+            return f"matrix col: new suffix over all prefixes <- {label}"
         return f"UNATTRIBUTED ({names[:4]})"
 
     def membership_query(self, string):

--- a/scripts/profile_query_origins.py
+++ b/scripts/profile_query_origins.py
@@ -60,15 +60,16 @@ BENCHMARKS = {
     ),
 }
 
-# Direct call sites: the function whose body contains the membership_query call.
-# Post-#119 the bulk prefix x suffix queries live in MaskTable._query (reached via
-# intern_suffix = new suffix column, or add_prefixes = new prefix row); predict and
-# relabel still query the oracle directly.
-DIRECT_SITES = {
-    "_query": "MaskTable._query",
-    "relabel": "denoise: fresh samples per state (relabel)",
-    "predict": "DT classify one string (TriPredicate.predict)",
-}
+# The bulk prefix x suffix queries live in MaskTable. We support both layouts
+# it has had: the EAGER one (queries in `_query`, reached via `intern_suffix`
+# for a new suffix column or `add_prefixes` for a new prefix row) and the LAZY
+# one (per-cell queries in `_ensure`, reached via `observed_masks`/`column`;
+# `add_prefixes` queries fully-observed family columns directly). `predict` and
+# `relabel` query the oracle directly in both. Attribution below is by role, so
+# it survives either layout.
+
+# A new-suffix-column query goes through one of these functions.
+COL_SITES = ("_query", "intern_suffix", "_ensure", "observed_masks", "column")
 
 # For predict, the enclosing high-level phase (searched outward, first match wins).
 PREDICT_PHASES = [
@@ -77,15 +78,22 @@ PREDICT_PHASES = [
     "enrich_underrepresented_leaves",
 ]
 
-# For a new-suffix column (_query <- intern_suffix), what needed the suffix
-# (searched outward, first match wins).
+# For a new-suffix column, what needed the suffix (searched outward, first wins).
 SUFFIX_TRIGGERS = [
-    "_sample_suffix",                # growing the suffix family
-    "sample_more_suffixes",          # (its caller, if _sample_suffix is inlined)
+    "_sample_suffix",                 # growing the suffix family
+    "sample_more_suffixes",           # (its caller, if _sample_suffix is inlined)
     "compute_decision_from_strings",  # evaluating a candidate suffix set while clustering
-    "sample_suffix_family",          # the cluster-around growth loop
-    "build",                         # TransitionResolver seeding the empty suffix
+    "compute_decision",               # observed_masks -> clustering decision (lazy layout)
+    "sample_suffix_family",           # the cluster-around growth loop
+    "build",                          # TransitionResolver seeding the empty suffix
     "discover_states",
+]
+
+# For a new-prefix row (add_prefixes), what added the prefixes.
+ROW_TRIGGERS = [
+    "add_counterexample_prefixes",
+    "enrich_underrepresented_leaves",
+    "sample_more_prefixes",
 ]
 
 
@@ -114,20 +122,22 @@ class ProfilingOracle(Oracle):
             frame = frame.f_back
             depth += 1
         name_set = set(names)
-        for site, label in DIRECT_SITES.items():
-            if site in name_set:
-                if site == "predict":
-                    phase = next((p for p in PREDICT_PHASES if p in name_set), "other")
-                    sub = f" [locate L{locate_line}]" if locate_line else ""
-                    return f"{label} <- {phase}{sub}"
-                if site == "_query":
-                    if "add_prefixes" in name_set:
-                        return "matrix row: new prefix over all suffixes (add_prefixes)"
-                    if "intern_suffix" in name_set:
-                        trig = next((t for t in SUFFIX_TRIGGERS if t in name_set), "other")
-                        return f"matrix col: new suffix over all prefixes (intern_suffix) <- {trig}"
-                    return f"{label} <- other"
-                return label
+        # Attribute by role, checking in priority order so the layout doesn't
+        # matter. DT classify and denoise query the oracle directly. A new prefix
+        # row is checked before the column sites because in the eager layout the
+        # row query still passes through `_query` (add_prefixes -> _query).
+        if "predict" in name_set:
+            phase = next((p for p in PREDICT_PHASES if p in name_set), "other")
+            sub = f" [locate L{locate_line}]" if locate_line else ""
+            return f"DT classify one string (TriPredicate.predict) <- {phase}{sub}"
+        if "relabel" in name_set:
+            return "denoise: fresh samples per state (relabel)"
+        if "add_prefixes" in name_set:
+            trig = next((t for t in ROW_TRIGGERS if t in name_set), "other")
+            return f"matrix row: new prefix over all suffixes (add_prefixes) <- {trig}"
+        if any(s in name_set for s in COL_SITES):
+            trig = next((t for t in SUFFIX_TRIGGERS if t in name_set), "other")
+            return f"matrix col: new suffix over all prefixes <- {trig}"
         return f"UNATTRIBUTED ({names[:4]})"
 
     def membership_query(self, string):

--- a/scripts/profile_query_origins.py
+++ b/scripts/profile_query_origins.py
@@ -78,25 +78,24 @@ PREDICT_PHASES = [
     "enrich_underrepresented_leaves",
 ]
 
-# For a new-suffix column, what needed the suffix: (stack frame -> label), searched
-# outward, first match wins. Ordered most-specific first, because the low-level
-# helpers (compute_decision*) are reached from several distinct phases — matching
-# the outer phase before them splits the otherwise-broad "decision" bucket into
-# clustering / fnr / transition-resolve / classify.
+# For a new-suffix column, the method that needed the suffix (searched outward,
+# first match wins). Ordered most-specific first, because the low-level helpers
+# (compute_decision*) are reached from several distinct phases — matching the
+# outer method before them splits the otherwise-broad decision bucket by caller.
 SUFFIX_TRIGGERS = [
-    ("identify_cluster_around", "clustering (pick discriminating family)"),
-    ("compute_fnr", "fnr check on a candidate family"),
-    ("_give_up_check", "give-up check"),
-    ("_resolve", "transition resolve (distinguisher)"),
-    ("_split", "transition split"),
-    ("classify_states_with_decision_tree", "classify / denoise"),
-    ("_sample_suffix", "suffix-family growth"),
-    ("sample_more_suffixes", "suffix-family growth"),
-    ("sample_suffix_family", "suffix-family (other)"),
-    ("build", "resolver build / seed"),
-    ("discover_states", "discovery"),
-    ("compute_decision_from_strings", "decision (other)"),
-    ("compute_decision", "decision (other)"),
+    "identify_cluster_around",
+    "compute_fnr",
+    "_give_up_check",
+    "_resolve",
+    "_split",
+    "classify_states_with_decision_tree",
+    "_sample_suffix",
+    "sample_more_suffixes",
+    "sample_suffix_family",
+    "build",
+    "discover_states",
+    "compute_decision_from_strings",
+    "compute_decision",
 ]
 
 # For a new-prefix row (add_prefixes), what added the prefixes.
@@ -146,8 +145,8 @@ class ProfilingOracle(Oracle):
             trig = next((t for t in ROW_TRIGGERS if t in name_set), "other")
             return f"matrix row: new prefix over all suffixes (add_prefixes) <- {trig}"
         if any(s in name_set for s in COL_SITES):
-            label = next((lbl for nm, lbl in SUFFIX_TRIGGERS if nm in name_set), "other")
-            return f"matrix col: new suffix over all prefixes <- {label}"
+            trig = next((t for t in SUFFIX_TRIGGERS if t in name_set), "other")
+            return f"matrix col: new suffix over all prefixes <- {trig}"
         return f"UNATTRIBUTED ({names[:4]})"
 
     def membership_query(self, string):


### PR DESCRIPTION
Builds on the `MaskTable` extraction (#119, now merged).

## What

Fixes finding **[1]** in `transition_resolver.py`: resolving `(s, c)` evaluated each distinguisher `[c]+w` over the **whole** prefix pool, even though `_resolve` reads only `s`'s cells (`s_mask`). Now the table represents unobserved cells and fills them on demand, so `[c]+w` is queried only on `s`'s own prefixes.

## How (all inside `MaskTable` + its callers)

- Cells become int8 `0` / `1` / `UNOBSERVED (-1)`. `intern_suffix` and `add_prefixes` reserve `UNOBSERVED` cells and issue **no** queries. `observed_masks` / `column` fill the cells they read on demand and reuse anything already observed — across splits, across states sifting the same node, during enrichment's tree classification, and **across rounds**.
- Clustering ranges over `table.fully_observed()` (the sampled family suffixes, whose columns `sample_suffix` / `add_prefixes` keep fully observed) instead of every interned row — so the partially-observed transition distinguishers are excluded **without a family/non-family tag**.
- `_give_up_check` sizes its statistic by the fully-observed count.

Because the noisy oracle is deterministic per string, lazy vs eager filling returns identical values — the hypothesis is unchanged; only cells no operation reads are skipped.

## Validation

Accuracy across seeds (never DFA identity). All **acc 1.000**, identical state counts, oracle queries down **11–53%** vs main:

| benchmark | seed | before | after | Δ |
|---|---|---:|---:|---:|
| modulo | 0 | 1,136,633 | 875,614 | −23.0% |
| modulo | 1 | 893,769 | 695,885 | −22.1% |
| modulo | 2 | 1,507,981 | 1,187,792 | −21.2% |
| subseq | 0 | 1,525,856 | 1,281,160 | −16.0% |
| subseq | 1 | 1,901,323 | 888,946 | −53.2% |
| subseq | 2 | 1,251,228 | 1,111,267 | −11.2% |
| two_subseq | 0 | 1,332,451 | 916,906 | −31.2% |
| two_subseq | 1 | 1,338,054 | 964,506 | −27.9% |
| two_subseq | 2 | 1,337,209 | 980,563 | −26.7% |

Only **[2]** (the sequential early stop) remains as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `fix-resolver-transition-query-cost` vs `main`

|   | task | queries `main` | queries `fix-resolver-transition-query-cost` | ratio | acc `main` | acc `fix-resolver-transition-query-cost` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| 🟢 | modulo | 1,136,633 | 875,614 | 0.77x | 1.000 | 1.000 | 9 |
| 🟢 | subseq | 1,520,929 | 1,277,963 | 0.84x | 1.000 | 1.000 | 8 |
| 🟢 | two_subseq | 1,334,905 | 916,203 | 0.69x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 5,761,587 | 5,672,298 | 0.98x | 0.977 | 0.977 | 9 |
| 🟢 | modulo_hard | 2,279,136 | 1,787,883 | 0.78x | 1.000 | 1.000 | 9 |
| 🟢 | modulo_asym | 4,721,499 | 3,490,044 | 0.74x | 1.000 | 1.000 | 9 |
| 🟢 | **geomean** |  |  | **0.80x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

## What remains after

```
===== QUERY ORIGINS: modulo (states=9, acc=1.000) =====
total queries: 875,614

     347,273   39.7%  matrix col: new suffix over all prefixes <- _resolve
     320,128   36.6%  matrix col: new suffix over all prefixes <- _sample_suffix
     120,963   13.8%  DT classify one string (TriPredicate.predict) <- estimate_agreement_rate [locate L132]
      86,000    9.8%  matrix row: new prefix over all suffixes (add_prefixes) <- sample_more_prefixes
         531    0.1%  denoise: fresh samples per state (relabel)
         244    0.0%  DT classify one string (TriPredicate.predict) <- other
         244    0.0%  DT classify one string (TriPredicate.predict) <- estimate_agreement_rate
         231    0.0%  matrix col: new suffix over all prefixes <- sample_suffix_family

===== QUERY ORIGINS: subseq (states=8, acc=1.000) =====
total queries: 1,277,963

     641,680   50.2%  matrix col: new suffix over all prefixes <- _resolve
     192,028   15.0%  DT classify one string (TriPredicate.predict) <- estimate_agreement_rate [locate L132]
     180,255   14.1%  matrix col: new suffix over all prefixes <- _sample_suffix
      71,611    5.6%  DT classify one string (TriPredicate.predict) <- generate_counterexamples
      49,000    3.8%  matrix row: new prefix over all suffixes (add_prefixes) <- add_counterexample_prefixes
      49,000    3.8%  matrix row: new prefix over all suffixes (add_prefixes) <- enrich_underrepresented_leaves
      37,000    2.9%  matrix row: new prefix over all suffixes (add_prefixes) <- sample_more_prefixes
      20,727    1.6%  DT classify one string (TriPredicate.predict) <- generate_counterexamples [locate L139]
      19,395    1.5%  DT classify one string (TriPredicate.predict) <- generate_counterexamples [locate L132]
      12,200    1.0%  DT classify one string (TriPredicate.predict) <- enrich_underrepresented_leaves
       3,538    0.3%  DT classify one string (TriPredicate.predict) <- estimate_agreement_rate [locate L139]
         488    0.0%  DT classify one string (TriPredicate.predict) <- other
         488    0.0%  DT classify one string (TriPredicate.predict) <- estimate_agreement_rate
         322    0.0%  denoise: fresh samples per state (relabel)
         231    0.0%  matrix col: new suffix over all prefixes <- sample_suffix_family

```