### PR TITLE
Extract the prefix x suffix table into a MaskTable object

### DIFF
--- a/orthogonal_dfa/l_star/cluster.py
+++ b/orthogonal_dfa/l_star/cluster.py
@@ -13,7 +13,9 @@ def identify_cluster_around(
     # statistically-unrepresentative short prefix-closed core.  Suffix (row)
     # indices are unaffected by the column slice, so the returned cluster is
     # still valid against the full prefix set used for state discovery.
-    masks = np.array(pst.corresponding_masks)[:, pst.representative]
+    masks = pst.table.observed_masks(
+        range(pst.table.num_suffixes), pst.table.representative
+    )
     cluster = [seed]
     loss = float("inf")
     while True:
@@ -73,7 +75,7 @@ def sample_suffix_family(pst, v: int, first_round: bool) -> Tuple[List[int], flo
     config = pst.config
 
     while True:
-        seed_mask = np.array(pst.corresponding_masks[v])
+        seed_mask = pst.table.column(v)
         empirical_pos = float(seed_mask.mean())
         if first_round:
             _give_up_check(pst, config, seed_mask, empirical_pos)
@@ -116,24 +118,24 @@ def _give_up_check(pst, config, seed_mask, empirical_pos):
     # the short prefix-closed core explores a skewed region of the state space and
     # is classified more confidently than the probe prefixes, so folding it in
     # would distort the agreement estimate and could trigger a spurious give-up.
-    rep = pst.representative
+    rep = pst.table.representative
     seed_mask = seed_mask[rep]
     empirical_pos = float(seed_mask.mean())
     result = give_up_check(
         config.min_signal_strength,
         int(rep.sum()),
-        len(pst.suffix_bank),
+        pst.table.num_suffixes,
         config.min_suffix_frequency,
         config.min_acc_rej,
         empirical_pos,
     )
     if result is not None:
         k, threshold = result
-        masks = np.array(pst.corresponding_masks)[:, rep]
+        masks = pst.table.observed_masks(range(pst.table.num_suffixes), rep)
         agreements = (masks == seed_mask).mean(axis=1)
         top_k_mean = float(np.sort(agreements)[-k:].mean())
         if top_k_mean <= threshold:
             raise GaveUpOnSuffixSearch(
-                f"Sampled {len(pst.suffix_bank)} suffixes. "
+                f"Sampled {pst.table.num_suffixes} suffixes. "
                 f"Top-{k} mean agreement {top_k_mean:.3f} <= {threshold:.3f}"
             )

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -35,8 +35,8 @@ from .transition_resolver import resolve_dfa
 
 def classify_states_with_decision_tree(pst, dt: DecisionTree):
     if isinstance(dt, DecisionTreeLeafNode):
-        return np.full(len(pst.prefixes), dt.state_idx)
-    results = np.full(len(pst.prefixes), -1)
+        return np.full(pst.num_prefixes, dt.state_idx)
+    results = np.full(pst.num_prefixes, -1)
     # Classify straight from the cached prefix x suffix mask matrix
     # (compute_decision_from_strings reads corresponding_masks), applying each node's
     # OWN thresholds rather than the PST's current margins.  For a discovery-time tree
@@ -85,7 +85,7 @@ def denoise_accept_labels(pst, dfa, *, max_samples=200):
 
     label = {
         states_intermediate(dfa.initial_state, prefix, dfa)[-1]: None
-        for prefix in pst.prefixes
+        for prefix in pst.table.prefixes
     }
     label = {state: relabel(state) for state in label}
 
@@ -118,7 +118,7 @@ def add_counterexample_prefixes(pst, dt, dfa, count, *, expected_acc):
         expected_acc=expected_acc,
     )
     if results:
-        pst.add_prefixes(results)
+        pst.table.add_prefixes(results)
     return results
 
 
@@ -198,7 +198,7 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count, expected_acc):
                 pbar.close()
                 return additional_prefixes
             continue
-        if prefix in additional_prefixes or prefix in pst.prefixes:
+        if prefix in additional_prefixes or pst.table.contains_prefix(prefix):
             continue
         state_1 = dt_with_decisive_predicates.classify(prefix, oracle)
         state_2 = dfa.transitions[state_1][sym]
@@ -290,7 +290,7 @@ def enrich_underrepresented_leaves(pst, dt_decisive, *, count):
         f" {sorted(target_leaves)} (median={median})"
     )
 
-    seen = {tuple(p) for p in pst.prefixes}
+    seen = {tuple(p) for p in pst.table.prefixes}
     new_prefixes = []
     max_attempts = count * 200
     attempts = 0
@@ -309,7 +309,7 @@ def enrich_underrepresented_leaves(pst, dt_decisive, *, count):
         pbar.update()
     pbar.close()
     if new_prefixes:
-        pst.add_prefixes(new_prefixes)
+        pst.table.add_prefixes(new_prefixes)
     return new_prefixes
 
 

--- a/orthogonal_dfa/l_star/mask_table.py
+++ b/orthogonal_dfa/l_star/mask_table.py
@@ -1,0 +1,104 @@
+"""The prefix x suffix membership table.
+
+A single object that owns the prefixes, the suffixes, and the membership matrix
+between them.  It is the *only* place the raw table lives; everything else works
+through the small interface below and never touches the underlying arrays.
+
+Each cell is ``membership_query(prefix + suffix)`` as a float32 ``0``/``1``.  A
+suffix's whole column is queried when the suffix is interned, and every column is
+extended when new prefixes are added, so the matrix is always fully populated.
+"""
+
+from typing import List
+
+import numpy as np
+
+
+class MaskTable:
+    def __init__(self, oracle, prefixes: List[List[int]], representative: List[bool]):
+        assert len(prefixes) == len(representative)
+        self._oracle = oracle
+        self._prefixes = [list(p) for p in prefixes]
+        self._prefix_keys = {tuple(p) for p in self._prefixes}
+        self._representative = list(representative)
+        self._suffixes: List[List[int]] = []
+        self._suffix_index = {}  # tuple(suffix) -> row
+        self._masks: List[np.ndarray] = []  # one float32 column per suffix
+
+    # -- sizes / prefix side ------------------------------------------------
+
+    @property
+    def num_prefixes(self) -> int:
+        return len(self._prefixes)
+
+    @property
+    def num_suffixes(self) -> int:
+        return len(self._suffixes)
+
+    @property
+    def prefixes(self) -> tuple:
+        """The prefixes, for read-only iteration."""
+        return tuple(self._prefixes)
+
+    @property
+    def representative(self) -> np.ndarray:
+        """Boolean mask selecting the representative (non-core) prefixes."""
+        return np.array(self._representative, dtype=bool)
+
+    def contains_prefix(self, prefix: List[int]) -> bool:
+        return tuple(prefix) in self._prefix_keys
+
+    def add_prefixes(self, new_prefixes: List[List[int]]) -> None:
+        assert new_prefixes, "No new prefixes to add"
+        assert all(not self.contains_prefix(p) for p in new_prefixes) and len(
+            new_prefixes
+        ) == len({tuple(p) for p in new_prefixes}), "Prefixes must be unique"
+        # Extend every existing suffix column to cover the new prefixes.
+        self._masks = [
+            np.concatenate([col, self._query(suffix, new_prefixes)])
+            for suffix, col in zip(self._suffixes, self._masks)
+        ]
+        self._prefixes.extend(list(p) for p in new_prefixes)
+        self._prefix_keys.update(tuple(p) for p in new_prefixes)
+        # Prefixes added after construction (counterexamples, leaf enrichment)
+        # are full-length probe prefixes, hence representative.
+        self._representative.extend([True] * len(new_prefixes))
+
+    # -- suffix side --------------------------------------------------------
+
+    def intern_suffix(self, v: List[int]) -> int:
+        """Return the row index for suffix ``v``, registering it -- and querying
+        its whole column against the oracle -- if it is new."""
+        key = tuple(v)
+        if key in self._suffix_index:
+            return self._suffix_index[key]
+        row = len(self._suffixes)
+        self._suffixes.append(list(v))
+        self._masks.append(self._query(v, self._prefixes))
+        self._suffix_index[key] = row
+        return row
+
+    def contains_suffix(self, v: List[int]) -> bool:
+        return tuple(v) in self._suffix_index
+
+    def suffix(self, row: int) -> List[int]:
+        return self._suffixes[row]
+
+    # -- reads --------------------------------------------------------------
+
+    def observed_masks(self, rows, prefix_mask) -> np.ndarray:
+        """The ``(len(rows), prefix_mask.sum())`` block for suffix ``rows`` over
+        the prefixes selected by ``prefix_mask``."""
+        return np.array([self._masks[r][prefix_mask] for r in rows])
+
+    def column(self, row: int) -> np.ndarray:
+        """The full membership column of suffix ``row`` over every prefix."""
+        return self._masks[row].copy()
+
+    # -- internal -----------------------------------------------------------
+
+    def _query(self, suffix: List[int], prefixes: List[List[int]]) -> np.ndarray:
+        return np.array(
+            [self._oracle.membership_query(p + suffix) for p in prefixes],
+            dtype=np.float32,
+        )

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -1,17 +1,12 @@
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import numpy as np
 import tqdm.auto as tqdm
 
+from .mask_table import MaskTable
 from .sampler import Sampler
 from .structures import Oracle
-
-
-def compute_mask(for_state, oracle, v):
-    mask = np.array([oracle.membership_query(x + v) for x in for_state], np.float32)
-
-    return mask
 
 
 def short_prefix_closure(
@@ -64,34 +59,29 @@ class SearchConfig:
 
 @dataclass
 class PrefixSuffixTracker:
+    """Owns the search calibration (decision boundary, evidence margin, family
+    sampling) on top of a :class:`MaskTable`.
+
+    The prefixes, suffixes and membership matrix live entirely in ``self.table``
+    and are reached only through its interface -- nothing here (or in callers)
+    touches the raw arrays.
+    """
+
     sampler: Sampler
     rng: np.random.Generator
     oracle: Oracle
     config: SearchConfig
-    prefixes: List[List[int]]
-    suffixes_seen: dict
-    suffix_bank: List[List[int]]
-    corresponding_masks: List[np.ndarray]
+    table: MaskTable
     decision_boundary: float = 0.5
     evidence_margin: float = 0.0
-    # Per-prefix flag: True for "representative" probe prefixes (drawn from the
-    # sampler), False for the short prefix-closed core.  Global calibration
-    # (decision boundary, FNR) is computed over representative prefixes only, so
-    # the statistically-unrepresentative core does not bias it; state discovery
-    # still uses every prefix so transient states are split out.  None => all
-    # prefixes are representative (the default with no core).
-    representative_prefixes: Optional[List[bool]] = None
 
     def __post_init__(self):
         if self.evidence_margin == 0.0:
             self.evidence_margin = self.config.evidence_margin
-        if self.representative_prefixes is None:
-            self.representative_prefixes = [True] * len(self.prefixes)
 
     @property
-    def representative(self) -> np.ndarray:
-        """Boolean mask selecting the representative (non-core) prefixes."""
-        return np.array(self.representative_prefixes, dtype=bool)
+    def num_prefixes(self) -> int:
+        return self.table.num_prefixes
 
     @property
     def alphabet_size(self) -> int:
@@ -121,6 +111,11 @@ class PrefixSuffixTracker:
             sampler.sample(rng, alphabet_size=oracle.alphabet_size)
             for _ in range(num_prefixes)
         ]
+        # Per-prefix flag: True for "representative" probe prefixes (drawn from
+        # the sampler), False for the short prefix-closed core.  Global
+        # calibration (decision boundary, FNR) is computed over representative
+        # prefixes only, so the statistically-unrepresentative core does not bias
+        # it; state discovery still uses every prefix so transient states split.
         representative = [True] * len(prefixes)
         if prefix_core_length > 0 and prefix_core_size > 0:
             existing = {tuple(p) for p in prefixes}
@@ -138,28 +133,15 @@ class PrefixSuffixTracker:
             rng=rng,
             oracle=oracle,
             config=config,
-            prefixes=prefixes,
-            suffixes_seen={},
-            suffix_bank=[],
-            corresponding_masks=[],
-            representative_prefixes=representative,
+            table=MaskTable(oracle, prefixes, representative),
         )
 
-    def sample_suffix(self) -> Tuple[List[int], np.ndarray, int]:
+    def _sample_suffix(self) -> int:
         while True:
             v = self.sampler.sample(rng=self.rng, alphabet_size=self.alphabet_size)
-            if tuple(v) in self.suffixes_seen:
+            if self.table.contains_suffix(v):
                 continue
-            return self.record_suffix(v)
-
-    def record_suffix(self, v: List[int]) -> Tuple[List[int], np.ndarray, int]:
-        if tuple(v) in self.suffixes_seen:
-            return self.suffixes_seen[tuple(v)]
-        self.suffix_bank.append(v)
-        mask = compute_mask(self.prefixes, self.oracle, v)
-        self.corresponding_masks.append(mask)
-        self.suffixes_seen[tuple(v)] = v, mask, len(self.suffix_bank) - 1
-        return v, mask, len(self.suffix_bank) - 1
+            return self.table.intern_suffix(v)
 
     def compute_fnr(self, vs):
         """
@@ -175,8 +157,9 @@ class PrefixSuffixTracker:
         core exists to give transient states discovery rows, not to recalibrate
         the family against an unrepresentative population.
         """
-        arr = self.compute_decision_array_from_strings(
-            [self.suffix_bank[v] for v in vs], self.representative
+        decision = self.compute_decision(vs, self.table.representative)
+        arr = np.array(
+            [decision < self.reject_thresh, decision >= self.accept_thresh]
         ).mean(1)
         if arr.min() == 0:
             return 1
@@ -189,75 +172,24 @@ class PrefixSuffixTracker:
             prefix = tuple(
                 self.sampler.sample(self.rng, alphabet_size=self.alphabet_size)
             )
-            if prefix in new_prefixes or prefix in self.prefixes:
+            if prefix in new_prefixes or self.table.contains_prefix(list(prefix)):
                 continue
             new_prefixes.add(prefix)
-        new_prefixes = sorted(list(x) for x in new_prefixes if x not in self.prefixes)
-        self.add_prefixes(new_prefixes)
+        self.table.add_prefixes(sorted(list(x) for x in new_prefixes))
 
     def sample_more_suffixes(self, *, amount: int):
         for _ in tqdm.trange(amount, desc="Completing suffix family", delay=1):
-            self.sample_suffix()
-
-    def corresponding_masks_for_subset(self, subset_prefixes) -> List[np.ndarray]:
-        corresponding_masks = np.array(self.corresponding_masks)
-        return corresponding_masks[:, subset_prefixes]
+            self._sample_suffix()
 
     def compute_decision(self, vs, subset_prefixes) -> np.ndarray:
-        selected_masks = self.corresponding_masks_for_subset(subset_prefixes)[vs]
-        return selected_masks.mean(0)
+        """Mean over the suffix rows ``vs`` of the membership matrix, restricted
+        to ``subset_prefixes``."""
+        return self.table.observed_masks(vs, subset_prefixes).mean(0)
 
     def compute_decision_from_strings(
         self, vs: List[List[int]], subset_prefixes=None
     ) -> np.ndarray:
         if subset_prefixes is None:
             subset_prefixes = np.ones(self.num_prefixes, dtype=bool)
-        vs_idxs = [self.record_suffix(v)[2] for v in vs]
+        vs_idxs = [self.table.intern_suffix(v) for v in vs]
         return self.compute_decision(vs_idxs, subset_prefixes)
-
-    def compute_decision_array_from_strings(
-        self, vs: List[List[int]], subset_prefixes=None
-    ) -> np.ndarray:
-        decision = self.compute_decision_from_strings(vs, subset_prefixes)
-        return np.array(
-            [
-                decision < self.reject_thresh,
-                decision >= self.accept_thresh,
-            ]
-        )
-
-    def add_prefixes(self, new_prefixes: List[List[int]]):
-
-        assert new_prefixes, "No new prefixes to add"
-        assert len(new_prefixes + self.prefixes) == len(
-            set(tuple(p) for p in new_prefixes + self.prefixes)
-        ), "Prefixes must be unique"
-
-        additional_prefixes = []
-        additional_masks = []
-        for prefix in tqdm.tqdm(new_prefixes, desc="Adding new prefixes", delay=1):
-            additional_prefixes.append(prefix)
-            additional_masks.append(
-                np.array(
-                    [
-                        self.oracle.membership_query(prefix + v)
-                        for v in self.suffix_bank
-                    ],
-                    np.float32,
-                )
-            )
-        additional_masks = np.array(additional_masks).T
-        self.prefixes.extend(additional_prefixes)
-        # Prefixes added after construction (counterexamples, leaf enrichment)
-        # are full-length probe prefixes, hence representative.
-        self.representative_prefixes.extend([True] * len(additional_prefixes))
-
-        assert len(self.corresponding_masks) == len(additional_masks)
-        self.corresponding_masks = [
-            np.concatenate([self.corresponding_masks[i], additional_masks[i]])
-            for i in range(len(self.suffix_bank))
-        ]
-
-    @property
-    def num_prefixes(self) -> int:
-        return len(self.prefixes)

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -164,7 +164,7 @@ class TransitionResolver:
 
     def build(self, first_round):
         pst = self.pst
-        _, _, v_idx = pst.record_suffix([])
+        v_idx = pst.table.intern_suffix([])
         vs, boundary = sample_suffix_family(pst, v_idx, first_round=first_round)
         pst.decision_boundary = boundary
         all_prefixes = np.ones(pst.num_prefixes, dtype=bool)
@@ -173,7 +173,7 @@ class TransitionResolver:
             acc = decision >= pst.accept_thresh
             rej = decision < pst.reject_thresh
         predicate = TriPredicate(
-            [pst.suffix_bank[i] for i in vs], pst.accept_thresh, pst.reject_thresh
+            [pst.table.suffix(i) for i in vs], pst.accept_thresh, pst.reject_thresh
         )
         rej_leaf = self._new_leaf(all_prefixes & rej)
         acc_leaf = self._new_leaf(all_prefixes & acc)


### PR DESCRIPTION
## What

Pure encapsulation refactor: the prefixes, suffixes and membership matrix move out of `PrefixSuffixTracker` into a dedicated **`MaskTable`** in its own module (`orthogonal_dfa/l_star/mask_table.py`), reached only through a small interface. No caller touches `pst.prefixes`, `pst.suffix_bank`, or `pst.corresponding_masks` any more — those attributes no longer exist on the PST.

## MaskTable interface

```
num_prefixes · num_suffixes · prefixes · representative
contains_prefix · add_prefixes
intern_suffix · contains_suffix · suffix
observed_masks · column
```

`PrefixSuffixTracker` keeps only the calibration/sampling layer (thresholds, family sampling, FNR) and delegates all storage to `self.table`. `cluster.py`, `lstar.py`, and `transition_resolver.py` go through the table interface.

## No behaviour change

Eager column filling (a suffix's whole column is queried when interned; every column is extended when prefixes are added), clustering over **every** suffix, and `float32` storage are all preserved exactly as before. This is a structural refactor only.

## Validation

Accuracy across seeds (never DFA identity). Oracle-query counts match the pre-refactor baseline **exactly**, acc 1.000, identical state counts:

| benchmark | seed | queries (this branch == main) |
|---|---|---:|
| modulo | 0 | 1,136,633 |
| modulo | 1 | 893,769 |
| subseq | 0 | 1,525,856 |

## Why

This lands ahead of the transition-resolver query-reduction work (#118): with the table isolated behind a minimal interface, making it lazily observed (the finding-[1] change) becomes a self-contained diff to `MaskTable` rather than something threaded through every caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `refactor-mask-table` vs `main`

|   | task | queries `main` | queries `refactor-mask-table` | ratio | acc `main` | acc `refactor-mask-table` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 1,136,633 | 1,136,633 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 1,520,929 | 1,520,929 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 1,334,905 | 1,334,905 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 5,761,587 | 5,761,587 | 1.00x | 0.977 | 0.977 | 9 |
| ⚪ | modulo_hard | 2,279,136 | 2,279,136 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 4,721,499 | 4,721,499 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **1.00x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)
