### PR TITLE
count_queries: fix multi-task measurer invocation

### DIFF
--- a/scripts/count_queries.py
+++ b/scripts/count_queries.py
@@ -221,7 +221,7 @@ def measure_worktree(root: Path, names: list[str]) -> dict:
     """Run this script as an in-worktree measurer; parse the JSON it prints."""
     out = subprocess.run(
         [sys.executable, str(Path(__file__).resolve()), "--emit-json",
-         "--root", str(root), *names],
+         "--root", str(root), "--tasks", *names],
         cwd=root, text=True, capture_output=True)
     if out.returncode != 0:
         raise SystemExit(f"count_queries: measurer failed in {root}:\n{out.stderr}")


### PR DESCRIPTION
Follow-up to #120.

`measure_worktree` spread the task names as **bare positional args** to the in-worktree measurer, but the parser only accepts two positionals (`base`, `pr`). So the default 6-task run overflowed:

```
count_queries.py: error: unrecognized arguments: two_subseq poor_case modulo_hard modulo_asym
```

It slipped past validation because the only prior end-to-end run used a single `--tasks subseq`. Fix: pass the names through `--tasks` (which the `--emit-json` path already reads).

Verified end-to-end: a 2-task run (`modulo`, `subseq`) now measures both on both worktrees and reports `1.00x` with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)