### PR TITLE
statistics: define decision-rule FPR as the actual wrong-prediction rate

### DIFF
--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -13,8 +13,17 @@ def population_size_and_evidence_margin(
     (center - epsilon, center + epsilon). The true distribution has accept rate
     center + signal_strength and reject rate center - signal_strength.
 
-    We want FPR (under the null B(center)) at most acceptable_fpr, and FNR (under
-    the true distribution) at most acceptable_fnr.
+    We want FPR at most acceptable_fpr, and FNR at most acceptable_fnr, where:
+
+    - FPR is the probability of a prefix flipping from one category to the
+      other: a true-reject prefix (rate center - signal_strength) whose count
+      lands in the accept region (>= k_high), or the symmetric true-accept
+      prefix decided reject. This is the error we care about -- a prefix that
+      is genuinely near the boundary being decided either way is not a
+      meaningful error -- so we bound the flip probability rather than the rate
+      at which a boundary prefix at center gets decided at all.
+    - FNR is the probability that a true-accept prefix (rate center +
+      signal_strength) fails to be decided and lands in the undecided band.
     """
     assert signal_strength > 0
     N_low = 1
@@ -47,8 +56,13 @@ def evidence_margin_for_population_size(
     for eps in np.linspace(0.01, signal_strength, 100):
         k_low = int(np.floor(N * (center - eps)))
         k_high = int(np.ceil(N * (center + eps)))
-        fpr = scipy.stats.binom.cdf(k_low, N, center) + (
-            1 - scipy.stats.binom.cdf(k_high - 1, N, center)
+        reject_rate = np.clip(center - signal_strength, 0, 1)
+        accept_rate = np.clip(center + signal_strength, 0, 1)
+        # FPR = probability of a category flip: a true-reject prefix decided
+        # accept, or a true-accept prefix decided reject.
+        fpr = max(
+            1 - scipy.stats.binom.cdf(k_high - 1, N, reject_rate),
+            scipy.stats.binom.cdf(k_low, N, accept_rate),
         )
         fnr = scipy.stats.binom.cdf(
             k_high - 1, N, signal_strength + center

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -395,13 +395,13 @@ class TestLStarAsymmetric(unittest.TestCase):
         )
         assertDFA(self, dfa, oracle_creator)
 
-    @unittest.expectedFailure
     def test_boundary_near_zero(self):
         """Both noise rates near 0, boundary far from 0.5.
-        Fails: finds only 3 states instead of 9. With the true boundary at
-        0.22, the clustering threshold is so low that true-reject prefixes
-        (mean ~0.02) get mixed into the "accept" group on noisy suffix
-        samples, contaminating the boundary estimate downward to ~0.11."""
+        Previously found only 3 states instead of 9: with the true boundary at
+        0.22 and FPR calibrated against the null B(center), the boundary
+        estimate contaminated downward to ~0.11 and true-reject prefixes got
+        mixed into the "accept" group. Calibrating FPR as the category-flip
+        rate lets enrichment recover all 9 states (verified across seeds)."""
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )


### PR DESCRIPTION
## Summary

`evidence_margin_for_population_size` sized the suffix population `N` so that the **FPR under the null `B(center)`** — the probability a prefix at exactly `center` gets decided to either side — is ≤ `acceptable_fpr`. But the error we actually care about is a prefix **flipping from one category to the other**; a prefix that is genuinely near the boundary being decided either way is not a meaningful error. Bounding the null-decision rate instead over-provisions `N`.

This PR redefines FPR as the **flip probability**: a true-reject prefix (rate `center − signal_strength`) whose count lands in the accept region (`≥ k_high`), or the symmetric true-accept prefix decided reject. FNR is unchanged.

## Impact on calibrated `N` (center=0.5, fpr=fnr=0.01)

| signal `s` | old N (null) | true flip prob old N bought | new N (flip) | queries saved |
|---|---|---|---|---|
| 0.10 | 607 | 1.7e-14 | 149 | ~75% |
| 0.05 | 2408 | 3.0e-14 | 839 | ~65% |
| 0.02 | 15058 | 3.3e-14 | 13537 | ~10% |

The old definition paid up to ~4× the samples to control a flip event ~12 orders of magnitude below its stated 0.01 budget. Under the new definition both FPR (flip) and FNR bound at ≤0.01 by construction.

## Also fixes `test_boundary_near_zero`

This case (boundary 0.22, signal 0.15) was a documented `@unittest.expectedFailure` — it found only 3 states instead of 9 because the boundary estimate contaminated downward to ~0.11 and true-reject prefixes leaked into the accept group. The tighter, correctly-targeted calibration lets enrichment recover the full 9-state DFA. Verified across seeds 0–4: all reach accuracy 1.0000 with 0 false positives/negatives. The decorator is removed.

## Notes / follow-ups
- Under the new definition the FPR constraint is essentially never binding, so the `eps` search now bottoms out at its `0.01` floor (FNR alone selects it). If that floor is incidental rather than a real minimum band width, there may be further savings available by widening the search — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)