### PR TITLE
l_star: link the calibration margin to decision_rule_fpr

### DIFF
--- a/orthogonal_dfa/l_star/cluster.py
+++ b/orthogonal_dfa/l_star/cluster.py
@@ -55,10 +55,17 @@ def identify_cluster_around(
 
 
 def recompute_evidence_margin(
-    min_signal_strength, suffix_family_size, decision_boundary
+    min_signal_strength, suffix_family_size, decision_boundary, decision_rule_fpr
 ):
+    # Re-size the margin against decision_rule_fpr -- the same split-noise budget
+    # _splits consumes -- so the moving boundary keeps the boundary-region leak
+    # rate under what the split test assumes. See SearchConfig.calibrated.
     result = evidence_margin_for_population_size(
-        min_signal_strength, 0.01, 0.01, suffix_family_size, center=decision_boundary
+        min_signal_strength,
+        decision_rule_fpr,
+        0.01,
+        suffix_family_size,
+        center=decision_boundary,
     )
     if result is None:
         return min_signal_strength * 0.5
@@ -90,6 +97,7 @@ def sample_suffix_family(pst, v: int, first_round: bool) -> Tuple[List[int], flo
             pst.config.min_signal_strength,
             pst.config.suffix_family_size,
             decision_boundary,
+            pst.config.decision_rule_fpr,
         )
 
         fnr = 1 if len(vs) < pst.config.suffix_family_size else pst.compute_fnr(vs)

--- a/orthogonal_dfa/l_star/cluster.py
+++ b/orthogonal_dfa/l_star/cluster.py
@@ -57,9 +57,6 @@ def identify_cluster_around(
 def recompute_evidence_margin(
     min_signal_strength, suffix_family_size, decision_boundary, decision_rule_fpr
 ):
-    # Re-size the margin against decision_rule_fpr -- the same split-noise budget
-    # _splits consumes -- so the moving boundary keeps the boundary-region leak
-    # rate under what the split test assumes. See SearchConfig.calibrated.
     result = evidence_margin_for_population_size(
         min_signal_strength,
         decision_rule_fpr,

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -68,19 +68,6 @@ class SearchConfig:
         num_addtl_prefixes=None,
         min_suffix_frequency=0.05,
     ) -> "SearchConfig":
-        """Build a config whose suffix family size and evidence margin are sized
-        against ``decision_rule_fpr``.
-
-        ``decision_rule_fpr`` is the split test's noise budget (see
-        ``transition_resolver._splits``): the rate at which a truly-homogeneous
-        state is allowed to leak prefixes to the wrong side of the decision
-        thresholds. The evidence margin has to be wide enough that the actual
-        boundary-region leak rate stays under that budget -- otherwise the split
-        test reads noise as real states. Because both come from this one value,
-        they cannot silently drift apart. ``evidence_margin_for_population_size``
-        computes exactly that leak rate (``fpr`` under ``B(center)``), so we pass
-        ``decision_rule_fpr`` in as its ``acceptable_fpr``.
-        """
         suffix_family_size, evidence_margin = population_size_and_evidence_margin(
             signal_strength=signal_strength,
             acceptable_fpr=decision_rule_fpr,

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -6,6 +6,7 @@ import tqdm.auto as tqdm
 
 from .mask_table import MaskTable
 from .sampler import Sampler
+from .statistics import population_size_and_evidence_margin
 from .structures import Oracle
 
 
@@ -55,6 +56,45 @@ class SearchConfig:
     split_pval: float = 0.001
     min_suffix_frequency: float = 0.05
     min_acc_rej: float = 0.1
+
+    @classmethod
+    def calibrated(
+        cls,
+        *,
+        signal_strength,
+        decision_rule_fpr,
+        acceptable_fnr,
+        suffix_size_counterexample_gen,
+        num_addtl_prefixes=None,
+        min_suffix_frequency=0.05,
+    ) -> "SearchConfig":
+        """Build a config whose suffix family size and evidence margin are sized
+        against ``decision_rule_fpr``.
+
+        ``decision_rule_fpr`` is the split test's noise budget (see
+        ``transition_resolver._splits``): the rate at which a truly-homogeneous
+        state is allowed to leak prefixes to the wrong side of the decision
+        thresholds. The evidence margin has to be wide enough that the actual
+        boundary-region leak rate stays under that budget -- otherwise the split
+        test reads noise as real states. Because both come from this one value,
+        they cannot silently drift apart. ``evidence_margin_for_population_size``
+        computes exactly that leak rate (``fpr`` under ``B(center)``), so we pass
+        ``decision_rule_fpr`` in as its ``acceptable_fpr``.
+        """
+        suffix_family_size, evidence_margin = population_size_and_evidence_margin(
+            signal_strength=signal_strength,
+            acceptable_fpr=decision_rule_fpr,
+            acceptable_fnr=acceptable_fnr,
+        )
+        return cls(
+            suffix_family_size=suffix_family_size,
+            evidence_margin=evidence_margin,
+            decision_rule_fpr=decision_rule_fpr,
+            suffix_size_counterexample_gen=suffix_size_counterexample_gen,
+            min_signal_strength=signal_strength,
+            num_addtl_prefixes=num_addtl_prefixes,
+            min_suffix_frequency=min_suffix_frequency,
+        )
 
 
 @dataclass

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -24,7 +24,6 @@ from orthogonal_dfa.l_star.statistics import (
     compute_prefix_set_size,
     compute_suffix_size_counterexample_gen,
     give_up_check,
-    population_size_and_evidence_margin,
 )
 from orthogonal_dfa.l_star.structures import AsymmetricBernoulli, SymmetricBernoulli
 
@@ -124,23 +123,20 @@ def compute_pst(
     if noise_model is None:
         noise_model = SymmetricBernoulli(p_correct=effective_p_acc)
     oracle = oracle_creator(noise_model, seed)
-    n, eps = population_size_and_evidence_margin(
-        signal_strength=min_signal_strength, acceptable_fpr=0.01, acceptable_fnr=0.01
-    )
     k = compute_prefix_set_size(0.05, effective_p_acc, 0.05)
     suffix_size = compute_suffix_size_counterexample_gen(0.01, effective_p_acc)
     num_prefixes = 200 if use_dynamic else k
-    config = SearchConfig(
-        suffix_family_size=n,
-        evidence_margin=eps,
+    config = SearchConfig.calibrated(
+        signal_strength=min_signal_strength,
         decision_rule_fpr=0.01,
+        acceptable_fnr=0.01,
         suffix_size_counterexample_gen=suffix_size,
-        min_signal_strength=min_signal_strength,
         num_addtl_prefixes=200 if use_dynamic else None,
         min_suffix_frequency=min_suffix_frequency,
     )
     print(
-        f"Using suffix population size {n}, eps {eps}, and {k} prefixes "
+        f"Using suffix population size {config.suffix_family_size}, "
+        f"eps {config.evidence_margin}, and {k} prefixes "
         f"(signal strength {min_signal_strength})."
     )
     pst = PrefixSuffixTracker.create(


### PR DESCRIPTION
## Summary

The evidence-margin calibration (`population_size_and_evidence_margin`) sizes `suffix_family_size` and `evidence_margin` so that a boundary-region prefix is decided (leaks to a side) at a rate at most some FPR budget. The split test `transition_resolver._splits` **independently** assumes that leak budget is `decision_rule_fpr`. These were two separate hardcoded `0.01` constants with nothing linking them — yet they *must* be equal, because the margin is what makes the split test's noise model true.

This is the latent footgun surfaced while investigating #124: redefining the calibration FPR (without touching `decision_rule_fpr`) collapsed the margin, drove the real boundary-leak rate to 0.87 while `_splits` still assumed 0.01, and shattered a 9-state DFA into 399 states. The two are one knob; the code should say so.

## Change

- **`SearchConfig.calibrated(...)`** — a factory that takes `decision_rule_fpr` once, passes it into the calibration as `acceptable_fpr`, and stores the same value as `decision_rule_fpr`. You can no longer size the margin against a different FPR than the split test consumes.
- **`recompute_evidence_margin`** now takes `decision_rule_fpr` (threaded from `config.decision_rule_fpr`) instead of a hardcoded `0.01`, so the runtime margin re-sizing stays consistent with the split test too.
- `compute_pst` builds the config via the factory.

## Behavior

Pure refactor. With `decision_rule_fpr = 0.01` the calibrated `(n, eps)` are identical to before (verified across signal strengths 0.10–0.30). `test_modulo_asymmetric_non_straddling_0` still passes in ~82s (main baseline: 80s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)