### PR TITLE
Batch estimate_agreement_rate's DT classifications

### DIFF
--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -29,7 +29,7 @@ from .dfa_utils import (
     states_intermediate,
 )
 from .statistics import binomial_side_of_boundary, unlikely_this_many_agreements
-from .structures import DecisionTree, DecisionTreeLeafNode, TriPredicate
+from .structures import DecisionTree, DecisionTreeLeafNode, TriPredicate, classify_many
 from .transition_resolver import resolve_dfa
 
 
@@ -122,14 +122,15 @@ def add_counterexample_prefixes(pst, dt, dfa, count, *, expected_acc):
     return results
 
 
-def locate_incorrect_point(oracle, dt, dfa, x, y, *, s0):
-    # ``s0`` is ``dt.classify(x, oracle)``, passed in by the caller: callers that hold
-    # ``x`` fixed across many calls (e.g. estimate_agreement_rate, where x is always
-    # the empty prefix) compute it once instead of re-querying the oracle every call.
+def locate_incorrect_point(oracle, dt, dfa, x, y, *, s0, s_end):
+    # ``s0`` and ``s_end`` are ``dt.classify(x, oracle)`` and ``dt.classify(x + y,
+    # oracle)``, computed by the caller so it can share them across many calls:
+    # estimate_agreement_rate holds ``x`` fixed (one ``s0`` for the whole loop) and
+    # batches the per-``y`` ``s_end`` through ``classify_many``.
     if s0 is None:
         return None, "could not classify initial state"
     dfa_states_each = states_intermediate(s0, y, dfa)
-    if dt.classify(x + y, oracle) == dfa_states_each[-1]:
+    if s_end == dfa_states_each[-1]:
         return None, "no inconsistency"
     correct_idx = 0
     incorrect_idx = len(y)
@@ -177,13 +178,21 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count, expected_acc):
         num_samples += 1
         x = us.sample(pst.rng, pst.alphabet_size)
         y = us.sample(pst.rng, pst.alphabet_size)
+        s0 = dt_with_reduced_predicates.classify(x, oracle)
         prefix, sym = locate_incorrect_point(
             oracle,
             dt_with_reduced_predicates,
             dfa,
             x,
             y,
-            s0=dt_with_reduced_predicates.classify(x, oracle),
+            s0=s0,
+            # Skip the endpoint classification when x itself is unclassifiable --
+            # locate_incorrect_point returns on s0 without reading s_end.
+            s_end=(
+                dt_with_reduced_predicates.classify(x + y, oracle)
+                if s0 is not None
+                else None
+            ),
         )
         if prefix is None:
             num_agreements += sym == "no inconsistency"
@@ -211,6 +220,36 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count, expected_acc):
             return additional_prefixes
 
 
+def _batch_before_possible_stop(agreements, valid, boundary, min_valid, remaining):
+    """The largest number of further valid samples that provably cannot let the
+    early-stop test fire -- so drawing this many and batching them changes nothing
+    the sequential loop would have decided, and never draws a sample past the stop.
+
+    The test needs ``min_valid`` samples and then significance against ``boundary``.
+    The soonest it *could* fire after ``k`` more samples is the best case: all ``k``
+    agree (pushes the 'above' tail) or none do (the 'below' tail).  ``possible`` is
+    monotonic in ``k`` (extra all-agree/all-disagree evidence only helps), so binary
+    search finds the smallest firing ``k``; below it, batching is free."""
+    lo = max(min_valid - valid, 1)
+
+    def possible(k):
+        return (
+            binomial_side_of_boundary(agreements + k, valid + k, boundary) is True
+            or binomial_side_of_boundary(agreements, valid + k, boundary) is False
+        )
+
+    if lo >= remaining or not possible(remaining):
+        return remaining
+    hi = remaining
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if possible(mid):
+            hi = mid
+        else:
+            lo = mid + 1
+    return lo
+
+
 def estimate_agreement_rate(
     pst, us, oracle, dt_decisive, dfa, *, num_samples, acc_threshold
 ):
@@ -223,10 +262,18 @@ def estimate_agreement_rate(
     side of *acc_threshold* the true rate lies on.  The estimate is consumed only
     to decide ``true_acc >= acc_threshold`` (the termination test) and as a loose
     ``expected_acc`` guard for counterexample search, so settling that decision is
-    all the precision required; the rate is almost always far from the threshold
-    (e.g. 0.2 or 0.8 vs 0.98), in which case a few dozen samples suffice instead
-    of the full budget.  Sampling is still capped at *num_samples*, so this never
-    costs more than the fixed-budget pass.
+    all the precision required.  When the true rate is far from the threshold a few
+    dozen samples settle it, but near the threshold it can run to the full
+    *num_samples* budget (e.g. on the poor_case guard it hits the cap on most
+    calls), which is why that budget caps the cost.
+
+    Samples whose ``y`` classifications are independent are drawn in a chunk and
+    classified through ``classify_many`` -- one oracle call per tree level for the
+    whole chunk rather than per sample.  Only the disagreeing minority pays the
+    sequential binary search.  Each chunk is exactly the span in which the test
+    provably cannot fire (``_batch_before_possible_stop``), so batching draws no
+    sample past the stopping point -- same queries as the sequential loop, just
+    grouped -- and needs no chunk-size constant.
     """
     # Minimum trials before the sequential test can fire: at acc_threshold near 1
     # the "above" tail cannot clear alpha with only a handful of samples anyway,
@@ -239,22 +286,34 @@ def estimate_agreement_rate(
     # each sample.  On multi-iteration benchmarks this empty-prefix reclassification
     # was ~24% of all oracle queries (it recurs on up to num_samples draws per call).
     s0 = dt_decisive.classify([], oracle)
-    for _ in range(num_samples):
-        y = us.sample(pst.rng, pst.alphabet_size)
-        prefix, reason = locate_incorrect_point(oracle, dt_decisive, dfa, [], y, s0=s0)
-        if prefix is None and reason == "no inconsistency":
-            agreements += 1
-            valid += 1
-        elif prefix is not None:
-            valid += 1
-        else:
-            # Could-not-classify samples leave the decision unchanged; don't test.
-            continue
-        if (
-            valid >= min_valid
-            and binomial_side_of_boundary(agreements, valid, acc_threshold) is not None
-        ):
-            break
+    if s0 is None:
+        return 0.0  # every sample would fail to classify
+    drawn = 0
+    while drawn < num_samples:
+        size = _batch_before_possible_stop(
+            agreements, valid, acc_threshold, min_valid, num_samples - drawn
+        )
+        ys = [us.sample(pst.rng, pst.alphabet_size) for _ in range(size)]
+        drawn += size
+        ends = classify_many(dt_decisive, ys, oracle)
+        for y, s_end in zip(ys, ends):
+            prefix, reason = locate_incorrect_point(
+                oracle, dt_decisive, dfa, [], y, s0=s0, s_end=s_end
+            )
+            if prefix is None and reason == "no inconsistency":
+                agreements += 1
+                valid += 1
+            elif prefix is not None:
+                valid += 1
+            else:
+                # Could-not-classify samples leave the decision unchanged; don't test.
+                continue
+            if (
+                valid >= min_valid
+                and binomial_side_of_boundary(agreements, valid, acc_threshold)
+                is not None
+            ):
+                return agreements / valid
     return agreements / valid if valid else 0.0
 
 

--- a/orthogonal_dfa/l_star/structures.py
+++ b/orthogonal_dfa/l_star/structures.py
@@ -201,6 +201,42 @@ class DecisionTreeLeafNode(DecisionTree):
         return self
 
 
+def classify_many(
+    dt: DecisionTree, strings: List[List[int]], oracle: Oracle
+) -> List[Union[int, None]]:
+    """
+    Equivalent of [dt.classify(s, oracle) for s in strings] but one batched oracle
+    call per tree level.
+
+    `dt` must be composed of TriPredicate nodes.
+    """
+    out = [None] * len(strings)
+    node_of = [dt] * len(strings)  # each string's current node; None once resolved
+    while True:
+        # spans: [(index in strings, node, lo, hi)]; lo/hi are the slice of queries for this node
+        queries, spans = [], []
+        for i, node in enumerate(node_of):
+            if node is None:
+                continue
+            if isinstance(node, DecisionTreeLeafNode):
+                out[i], node_of[i] = node.state_idx, None
+                continue
+            assert isinstance(
+                node.predicate, TriPredicate
+            ), "classify_many needs TriPredicate nodes"
+            lo = len(queries)
+            queries.extend(strings[i] + v for v in node.predicate.vs)
+            spans.append((i, node, lo, len(queries)))
+        if not queries:
+            return out
+        answers = np.asarray(oracle.membership_queries(queries))
+        assert len(answers) == len(queries), "oracle dropped answers"
+        for i, node, lo, hi in spans:
+            decision = node.predicate.decide(float(answers[lo:hi].mean()))
+            # None => undecided: drop the string (out[i] stays None); else descend.
+            node_of[i] = None if decision is None else node.by_rejection[int(decision)]
+
+
 @dataclass
 class TriPredicate:
     vs: List[List[int]]
@@ -208,15 +244,19 @@ class TriPredicate:
     reject_threshold: float
 
     def predict(self, x: List[int], oracle: Oracle) -> float:
-        return np.mean([oracle.membership_query(x + v) for v in self.vs])
+        answers = oracle.membership_queries([x + v for v in self.vs])
+        assert len(answers) == len(self.vs), "oracle dropped answers"
+        return float(np.mean(answers))
 
-    def __call__(self, x: List[int], oracle: Oracle) -> Union[bool, None]:
-        f = self.predict(x, oracle)
+    def decide(self, f: float) -> Union[bool, None]:
         if f > self.accept_threshold:
             return True
         if f < self.reject_threshold:
             return False
         return None
+
+    def __call__(self, x: List[int], oracle: Oracle) -> Union[bool, None]:
+        return self.decide(self.predict(x, oracle))
 
     def __hash__(self):
         return hash(

--- a/scripts/profile_query_origins.py
+++ b/scripts/profile_query_origins.py
@@ -138,10 +138,11 @@ class ProfilingOracle(Oracle):
         # matter. DT classify and denoise query the oracle directly. A new prefix
         # row is checked before the column sites because in the eager layout the
         # row query still passes through `_query` (add_prefixes -> _query).
-        if "predict" in name_set:
+        if name_set & {"predict", "classify_many"}:
             phase = next((p for p in PREDICT_PHASES if p in name_set), "other")
             sub = f" [locate L{locate_line}]" if locate_line else ""
-            return f"DT classify one string (TriPredicate.predict) <- {phase}{sub}"
+            how = "batched" if "classify_many" in name_set else "one string"
+            return f"DT classify {how} <- {phase}{sub}"
         if "relabel" in name_set:
             return "denoise: fresh samples per state (relabel)"
         if "add_prefixes" in name_set:

--- a/tests/test_batch_queries.py
+++ b/tests/test_batch_queries.py
@@ -1,11 +1,19 @@
-"""The batched MaskTable fill paths must agree, cell for cell, with per-string queries."""
+"""The batched oracle paths must agree, cell for cell, with the per-string ones."""
 
 import unittest
 
 import numpy as np
 
+from orthogonal_dfa.l_star.lstar import _batch_before_possible_stop
 from orthogonal_dfa.l_star.mask_table import UNOBSERVED, MaskTable
-from orthogonal_dfa.l_star.structures import Oracle
+from orthogonal_dfa.l_star.statistics import binomial_side_of_boundary
+from orthogonal_dfa.l_star.structures import (
+    DecisionTreeInternalNode,
+    DecisionTreeLeafNode,
+    Oracle,
+    TriPredicate,
+    classify_many,
+)
 
 
 class HashOracle(Oracle):
@@ -22,6 +30,52 @@ class HashOracle(Oracle):
     def membership_queries(self, strings):
         self.calls.append(len(strings))
         return super().membership_queries(strings)
+
+
+def random_tree(rng, depth, next_state):
+    if depth == 0:
+        next_state[0] += 1
+        return DecisionTreeLeafNode(next_state[0] - 1)
+    vs = [list(rng.integers(0, 2, size=int(rng.integers(1, 4)))) for _ in range(5)]
+    # Half decisive, half tri-state, so the None ("could not classify") path is hit.
+    a, r = (0.5, 0.5) if rng.random() < 0.5 else (0.7, 0.3)
+    return DecisionTreeInternalNode(
+        TriPredicate(vs, a, r),
+        tuple(random_tree(rng, depth - 1, next_state) for _ in range(2)),
+    )
+
+
+class TestClassifyMany(unittest.TestCase):
+    def test_matches_per_string_classify(self):
+        rng = np.random.default_rng(0)
+        saw_none = False
+        for _ in range(25):
+            tree = random_tree(rng, 3, [0])
+            strings = [
+                list(rng.integers(0, 2, size=int(rng.integers(0, 8))))
+                for _ in range(40)
+            ]
+            per_string, batched = HashOracle(), HashOracle()
+            expected = [tree.classify(s, per_string) for s in strings]
+            self.assertEqual(expected, classify_many(tree, strings, batched))
+            # Same work, far fewer calls: one per tree level rather than per string.
+            self.assertEqual(sum(per_string.calls), sum(batched.calls))
+            self.assertLessEqual(len(batched.calls), tree.depth)
+            saw_none |= None in expected
+        self.assertTrue(saw_none, "no undecided classification exercised")
+
+    def test_empty(self):
+        tree = random_tree(np.random.default_rng(0), 2, [0])
+        oracle = HashOracle()
+        self.assertEqual([], classify_many(tree, [], oracle))
+        self.assertEqual([], oracle.calls)
+
+    def test_leaf_root(self):
+        oracle = HashOracle()
+        self.assertEqual(
+            [7, 7], classify_many(DecisionTreeLeafNode(7), [[0], [1]], oracle)
+        )
+        self.assertEqual([], oracle.calls)
 
 
 class TestMaskTableBatching(unittest.TestCase):
@@ -106,6 +160,49 @@ class TestMaskTableBatching(unittest.TestCase):
         filled = np.array([table._masks[r] for r in rows])
         self.assertNotEqual(filled.min(), filled.max(), "fixture is order-blind")
         self._assert_cells_correct(oracle, table)
+
+
+class TestBatchBeforePossibleStop(unittest.TestCase):
+    """The look-ahead chunk must never span the sequential early-stop: below the
+    returned size the binomial test provably cannot fire, so batching that many is
+    identical to drawing them one at a time."""
+
+    boundary = 0.98
+    min_valid = 30
+    remaining = 2000
+    states = [(0, 0), (30, 30), (29, 30), (98, 100), (490, 500), (1900, 1950)]
+
+    def _fires(self, agreements, valid, k):
+        return (
+            binomial_side_of_boundary(agreements + k, valid + k, self.boundary) is True
+            or binomial_side_of_boundary(agreements, valid + k, self.boundary) is False
+        )
+
+    def test_never_spans_the_stop(self):
+        # No k strictly inside the chunk (at or above the min_valid floor) can fire.
+        for a, n in self.states:
+            k = _batch_before_possible_stop(
+                a, n, self.boundary, self.min_valid, self.remaining
+            )
+            self.assertGreaterEqual(n + k, self.min_valid)  # respects the floor
+            floor = max(self.min_valid - n, 1)
+            for kp in range(floor, k):
+                self.assertFalse(self._fires(a, n, kp), (a, n, kp))
+
+    def test_chunk_is_maximal(self):
+        # It is the *largest* safe chunk: firing is possible exactly at k (unless we
+        # ran out of budget), so stopping one sooner would have left batching on table.
+        for a, n in self.states:
+            k = _batch_before_possible_stop(
+                a, n, self.boundary, self.min_valid, self.remaining
+            )
+            if k < self.remaining:
+                self.assertTrue(self._fires(a, n, k), (a, n, k))
+
+    def test_capped_by_remaining(self):
+        self.assertEqual(
+            5, _batch_before_possible_stop(0, 0, self.boundary, self.min_valid, 5)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rebased onto main after #132 (the batching infrastructure) and #130 landed. Now scoped to just the algorithmic change — the DT-classification batching that actually affects the search trajectory.

## What's here
- **`classify_many`** — classify N strings with one oracle call per decision-tree level instead of one per (string, node). Every string still descending pays its predicate's queries into the same batch. Verified cell-for-cell against per-string `classify`.
- **`estimate_agreement_rate`** — classifies each chunk of fresh samples through `classify_many`. Each chunk is the **largest span the early-stop binomial test provably cannot fire in** (`_batch_before_possible_stop`), so batching never draws a sample past where a sequential loop would stop — same queries, just grouped, and **no magic chunk-size constant**.
- **`locate_incorrect_point`** — takes `s_end` (the endpoint classification) from the caller, so the batched result is reused instead of recomputed per string.
- Tests: `classify_many` equivalence + the look-ahead's no-overshoot / maximality property.

## Depends on
- #132 (`Oracle.membership_queries` batch API) — **merged**.

## Validation
- Accuracy and learned-state count hold across seeds; queries equal the sequential baseline (zero overshoot by construction). Forward passes drop ~1.6× on the fast benchmarks. See the query-count table posted by the benchmark run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `batch` vs `main`

|   | task | queries `main` | queries `batch` | ratio | acc `main` | acc `batch` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 875,614 | 875,614 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 1,277,963 | 1,277,963 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 916,203 | 916,203 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 5,672,298 | 5,672,298 | 1.00x | 0.977 | 0.977 | 9 |
| ⚪ | modulo_hard | 1,787,883 | 1,787,883 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 3,490,044 | 3,490,044 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **1.00x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

### Forward passes — `batch` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 145,672 → 28,096 (0.19x, 97% packed) | 128,010 → 7,588 (0.06x, 90% packed) | 122,909 → 1,676 (0.01x, 51% packed) |
| subseq | 350,893 → 45,419 (0.13x, 88% packed) | 328,470 → 17,368 (0.05x, 57% packed) | 321,948 → 9,542 (0.03x, 13% packed) |
| two_subseq | 236,242 → 31,419 (0.13x, 91% packed) | 219,846 → 10,965 (0.05x, 65% packed) | 215,010 → 5,218 (0.02x, 17% packed) |
| poor_case | 2,013,108 → 183,365 (0.09x, 97% packed) | 1,924,695 → 59,336 (0.03x, 75% packed) | 1,898,859 → 27,995 (0.01x, 20% packed) |
| modulo_hard | 351,095 → 57,867 (0.16x, 97% packed) | 316,309 → 15,987 (0.05x, 87% packed) | 306,260 → 3,884 (0.01x, 45% packed) |
| modulo_asym | 629,685 → 110,941 (0.18x, 98% packed) | 560,663 → 29,373 (0.05x, 93% packed) | 540,407 → 5,454 (0.01x, 63% packed) |
