### PR TITLE
Terminate synthesis when counterexample search early-stops (issue #128)

### DIFF
--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -146,6 +146,16 @@ def locate_incorrect_point(oracle, dt, dfa, x, y, *, s0):
     return x + y[: correct_idx + 1], y[correct_idx + 1]
 
 
+class _CounterexampleSearchExhausted(Exception):
+    """Raised when counterexample search early-stops on the unlikely-agreements
+    signal. Carries whatever prefixes were found before stopping. Caught in
+    counterexample_driven_synthesis to terminate synthesis (issue #128)."""
+
+    def __init__(self, prefixes):
+        super().__init__()
+        self.prefixes = prefixes
+
+
 def generate_counterexamples(pst, us, oracle, dt, dfa, *, count, expected_acc):
     boundary = pst.decision_boundary
     # The counterexample pipeline classifies strings many times: ~log2(string_len)
@@ -196,7 +206,14 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count, expected_acc):
                     f" prefixes"
                 )
                 pbar.close()
-                return additional_prefixes
+                # EXPERIMENT (issue #128): the counterexample search is seeing
+                # far more agreement than expected_acc predicts, i.e. it can no
+                # longer find distinguishing prefixes. Treat that as "synthesis
+                # has converged as far as it can" and stop the whole loop,
+                # rather than letting leaf enrichment keep growing the prefix
+                # set forever. Signalled by exception so it unwinds the full
+                # generate -> add -> synthesis call chain at once.
+                raise _CounterexampleSearchExhausted(additional_prefixes)
             continue
         if prefix in additional_prefixes or pst.table.contains_prefix(prefix):
             continue
@@ -345,9 +362,21 @@ def counterexample_driven_synthesis(
             print(f"Achieved desired accuracy of {acc_threshold}; stopping synthesis")
             yield dfa, dt, None
             return
-        ce = add_counterexample_prefixes(
-            pst, dt, dfa, additional_counterexamples, expected_acc=true_acc
-        )
+        try:
+            ce = add_counterexample_prefixes(
+                pst, dt, dfa, additional_counterexamples, expected_acc=true_acc
+            )
+        except _CounterexampleSearchExhausted:
+            # Counterexample search could no longer find distinguishing
+            # prefixes; stop synthesis instead of falling through to leaf
+            # enrichment (which never runs dry, so the loop would not
+            # terminate). See issue #128.
+            print(
+                "Counterexample search exhausted (unlikely-agreements signal);"
+                " stopping synthesis"
+            )
+            yield dfa, dt, None
+            return
         enriched = enrich_underrepresented_leaves(
             pst, dt_decisive, count=additional_counterexamples
         )


### PR DESCRIPTION
## What

When counterexample search hits the **"unlikely given expected accuracy"** signal in `generate_counterexamples`, make it terminate the whole synthesis loop and return the current best hypothesis, instead of returning a partial prefix list and letting the outer loop continue.

## Why

Per #128, `counterexample_driven_synthesis` never terminates on targets the learner cannot represent. Each round:

- counterexample search early-stops (`unlikely_this_many_agreements`) → returns few/no prefixes
- `enrich_underrepresented_leaves` → **always** returns prefixes

The only non-success exit is `if not ce and not enriched`, which can never fire because enrichment never runs dry. So the prefix set grows by `additional_counterexamples` every round forever (unbounded time + memory).

The early-stop signal means CE search can no longer find distinguishing prefixes — i.e. synthesis has converged as far as it can. This treats it as a stop condition.

## How

A `_CounterexampleSearchExhausted` sentinel raised at the early-stop point unwinds the `generate → add → synthesis` call chain in one step; the synthesis loop catches it, yields the current DFA, and returns.

## Effect

`Difficult09` (`{ w : |w| >= 3 and w[2] == 'a' }`), which previously ran >15 min and grew without bound, now terminates in **~1.3s** returning its best-effort hypothesis.

## Status

This is deliberately a **behavioural experiment** to surface which tests depend on synthesis continuing past this signal — the early-stop is a heuristic, and terminating on it may cut synthesis short on targets that would otherwise have improved via enrichment. Opening to read that off CI.

Closes #128 if the test fallout is acceptable.