### PR TITLE
Terminate gracefully on uncoverable access strings (issue #128)

### DIFF
--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -313,6 +313,68 @@ def enrich_underrepresented_leaves(pst, dt_decisive, *, count):
     return new_prefixes
 
 
+def uncoverable_access_strings(pst, dt):
+    """Access strings the hypothesis cannot resolve *and* cannot ever cover.
+
+    The short prefix-closed core is the set of access strings -- it reaches
+    every state, including transient ones that a fixed-length prefix sampler
+    never lands on. The resolver excludes the core from state discovery (too
+    few, too noisy to drive splits), but the core still lets us check whether
+    the hypothesis is even *consistent* with its own access strings.
+
+    A core prefix is flagged when both hold:
+
+    - *closedness*: the hypothesis cannot classify it (``dt.classify`` is
+      ``None``) -- it belongs to no discovered state; and
+    - *uncoverable*: no representative (sampled) prefix matches its behaviour
+      over the suffix family within the noise floor -- so the state it
+      witnesses has no representative witness and no amount of further sampling
+      at this length can produce one.
+
+    The second condition is what separates this from an ordinary
+    under-represented state (``poor_case``): there, the rare state *is* reached
+    by some representative prefixes, so it has a match and is not flagged, and
+    enrichment resolves it. Only a genuinely uncoverable state -- e.g. a
+    transient state under a fixed-length sampler -- is flagged, which is the
+    signal to stop rather than grow the prefix set forever (issue #128).
+
+    Returns a list of ``(access_string, nearest_representative_disagreement)``.
+    """
+    prefixes = list(pst.table.prefixes)
+    rep = pst.table.representative
+    fam = pst.table.fully_observed()
+    if len(fam) == 0 or not rep.any():
+        return []
+
+    eta = 0.5 - pst.config.min_signal_strength
+    # Two prefixes at the same state agree on every suffix up to independent
+    # per-cell noise, so their expected mask-disagreement rate is 2*eta*(1-eta).
+    same_state_rate = 2 * eta * (1 - eta)
+    n = len(fam)
+
+    repr_masks = pst.table.observed_masks(fam, rep).T  # [n_repr, n_fam]
+    oracle = pst.oracle
+    flagged = []
+    for i in range(len(prefixes)):
+        if rep[i] or dt.classify(prefixes[i], oracle) is not None:
+            continue  # only unclassifiable core prefixes are candidates
+        col = np.zeros(len(prefixes), dtype=bool)
+        col[i] = True
+        mask_i = pst.table.observed_masks(fam, col).T[0]
+        # The nearest representative by disagreement count over the family; `min`
+        # is conservative (biased toward finding a match, i.e. toward *not*
+        # flagging). Flag only when even that nearest count is too high to be
+        # same-state noise: a one-sided binomial test against same_state_rate,
+        # at the give-up failure probability the codebase uses elsewhere
+        # (give_up_check), rather than the strict decision-rule level -- a false
+        # non-flag here just costs another round, a false flag abandons a
+        # learnable target.
+        nearest = int((repr_masks != mask_i).sum(1).min())
+        if binomial_side_of_boundary(nearest, n, same_state_rate, failure_prob=0.01):
+            flagged.append((list(prefixes[i]), nearest / n))
+    return flagged
+
+
 def counterexample_driven_synthesis(
     pst, *, additional_counterexamples: int, acc_threshold: float
 ):
@@ -343,6 +405,23 @@ def counterexample_driven_synthesis(
         print(f"Estimated DFA accuracy on fresh samples: {true_acc:.4f}")
         if true_acc >= acc_threshold:
             print(f"Achieved desired accuracy of {acc_threshold}; stopping synthesis")
+            yield dfa, dt, None
+            return
+        uncoverable = uncoverable_access_strings(pst, dt)
+        if uncoverable:
+            # The hypothesis is inconsistent with access strings it can never
+            # cover at this sampling length (issue #128). More rounds only grow
+            # the prefix set; stop and return the best hypothesis with a reason
+            # naming the offending access strings.
+            examples = ", ".join(
+                "".join(map(str, p)) or "eps" for p, _ in uncoverable[:5]
+            )
+            print(
+                f"Stopping synthesis: {len(uncoverable)} access string(s) reach "
+                f"states no sampled prefix can cover at length "
+                f"{pst.sampler.length} (e.g. {examples}); the target is not "
+                f"learnable with this prefix sampler."
+            )
             yield dfa, dt, None
             return
         ce = add_counterexample_prefixes(

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -314,31 +314,18 @@ def enrich_underrepresented_leaves(pst, dt_decisive, *, count):
 
 
 def uncoverable_access_strings(pst, dt):
-    """Access strings the hypothesis cannot resolve *and* cannot ever cover.
+    """Access strings the hypothesis cannot resolve and can never be covered.
 
-    The short prefix-closed core is the set of access strings -- it reaches
+    The short prefix-closed core is the set of access strings, it reaches
     every state, including transient ones that a fixed-length prefix sampler
-    never lands on. The resolver excludes the core from state discovery (too
-    few, too noisy to drive splits), but the core still lets us check whether
-    the hypothesis is even *consistent* with its own access strings.
+    never lands on.
 
-    A core prefix is flagged when both hold:
-
-    - *closedness*: the hypothesis cannot classify it (``dt.classify`` is
-      ``None``) -- it belongs to no discovered state; and
-    - *uncoverable*: no representative (sampled) prefix matches its behaviour
-      over the suffix family within the noise floor -- so the state it
-      witnesses has no representative witness and no amount of further sampling
-      at this length can produce one.
-
-    The second condition is what separates this from an ordinary
-    under-represented state (``poor_case``): there, the rare state *is* reached
-    by some representative prefixes, so it has a match and is not flagged, and
-    enrichment resolves it. Only a genuinely uncoverable state -- e.g. a
-    transient state under a fixed-length sampler -- is flagged, which is the
-    signal to stop rather than grow the prefix set forever (issue #128).
-
-    Returns a list of ``(access_string, nearest_representative_disagreement)``.
+    We can use this to detect when the underlying DFA is not learnable in
+    our model. Specifically, when a state in the access strings is not also
+    reached by any representative (longer) prefix. This prevents us from
+    averaging across multiple prefixes to get a representative set for this state
+    implying that the state is only reached by a small number of strings
+    overall.
     """
     prefixes = list(pst.table.prefixes)
     rep = pst.table.representative
@@ -353,22 +340,16 @@ def uncoverable_access_strings(pst, dt):
     n = len(fam)
 
     repr_masks = pst.table.observed_masks(fam, rep).T  # [n_repr, n_fam]
-    oracle = pst.oracle
+    leaves = classify_states_with_decision_tree(pst, dt)
+    potentially_problematic = np.flatnonzero(
+        (~rep) & (leaves == -1)
+    )  # only unclassifiable core prefixes
     flagged = []
-    for i in range(len(prefixes)):
-        if rep[i] or dt.classify(prefixes[i], oracle) is not None:
-            continue  # only unclassifiable core prefixes are candidates
+    for i in potentially_problematic:
         col = np.zeros(len(prefixes), dtype=bool)
         col[i] = True
         mask_i = pst.table.observed_masks(fam, col).T[0]
-        # The nearest representative by disagreement count over the family; `min`
-        # is conservative (biased toward finding a match, i.e. toward *not*
-        # flagging). Flag only when even that nearest count is too high to be
-        # same-state noise: a one-sided binomial test against same_state_rate,
-        # at the give-up failure probability the codebase uses elsewhere
-        # (give_up_check), rather than the strict decision-rule level -- a false
-        # non-flag here just costs another round, a false flag abandons a
-        # learnable target.
+        # get the nearest and see if it's too far away to be a sibling.  If so, this prefix is problematic.
         nearest = int((repr_masks != mask_i).sum(1).min())
         if binomial_side_of_boundary(nearest, n, same_state_rate, failure_prob=0.01):
             flagged.append((list(prefixes[i]), nearest / n))
@@ -409,10 +390,6 @@ def counterexample_driven_synthesis(
             return
         uncoverable = uncoverable_access_strings(pst, dt)
         if uncoverable:
-            # The hypothesis is inconsistent with access strings it can never
-            # cover at this sampling length (issue #128). More rounds only grow
-            # the prefix set; stop and return the best hypothesis with a reason
-            # naming the offending access strings.
             examples = ", ".join(
                 "".join(map(str, p)) or "eps" for p, _ in uncoverable[:5]
             )

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -1,3 +1,4 @@
+import signal
 import unittest
 
 import numpy as np
@@ -323,6 +324,44 @@ class TestLStar(unittest.TestCase):
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, dfa, oracle_creator)
+
+    def test_transient_states_terminate(self):
+        # Regression for issue #128. This target -- {w : |w| >= 3 and
+        # w[2] == '0'} -- has transient states (0, 1, 2) that a fixed-length
+        # prefix sampler never lands on, so they are unresolvable and the DFA
+        # is not learnable with this sampler. Synthesis must still *terminate*
+        # rather than grow the prefix set forever. We assert only that it
+        # returns within a generous timeout, not what it returns: the learned
+        # DFA is expected to be imperfect, so there is no correct output to
+        # check.
+        dfa = DFA(
+            states={0, 1, 2, 3, 4},
+            input_symbols={0, 1},
+            transitions={
+                0: {0: 1, 1: 1},
+                1: {0: 2, 1: 2},
+                2: {0: 3, 1: 4},
+                3: {0: 3, 1: 3},
+                4: {0: 4, 1: 4},
+            },
+            initial_state=0,
+            final_states={3},
+            allow_partial=False,
+        )
+        oracle_creator = lambda nm, s, _dfa=dfa: DFAOracle(nm, s, _dfa)
+
+        def _timeout(signum, frame):
+            raise AssertionError(
+                "synthesis did not terminate within the timeout (issue #128)"
+            )
+
+        previous = signal.signal(signal.SIGALRM, _timeout)
+        signal.alarm(60)
+        try:
+            compute_dfa_for_oracle(oracle_creator, min_signal_strength=0.45, seed=0)
+        finally:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, previous)
 
 
 class TestLStarAsymmetric(unittest.TestCase):

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -1,4 +1,3 @@
-import signal
 import unittest
 
 import numpy as np
@@ -349,6 +348,10 @@ class TestLStar(unittest.TestCase):
             allow_partial=False,
         )
         oracle_creator = lambda nm, s, _dfa=dfa: DFAOracle(nm, s, _dfa)
+
+        # Imported locally: a module-level `import signal` would shadow the
+        # `signal` (signal-strength) parameter other tests in this file use.
+        import signal
 
         def _timeout(signum, frame):
             raise AssertionError(


### PR DESCRIPTION
## What

Makes `counterexample_driven_synthesis` stop and return its best hypothesis — instead of looping forever — when the target has states that no fixed-length prefix sample can reach.

## Why

Per #128, synthesis never terminates on targets like `Difficult09` = `{ w : |w| >= 3 and w[2] == 'a' }`. The resolver discovers states only from **representative** (length-40) prefixes; a **transient** state (reached only by short prefixes) gets zero coverage and is never resolved. Leaf enrichment then adds prefixes every round without the loop's exit condition ever firing → unbounded time and memory.

## How — a principled invariant, not a round counter

The short prefix-closed **core** is the set of access strings; it reaches every state, including the transient ones. The resolver excludes it from state *discovery* (too few/noisy to drive splits), but the core still lets us check whether the hypothesis is **consistent with its own access strings**. `uncoverable_access_strings(pst, dt)` flags an access string when **both**:

- **closedness**: the hypothesis cannot classify it (`dt.classify` is `None`); and
- **uncoverable**: no representative prefix matches its behaviour over the suffix family within the same-state noise floor (one-sided scipy binomial test against `2·eta·(1-eta)`, at give_up_check's failure probability), so its state has no representative witness and no further sampling at this length can produce one.

When any access string is uncoverable, synthesis stops and returns the best hypothesis with a message naming the offending strings.

## Why it doesn't break `poor_case` (which sank #129)

#129 bailed on the "unlikely-agreements" signal and broke `poor_case`/generated benchmarks, because that signal also fires during *legitimate* enrichment. Condition **(b)** is the difference here: in `poor_case` the rare state **is** reached by some representative prefixes, so it has a match, is **not** flagged, and enrichment still resolves it. Only a genuinely uncoverable state (transient under a fixed-length sampler) is flagged.

## Validation (local)

- `Difficult09`: terminates in ~1s (was unbounded), returns its 2-state best-effort with a clear reason.
- `poor_case`: 0 flags every round; still learns all 10 states.
- Healthy targets (`parity_mod9`, `regex_subseq`, `Simple01`): never flag — including `regex_subseq`, whose resolved state count oscillates (2→2→4→2→8) mid-synthesis, which a stall/round counter would misread.

Relying on CI for the full suite.

Closes #128.

## Query count — `fix/graceful-terminate-uncoverable` vs `main`

|   | task | queries `main` | queries `fix/graceful-terminate-uncoverable` | ratio | acc `main` | acc `fix/graceful-terminate-uncoverable` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 875,614 | 875,614 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 1,277,963 | 1,277,963 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 916,203 | 916,203 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 5,672,298 | 5,672,298 | 1.00x | 0.977 | 0.977 | 9 |
| ⚪ | modulo_hard | 1,787,883 | 1,787,883 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 3,490,044 | 3,490,044 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **1.00x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)
