### PR TITLE
Batch the MaskTable membership queries

### DIFF
--- a/orthogonal_dfa/l_star/mask_table.py
+++ b/orthogonal_dfa/l_star/mask_table.py
@@ -66,16 +66,20 @@ class MaskTable:
         # gets UNOBSERVED cells, filled later on demand only if some read needs
         # them.
         pad = np.full(len(new_prefixes), UNOBSERVED, dtype=np.int8)
-        updated = []
-        for suffix, col in zip(self._suffixes, self._masks):
-            if (col != UNOBSERVED).all():
-                add = np.array(
-                    [self._oracle.membership_query(p + suffix) for p in new_prefixes],
-                    dtype=np.int8,
-                )
-            else:
-                add = pad
-            updated.append(np.concatenate([col, add]))
+        # Flatten out the pairs to update
+        full_cols = [
+            i for i, col in enumerate(self._masks) if (col != UNOBSERVED).all()
+        ]
+        adds = {}
+        if full_cols:
+            strings = [p + self._suffixes[i] for i in full_cols for p in new_prefixes]
+            observed = np.asarray(
+                self._oracle.membership_queries(strings), dtype=np.int8
+            ).reshape(len(full_cols), len(new_prefixes))
+            adds = {i: observed[k] for k, i in enumerate(full_cols)}
+        updated = [
+            np.concatenate([col, adds.get(i, pad)]) for i, col in enumerate(self._masks)
+        ]
         self._masks = updated
         self._prefixes.extend(list(p) for p in new_prefixes)
         self._prefix_keys.update(tuple(p) for p in new_prefixes)
@@ -109,12 +113,21 @@ class MaskTable:
         """Fill any UNOBSERVED cells for ``rows`` over the boolean
         ``prefix_mask``.  Cells already observed are reused, so no
         ``(prefix, suffix)`` pair is queried twice."""
+        assert len(set(rows)) == len(rows), "rows must be distinct"
         idx = np.flatnonzero(prefix_mask)
+        strings, targets = [], []
         for r in rows:
             col = self._masks[r]
             suffix = self._suffixes[r]
             for p in idx[col[idx] == UNOBSERVED]:
-                col[p] = self._oracle.membership_query(self._prefixes[p] + suffix)
+                strings.append(self._prefixes[p] + suffix)
+                targets.append((r, p))
+        if not strings:
+            return
+        results = self._oracle.membership_queries(strings)
+        assert len(results) == len(strings), "oracle dropped answers"
+        for (r, p), val in zip(targets, results):
+            self._masks[r][p] = val
 
     def observed_masks(self, rows, prefix_mask) -> np.ndarray:
         """The ``(len(rows), prefix_mask.sum())`` int8 block for ``rows`` over the

--- a/orthogonal_dfa/l_star/structures.py
+++ b/orthogonal_dfa/l_star/structures.py
@@ -85,6 +85,14 @@ class Oracle(ABC):
     def membership_query(self, string: List[int]) -> bool:
         pass
 
+    def membership_queries(self, strings: List[List[int]]) -> np.ndarray:
+        """
+        Query multiple strings at once. Implementations can choose to override this
+        and provide a more efficient batch query method. This does not have a cap
+        on `strings`'s length.
+        """
+        return np.array([self.membership_query(s) for s in strings], dtype=bool)
+
 
 class DecisionTree(ABC):
     @abstractmethod

--- a/scripts/count_queries.py
+++ b/scripts/count_queries.py
@@ -76,6 +76,9 @@ POOR_CASE_DFA = {
 QUERY_BAND = 0.02
 ACC_EPS = 0.005
 
+# A call of N strings is costed at ceil(N / cap) forward passes
+BATCH_CAPS = (32, 128, 1024)
+
 
 # ---------------------------------------------------------------------------
 # Measurer: runs INSIDE a worktree (imports that branch's orthogonal_dfa).
@@ -98,6 +101,7 @@ def _measure(root: str, names: list[str]) -> dict:
             self._inner = inner
             self.count = 0
             self.distinct = set()
+            self.batches = []  # size of each issued call
 
         @property
         def alphabet_size(self):
@@ -106,7 +110,14 @@ def _measure(root: str, names: list[str]) -> dict:
         def membership_query(self, string):
             self.count += 1
             self.distinct.add(tuple(string))
+            self.batches.append(1)
             return self._inner.membership_query(string)
+
+        def membership_queries(self, strings):
+            self.count += len(strings)
+            self.distinct.update(tuple(s) for s in strings)
+            self.batches.append(len(strings))
+            return self._inner.membership_queries(strings)
 
     def build_creator(spec):
         kind = spec["kind"]
@@ -146,9 +157,14 @@ def _measure(root: str, names: list[str]) -> dict:
                 counting_creator, min_signal_strength=bench["signal"], seed=0,
                 noise_model=noise_model)
             acc = evaluate_accuracy(dfa, creator, symbols=bench["symbols"])
+        all_batches = [n for c in counters for n in c.batches]
         results[name] = {
             "queries": sum(c.count for c in counters),
             "distinct": len(set().union(*[c.distinct for c in counters])),
+            "batches": len(all_batches),
+            "forward_passes": {
+                str(cap): sum(math.ceil(n / cap) for n in all_batches)
+                for cap in BATCH_CAPS},
             "states": len(dfa.states),
             "accuracy": acc,
             "seconds": time.time() - t0,
@@ -260,17 +276,46 @@ def comparison_report(base_ref: str, pr_ref: str, base: dict, pr: dict,
             any_regression = True
         st = f"{b['states']}" if states_ok else f"{b['states']}→{p['states']} ‼️"
         lines.append(
-            f"| {emoji} | {name} | {b['queries']:,} | {p['queries']:,} | {ratio:.2f}x | "
+            f"| {emoji} | {name} | {b['queries']:,} | {p['queries']:,} | "
+            f"{_ratio_str(ratio)} | "
             f"{b['accuracy']:.3f} | {p['accuracy']:.3f} | {st} |")
     geo = math.prod(ratios) ** (1 / len(ratios)) if ratios else float("nan")
     lines.append(
         f"| {'🟢' if geo < 1 - QUERY_BAND else '🔴' if geo > 1 + QUERY_BAND else '⚪'} "
-        f"| **geomean** |  |  | **{geo:.2f}x** |  |  |  |")
+        f"| **geomean** |  |  | **{_ratio_str(geo)}** |  |  |  |")
     lines.append("")
     lines.append("**❌ REGRESSION** (queries up or accuracy/states broke on ≥1 task)"
                  if any_regression else
                  "**✅ no regressions** (accuracy held, no task's queries rose beyond band)")
+
+    lines.append("")
+    lines.append(f"### Forward passes — `{pr_ref}` vs `{base_ref}` "
+                 "(neural passes at each batch cap; `base → pr (ratio, pr packing)`)")
+    lines.append("")
+    lines.append("*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every "
+                 "call filled its batch. Below 100% the remaining passes are "
+                 "under-filled calls, i.e. headroom from co-batching more call sites, "
+                 "not irreducible work.*")
+    lines.append("")
+    lines.append("| task | " + " | ".join(f"fp@{c}" for c in BATCH_CAPS) + " |")
+    lines.append("|---|" + "|".join(["---:"] * len(BATCH_CAPS)) + "|")
+    for name in names:
+        b, p = base[name], pr[name]
+        cells = []
+        for cap in BATCH_CAPS:
+            bf, pf = b["forward_passes"][str(cap)], p["forward_passes"][str(cap)]
+            packed = math.ceil(p["queries"] / cap) / pf if pf else float("nan")
+            ratio = pf / bf if bf else float("inf")
+            cells.append(f"{bf:,} → {pf:,} ({_ratio_str(ratio)}, "
+                         f"{100 * packed:.0f}% packed)")
+        lines.append(f"| {name} | " + " | ".join(cells) + " |")
     return "\n".join(lines)
+
+
+def _ratio_str(ratio: float) -> str:
+    """pr/base as ``0.02x``. Two decimals, except below 0.01 (batching moves
+    forward passes by 100x+) where that would print ``0.00x``."""
+    return f"{ratio:.2f}x" if ratio >= 0.01 else f"{ratio:.2g}x"
 
 
 def update_pr_report(pr_ref: str, report: str):
@@ -299,14 +344,23 @@ def update_pr_report(pr_ref: str, report: str):
 
 def print_local_table(results: dict, names: list[str]):
     print("\n===== QUERY COUNT SUMMARY =====")
-    header = f"{'task':<14}{'queries':>12}{'distinct':>11}{'states':>8}{'acc':>8}{'sec':>8}"
+    caps = "".join(f"{f'fp@{cap}':>11}" for cap in BATCH_CAPS)
+    header = (f"{'task':<14}{'queries':>12}{'distinct':>11}{'batches':>10}{caps}"
+              f"{'states':>8}{'acc':>8}{'sec':>8}")
     print(header)
     print("-" * len(header))
     for name in names:
         r = results[name]
-        print(f"{name:<14}{r['queries']:>12,}{r['distinct']:>11,}{r['states']:>8}"
-              f"{r['accuracy']:>8.3f}{r['seconds']:>8.1f}")
-    print(f"\nTOTAL queries: {sum(results[n]['queries'] for n in names):,}")
+        fps = "".join(f"{r['forward_passes'][str(cap)]:>11,}" for cap in BATCH_CAPS)
+        print(f"{name:<14}{r['queries']:>12,}{r['distinct']:>11,}{r['batches']:>10,}"
+              f"{fps}{r['states']:>8}{r['accuracy']:>8.3f}{r['seconds']:>8.1f}")
+    queries = sum(results[n]["queries"] for n in names)
+    print(f"\nTOTAL queries: {queries:,}")
+    for cap in BATCH_CAPS:
+        total = sum(results[n]["forward_passes"][str(cap)] for n in names)
+        ideal = math.ceil(queries / cap)
+        print(f"TOTAL forward passes @ batch {cap}: {total:,} "
+              f"(ideal {ideal:,}, {100 * ideal / total:.0f}% packed)")
 
 
 def main():

--- a/scripts/profile_query_origins.py
+++ b/scripts/profile_query_origins.py
@@ -11,8 +11,9 @@ Usage:
     python scripts/profile_query_origins.py modulo subseq    # several, in one run
 """
 
+import math
 import sys
-from collections import Counter
+from collections import Counter, defaultdict
 from pathlib import Path
 
 # Profile THIS working tree, not whatever `orthogonal_dfa` is pip-installed
@@ -109,7 +110,9 @@ ROW_TRIGGERS = [
 class ProfilingOracle(Oracle):
     def __init__(self, inner: Oracle):
         self._inner = inner
-        self.buckets = Counter()
+        # label -> Counter(batch size -> calls at that size). Forward passes
+        # need the sizes, not just the totals.
+        self.sizes = defaultdict(Counter)
         self.total = 0
 
     @property
@@ -122,7 +125,7 @@ class ProfilingOracle(Oracle):
         # the exact call site (empty-string s0 vs full-string check vs binary search).
         names = []
         locate_line = None
-        frame = sys._getframe(2)  # skip _attribute + membership_query
+        frame = sys._getframe(3)  # skip _attribute + _record + the query method
         depth = 0
         while frame is not None and depth < 60:
             names.append(frame.f_code.co_name)
@@ -149,10 +152,17 @@ class ProfilingOracle(Oracle):
             return f"matrix col: new suffix over all prefixes <- {trig}"
         return f"UNATTRIBUTED ({names[:4]})"
 
+    def _record(self, n):
+        self.total += n
+        self.sizes[self._attribute()][n] += 1
+
     def membership_query(self, string):
-        self.total += 1
-        self.buckets[self._attribute()] += 1
+        self._record(1)
         return self._inner.membership_query(string)
+
+    def membership_queries(self, strings):
+        self._record(len(strings))
+        return self._inner.membership_queries(strings)
 
 
 def profile_one(name: str) -> None:
@@ -171,8 +181,26 @@ def profile_one(name: str) -> None:
     print(f"\n\n===== QUERY ORIGINS: {name} "
           f"(states={len(dfa.states)}, acc={acc:.3f}) =====")
     print(f"total queries: {o.total:,}\n")
-    for label, n in o.buckets.most_common():
-        print(f"{n:>12,}  {100 * n / o.total:5.1f}%  {label}")
+    # A call of n strings costs ceil(n / cap) passes, so a site issuing many
+    # small calls costs far more than its query share suggests. Sorted by fp at
+    # the largest cap, where under-filled batches hurt most.
+    caps = (32, 128, 1024)
+    fp = {lab: {c: sum(math.ceil(n / c) * k for n, k in sz.items()) for c in caps}
+          for lab, sz in o.sizes.items()}
+    head = (f"{'queries':>12}{'':7}{'calls':>9}{'avg sz':>8}"
+            + "".join(f"{f'fp@{c}':>10}" for c in caps) + "  site")
+    print(head)
+    for label in sorted(o.sizes, key=lambda lab: -fp[lab][caps[-1]]):
+        sz = o.sizes[label]
+        strings, calls = sum(n * k for n, k in sz.items()), sum(sz.values())
+        print(f"{strings:>12,}{100 * strings / o.total:6.1f}%{calls:>9,}"
+              f"{strings / calls:>8.0f}"
+              + "".join(f"{fp[label][c]:>10,}" for c in caps) + f"  {label}")
+    for c in caps:
+        actual = sum(fp[lab][c] for lab in fp)
+        ideal = math.ceil(o.total / c)
+        print(f"fp@{c}: {actual:,} (ideal {ideal:,}, "
+              f"{100 * ideal / actual:.0f}% packed)")
 
 
 def main():

--- a/tests/test_batch_queries.py
+++ b/tests/test_batch_queries.py
@@ -1,0 +1,112 @@
+"""The batched MaskTable fill paths must agree, cell for cell, with per-string queries."""
+
+import unittest
+
+import numpy as np
+
+from orthogonal_dfa.l_star.mask_table import UNOBSERVED, MaskTable
+from orthogonal_dfa.l_star.structures import Oracle
+
+
+class HashOracle(Oracle):
+    """Deterministic, order-independent, and records the batch sizes it saw."""
+
+    alphabet_size = 2
+
+    def __init__(self):
+        self.calls = []
+
+    def membership_query(self, string):
+        return sum(3**i * (s + 1) for i, s in enumerate(string)) % 7 < 3
+
+    def membership_queries(self, strings):
+        self.calls.append(len(strings))
+        return super().membership_queries(strings)
+
+
+class TestMaskTableBatching(unittest.TestCase):
+    # These tests deliberately inspect MaskTable's lazy-observation internals
+    # (_masks / _ensure); there is no public API for which cells are UNOBSERVED.
+    # pylint: disable=protected-access
+    def _table(self):
+        oracle = HashOracle()
+        table = MaskTable(oracle, [[0], [1], [0, 1]], [True, True, False])
+        return oracle, table
+
+    def _assert_cells_correct(self, oracle, table):
+        for row, mask in enumerate(table._masks):
+            suffix = table.suffix(row)
+            for col, prefix in enumerate(table.prefixes):
+                observed = mask[col]
+                if observed != UNOBSERVED:
+                    self.assertEqual(
+                        bool(observed),
+                        oracle.membership_query(list(prefix) + suffix),
+                        (prefix, suffix),
+                    )
+
+    def test_add_prefixes_fills_family_columns(self):
+        # add_prefixes flattens (suffix, prefix) pairs into one call and reshapes the
+        # answers back, so the fixture has to be able to see both ways that can go
+        # wrong: 2 full columns x 3 new prefixes is non-square (a reshape with the dims
+        # swapped no longer fits), and the block is checked to be order-sensitive (a
+        # swapped comprehension order changes the values, not just the layout).
+        oracle, table = self._table()
+        full = [table.intern_suffix([1, 1]), table.intern_suffix([0, 1, 0])]
+        partial = table.intern_suffix([0])
+        for row in full:
+            table.column(row)
+        table._ensure([partial], np.array([True, False, True]))
+        new_prefixes = [[1, 1], [0, 0, 1], [1, 0, 0]]
+        block = [
+            [oracle.membership_query(p + table.suffix(r)) for p in new_prefixes]
+            for r in full
+        ]
+        self.assertNotEqual(len(full), len(new_prefixes), "fixture is reshape-blind")
+        self.assertNotEqual(
+            [c for row in block for c in row],
+            [row[j] for j in range(len(new_prefixes)) for row in block],
+            "fixture is order-blind",
+        )
+
+        table.add_prefixes(new_prefixes)
+        self._assert_cells_correct(oracle, table)
+        # The fully-observed columns stay fully observed; the partial one does not
+        # acquire cells it was never asked for.
+        for row in full:
+            self.assertFalse((table._masks[row] == UNOBSERVED).any())
+        self.assertEqual(
+            1 + len(new_prefixes), int((table._masks[partial] == UNOBSERVED).sum())
+        )
+
+    def test_ensure_queries_only_missing_cells_in_one_call(self):
+        oracle, table = self._table()
+        rows = [table.intern_suffix([1]), table.intern_suffix([0, 0])]
+        narrow = np.array([True, False, True])
+        wide = np.ones(table.num_prefixes, dtype=bool)
+        table._ensure(rows, narrow)
+        self.assertEqual([len(rows) * int(narrow.sum())], oracle.calls)
+        self._assert_cells_correct(oracle, table)
+        # Widening asks only for the cells the narrow mask left out, still in one call.
+        oracle.calls.clear()
+        table._ensure(rows, wide)
+        self.assertEqual([len(rows) * int((~narrow).sum())], oracle.calls)
+        self._assert_cells_correct(oracle, table)
+        # Everything is observed now, so a repeat asks the oracle nothing.
+        oracle.calls.clear()
+        table._ensure(rows, wide)
+        self.assertEqual([], oracle.calls)
+
+    def test_ensure_scatters_answers_to_the_right_cells(self):
+        # The scatter-back is a zip over a flat result list; a misordered zip is only
+        # visible if the cells being filled disagree with each other.
+        oracle, table = self._table()
+        rows = [table.intern_suffix([1]), table.intern_suffix([0, 0])]
+        table._ensure(rows, np.ones(table.num_prefixes, dtype=bool))
+        filled = np.array([table._masks[r] for r in rows])
+        self.assertNotEqual(filled.min(), filled.max(), "fixture is order-blind")
+        self._assert_cells_correct(oracle, table)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Prerequisite split out of #126 ("batch oracle") — the batching **infrastructure**, so #126 can rebase onto this and shrink to just the algorithmic change.

## What's here
- **`Oracle.membership_queries`** — a batch query API. Default implementation just loops over `membership_query`; real oracles may override with a single batched (e.g. neural) call. No cap on input length.
- **`MaskTable.add_prefixes` / `_ensure`** — issue one batched `membership_queries` call per fill instead of one query per cell. Behaviour-preserving: the exact same `(prefix, suffix)` pairs are queried, just grouped.
- **`count_queries` / `profile_query_origins`** — forward-pass accounting (`ceil(N / cap)` at several batch caps) so the batching's effect is measurable.
- **`tests/test_batch_queries.py`** — verifies the batched fill equals the per-string fill cell-for-cell, that `_ensure` re-queries nothing already observed, and pins the `add_prefixes` reshape/scatter ordering (non-square, order-sensitive fixtures).

## Not here (stays in #126)
The DT-classification batching (`classify_many`), the `estimate_agreement_rate` look-ahead chunking, and the `s_end` refactor — the parts that change the search trajectory and needed multi-seed validation.

## Verification
- Table fill is query-identical to `main`, just batched (tests + mutation-checked).
- pylint 10.00/10, isort+black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `batch-membership-api` vs `main`

|   | task | queries `main` | queries `batch-membership-api` | ratio | acc `main` | acc `batch-membership-api` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 875,614 | 875,614 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 1,277,963 | 1,277,963 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 916,203 | 916,203 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 5,672,298 | 5,672,298 | 1.00x | 0.977 | 0.977 | 9 |
| ⚪ | modulo_hard | 1,787,883 | 1,787,883 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 3,490,044 | 3,490,044 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **1.00x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

### Forward passes — `batch-membership-api` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 875,614 → 145,672 (0.17x, 19% packed) | 875,614 → 128,010 (0.15x, 5% packed) | 875,614 → 122,909 (0.14x, 1% packed) |
| subseq | 1,277,963 → 350,893 (0.27x, 11% packed) | 1,277,963 → 328,470 (0.26x, 3% packed) | 1,277,963 → 321,948 (0.25x, 0% packed) |
| two_subseq | 916,203 → 236,242 (0.26x, 12% packed) | 916,203 → 219,846 (0.24x, 3% packed) | 916,203 → 215,010 (0.23x, 0% packed) |
| poor_case | 5,672,298 → 2,013,108 (0.35x, 9% packed) | 5,672,298 → 1,924,695 (0.34x, 2% packed) | 5,672,298 → 1,898,859 (0.33x, 0% packed) |
| modulo_hard | 1,787,883 → 351,095 (0.20x, 16% packed) | 1,787,883 → 316,309 (0.18x, 4% packed) | 1,787,883 → 306,260 (0.17x, 1% packed) |
| modulo_asym | 3,490,044 → 629,685 (0.18x, 17% packed) | 3,490,044 → 560,663 (0.16x, 5% packed) | 3,490,044 → 540,407 (0.15x, 1% packed) |
