### PR TITLE
Add the reachability precondition to satisfies_preconditions

### DIFF
--- a/orthogonal_dfa/l_star/preconditions.py
+++ b/orthogonal_dfa/l_star/preconditions.py
@@ -7,6 +7,8 @@ the following conditions, for a particular length of uniform sampling:
 - acceptance_rate: the language does not accept or reject nearly all strings
 - class_preserving_fraction: some fraction of suffixes map all accept
   states to an accept state and all reject states to a reject state
+- infinitely_reachable_states: every non-start state is reached by infinitely
+  many strings, so the fixed-length sampler can land in it
 """
 
 from typing import List
@@ -58,6 +60,38 @@ def class_preserving_fraction(
     return preserving / num_samples
 
 
+def _reachable_from(dfa: DFA, sources) -> set:
+    """States reachable from any of ``sources`` by following transitions."""
+    seen = set(sources)
+    stack = list(seen)
+    while stack:
+        s = stack.pop()
+        for c in dfa.input_symbols:
+            t = dfa.transitions[s][c]
+            if t not in seen:
+                seen.add(t)
+                stack.append(t)
+    return seen
+
+
+def infinitely_reachable_states(dfa: DFA) -> set:
+    """The states reached by infinitely many strings from the start.
+
+    A state is reached by infinitely many strings iff it is forward-reachable
+    from a state that lies on a cycle: pump the cycle for unboundedly many
+    prefixes, then walk on to the state. Every other reachable state is reached
+    by only finitely many (short) strings -- a transient state a fixed-length
+    prefix sampler almost never lands in, so the learner cannot build it.
+    """
+    reachable = _reachable_from(dfa, [dfa.initial_state])
+    on_cycle = {
+        q
+        for q in reachable
+        if q in _reachable_from(dfa, [dfa.transitions[q][c] for c in dfa.input_symbols])
+    }
+    return _reachable_from(dfa, on_cycle)
+
+
 def satisfies_preconditions(
     dfa: DFA,
     *,
@@ -66,16 +100,22 @@ def satisfies_preconditions(
     min_class_preserving_frac: float = 0.05,
     num_samples: int = DEFAULT_NUM_SAMPLES,
 ) -> bool:
-    """True iff ``dfa`` meets every learnability precondition, under
-    length-``length`` uniform sampling:
+    """True iff ``dfa`` meets every learnability precondition:
 
     - acceptance rate in ``[min_accept_or_reject, 1 - min_accept_or_reject]``;
-    - class-preserving fraction at least ``min_class_preserving_frac``.
+    - class-preserving fraction at least ``min_class_preserving_frac``;
+    - every state other than the start is reached by infinitely many strings
+      (the start is exempt -- it is always accessible via the empty string).
 
-    Checks run in increasing cost and short-circuit on the first failure.
+    The first two are sampled under length-``length`` uniform sampling; the last
+    is an exact graph property. Checks run in increasing cost and short-circuit
+    on the first failure.
     """
     rate = acceptance_rate(dfa, length=length, num_samples=num_samples)
     if not min_accept_or_reject <= rate <= 1 - min_accept_or_reject:
         return False
     cp = class_preserving_fraction(dfa, length=length, num_samples=num_samples)
-    return cp >= min_class_preserving_frac
+    if cp < min_class_preserving_frac:
+        return False
+    infinite = infinitely_reachable_states(dfa)
+    return all(q in infinite for q in dfa.states if q != dfa.initial_state)

--- a/tests/test_preconditions.py
+++ b/tests/test_preconditions.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 import unittest
 
 from automata.fa.dfa import DFA
@@ -11,6 +12,23 @@ MOD3 = DFA(
     transitions={0: {0: 0, 1: 1}, 1: {0: 1, 1: 2}, 2: {0: 2, 1: 0}},
     initial_state=0,
     final_states={1},
+    allow_partial=False,
+)
+
+# {w : |w| >= 3 and w[2] == 0}: states 0,1,2 are transient (issue #128), 3/4 are
+# absorbing sinks. No fixed-length string ends in 0/1/2.
+DIFFICULT09 = DFA(
+    states={0, 1, 2, 3, 4},
+    input_symbols={0, 1},
+    transitions={
+        0: {0: 1, 1: 1},
+        1: {0: 2, 1: 2},
+        2: {0: 3, 1: 4},
+        3: {0: 3, 1: 3},
+        4: {0: 4, 1: 4},
+    },
+    initial_state=0,
+    final_states={3},
     allow_partial=False,
 )
 
@@ -40,6 +58,27 @@ class TestMeasures(unittest.TestCase):
         self.assertTrue(0.0 <= frac <= 1.0)
 
 
+class TestReachability(unittest.TestCase):
+    def test_infinitely_reachable_states(self):
+        # MOD3 is strongly connected: every state lies on a cycle.
+        self.assertEqual(P.infinitely_reachable_states(MOD3), set(MOD3.states))
+        # DIFFICULT09: only the two absorbing sinks; 0/1/2 are transient.
+        self.assertEqual(P.infinitely_reachable_states(DIFFICULT09), {3, 4})
+
+    def test_start_state_is_exempt(self):
+        # A start reached only by the empty string (nothing cycles back) is not
+        # infinitely reachable, but must not fail the precondition.
+        dfa = DFA(
+            states={0, 1},
+            input_symbols={0, 1},
+            transitions={0: {0: 1, 1: 1}, 1: {0: 1, 1: 1}},
+            initial_state=0,
+            final_states={1},
+            allow_partial=False,
+        )
+        self.assertEqual(P.infinitely_reachable_states(dfa), {1})
+
+
 class TestSatisfiesPreconditions(unittest.TestCase):
     def test_balanced_target_passes(self):
         self.assertTrue(P.satisfies_preconditions(MOD3, length=40))
@@ -47,6 +86,15 @@ class TestSatisfiesPreconditions(unittest.TestCase):
     def test_degenerate_acceptance_rate_fails(self):
         self.assertFalse(P.satisfies_preconditions(_constant_dfa({0}), length=40))
         self.assertFalse(P.satisfies_preconditions(_constant_dfa(set()), length=40))
+
+    def test_reachability_catches_transient_states(self):
+        # Difficult09 is balanced and class-preserving, so only the reachability
+        # condition catches it: non-start states 1/2 are not infinitely reachable.
+        self.assertTrue(0.15 <= P.acceptance_rate(DIFFICULT09, length=40) <= 0.85)
+        self.assertGreaterEqual(
+            P.class_preserving_fraction(DIFFICULT09, length=40), 0.05
+        )
+        self.assertFalse(P.satisfies_preconditions(DIFFICULT09, length=40))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Stacked on #135** (extract generator filters) — review/merge that first. This PR's diff is only the reachability additions.

## What

Adds, on top of the extracted `acceptance_rate` / `class_preserving_fraction` measures:

- **`infinitely_reachable_states(dfa)`** — the states reached by infinitely many strings (forward-reachable from a cycle), computed exactly (no sampling). Every other reachable state is transient: reached by only finitely many short strings, so a fixed-length prefix sampler never lands in it and the learner cannot build it (#128).
- **`satisfies_preconditions(dfa, *, length, ...)`** — the single learnability check: balanced acceptance, class-preserving, and **every non-start state infinitely reachable**. The start is exempt — it's always accessible via the empty string.

## Why this reachability rule

It's the structural condition for *exact* learnability, and it's symmetric (no accept/reject asymmetry). `Difficult09` (`{w : |w|>=3 and w[2]==0}`) is balanced **and** class-preserving, yet its non-start states 1,2 are transient — so only this condition catches it, and it's exactly why the learner collapses to a 2-state "reject everything" hypothesis there.

Note this flags any DFA with a transient non-start state, including generated benchmarks that still learn to ~97% (their transient state is low-measure). That's correct: it's a precondition for *exact* learnability, and those aren't exactly learnable — the 97% is the low measure of the missed state. So `sample_balanced_benchmark` deliberately still applies only the two sampled filters, not this one.