### PR TITLE
Extract the benchmark generator's filters into a preconditions module

### DIFF
--- a/orthogonal_dfa/l_star/examples/benchmark_generator.py
+++ b/orthogonal_dfa/l_star/examples/benchmark_generator.py
@@ -29,7 +29,7 @@ import numpy as np
 from automata.fa.dfa import DFA
 from automata.fa.nfa import NFA
 
-from orthogonal_dfa.l_star.sampler import UniformSampler
+from orthogonal_dfa.l_star import preconditions
 from orthogonal_dfa.l_star.structures import NoiseModel, Oracle
 from orthogonal_dfa.utils.dfa import al_dfa_symbols_to_int, al_dfa_symbols_to_str
 
@@ -141,34 +141,6 @@ def sample_star_l_star(
     return outer, inner, separator_char
 
 
-def _frac_strings_preserving(
-    dfa: DFA, probe_len: int, num_strings: int, rng: np.random.Generator
-) -> float:
-    """Fraction of random length-*probe_len* strings s for which every state q
-    satisfies ``(q in F) == (δ*(q, s) in F)``. Low values indicate there is
-    essentially no suffix that acts as a "class-preserving reset" across the
-    whole state set — a regime that appears to confuse L* synthesis (see
-    `test_undersampled_transitions_poor_case`).
-    """
-    alphabet = sorted(dfa.input_symbols)
-    states = list(dfa.states)
-    finals = dfa.final_states
-    strings_ok = 0
-    for _ in range(num_strings):
-        s = rng.choice(alphabet, size=probe_len).tolist()
-        ok = True
-        for q in states:
-            cur = q
-            for c in s:
-                cur = dfa.transitions[cur][c]
-            if (q in finals) != (cur in finals):
-                ok = False
-                break
-        if ok:
-            strings_ok += 1
-    return strings_ok / num_strings
-
-
 def sample_balanced_benchmark(
     seed: int,
     *,
@@ -212,8 +184,6 @@ def sample_balanced_benchmark(
     ------
     RuntimeError if no candidate passes the filters within ``max_attempts``.
     """
-    sampler = UniformSampler(probe_length)
-    probe_rng = np.random.default_rng(seed)
     for sub in range(max_attempts):
         rng = np.random.default_rng((seed, sub))
         outer, inner, sep = sample_star_l_star(
@@ -223,20 +193,13 @@ def sample_balanced_benchmark(
         )
         if len(outer.states) != num_outer_states:
             continue
-        rate = (
-            sum(
-                outer.accepts_input(sampler.sample(probe_rng, alphabet_size))
-                for _ in range(num_probe_samples)
-            )
-            / num_probe_samples
+        rate = preconditions.acceptance_rate(
+            outer, length=probe_length, num_samples=num_probe_samples
         )
         if not min_accept_or_reject <= rate <= 1 - min_accept_or_reject:
             continue
-        cp_frac = _frac_strings_preserving(
-            outer,
-            probe_len=probe_length,
-            num_strings=num_class_preserving_samples,
-            rng=np.random.default_rng((seed, sub)),
+        cp_frac = preconditions.class_preserving_fraction(
+            outer, length=probe_length, num_samples=num_class_preserving_samples
         )
         if cp_frac < min_class_preserving_frac:
             continue

--- a/orthogonal_dfa/l_star/preconditions.py
+++ b/orthogonal_dfa/l_star/preconditions.py
@@ -1,0 +1,81 @@
+"""
+Preconditions for E-L* learnability of a target DFA.
+
+satisfies_preconditions(dfa, *, length, ...) is the main check, checking
+the following conditions, for a particular length of uniform sampling:
+
+- acceptance_rate: the language does not accept or reject nearly all strings
+- class_preserving_fraction: some fraction of suffixes map all accept
+  states to an accept state and all reject states to a reject state
+"""
+
+from typing import List
+
+import numpy as np
+from automata.fa.dfa import DFA
+
+DEFAULT_NUM_SAMPLES = 2000
+
+
+def _random_string(dfa: DFA, length: int, rng: np.random.Generator) -> List[int]:
+    """A uniform random string of ``length`` symbols over the DFA's alphabet."""
+    return rng.choice(sorted(dfa.input_symbols), size=length).tolist()
+
+
+def _endpoint(dfa: DFA, string: List[int], start=None):
+    """The state reached by running ``string`` from ``start`` (default q0)."""
+    q = dfa.initial_state if start is None else start
+    for c in string:
+        q = dfa.transitions[q][c]
+    return q
+
+
+def acceptance_rate(
+    dfa: DFA, *, length: int, num_samples: int = DEFAULT_NUM_SAMPLES
+) -> float:
+    """Fraction of random length-``length`` strings the DFA accepts."""
+    rng = np.random.default_rng(0)
+    accepts = sum(
+        _endpoint(dfa, _random_string(dfa, length, rng)) in dfa.final_states
+        for _ in range(num_samples)
+    )
+    return accepts / num_samples
+
+
+def class_preserving_fraction(
+    dfa: DFA, *, length: int, num_samples: int = DEFAULT_NUM_SAMPLES
+) -> float:
+    """Fraction of random length-``length`` strings ``s`` for which *every*
+    state ``q`` satisfies ``(q in F) == (delta*(q, s) in F)`` -- the suffixes
+    that reset the whole state set into a single accept/reject class."""
+    rng = np.random.default_rng(0)
+    finals = dfa.final_states
+    states = list(dfa.states)
+    preserving = sum(
+        all((q in finals) == (_endpoint(dfa, s, q) in finals) for q in states)
+        for s in (_random_string(dfa, length, rng) for _ in range(num_samples))
+    )
+    return preserving / num_samples
+
+
+def satisfies_preconditions(
+    dfa: DFA,
+    *,
+    length: int,
+    min_accept_or_reject: float = 0.15,
+    min_class_preserving_frac: float = 0.05,
+    num_samples: int = DEFAULT_NUM_SAMPLES,
+) -> bool:
+    """True iff ``dfa`` meets every learnability precondition, under
+    length-``length`` uniform sampling:
+
+    - acceptance rate in ``[min_accept_or_reject, 1 - min_accept_or_reject]``;
+    - class-preserving fraction at least ``min_class_preserving_frac``.
+
+    Checks run in increasing cost and short-circuit on the first failure.
+    """
+    rate = acceptance_rate(dfa, length=length, num_samples=num_samples)
+    if not min_accept_or_reject <= rate <= 1 - min_accept_or_reject:
+        return False
+    cp = class_preserving_fraction(dfa, length=length, num_samples=num_samples)
+    return cp >= min_class_preserving_frac

--- a/tests/test_preconditions.py
+++ b/tests/test_preconditions.py
@@ -1,0 +1,53 @@
+import unittest
+
+from automata.fa.dfa import DFA
+
+from orthogonal_dfa.l_star import preconditions as P
+
+# mod-3 counter on 1s: strongly connected, balanced under uniform sampling.
+MOD3 = DFA(
+    states={0, 1, 2},
+    input_symbols={0, 1},
+    transitions={0: {0: 0, 1: 1}, 1: {0: 1, 1: 2}, 2: {0: 2, 1: 0}},
+    initial_state=0,
+    final_states={1},
+    allow_partial=False,
+)
+
+
+def _constant_dfa(final_states):
+    return DFA(
+        states={0},
+        input_symbols={0, 1},
+        transitions={0: {0: 0, 1: 0}},
+        initial_state=0,
+        final_states=final_states,
+        allow_partial=False,
+    )
+
+
+class TestMeasures(unittest.TestCase):
+    def test_acceptance_rate_degenerate_languages(self):
+        self.assertEqual(
+            P.acceptance_rate(_constant_dfa({0}), length=40, num_samples=200), 1.0
+        )
+        self.assertEqual(
+            P.acceptance_rate(_constant_dfa(set()), length=40, num_samples=200), 0.0
+        )
+
+    def test_class_preserving_fraction_in_unit_interval(self):
+        frac = P.class_preserving_fraction(MOD3, length=40, num_samples=500)
+        self.assertTrue(0.0 <= frac <= 1.0)
+
+
+class TestSatisfiesPreconditions(unittest.TestCase):
+    def test_balanced_target_passes(self):
+        self.assertTrue(P.satisfies_preconditions(MOD3, length=40))
+
+    def test_degenerate_acceptance_rate_fails(self):
+        self.assertFalse(P.satisfies_preconditions(_constant_dfa({0}), length=40))
+        self.assertFalse(P.satisfies_preconditions(_constant_dfa(set()), length=40))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Moves the two filters `sample_balanced_benchmark` applies — acceptance balance and class-preservation — out of the generator into a new `orthogonal_dfa/l_star/preconditions.py`, behind a single `satisfies_preconditions(dfa, *, length, ...)` check:

- `acceptance_rate(dfa, *, length, num_samples)`
- `class_preserving_fraction(dfa, *, length, num_samples)` — was the generator's private `_frac_strings_preserving`

So the same check applies to any DFA (generated or hand-written) with one implementation.

## RNG / benchmarks

The measures sample with a fixed internal seed rather than an injected generator, so `sample_balanced_benchmark` no longer threads specific RNG streams through them. This drops the byte-identical guarantee: **the 10-state generated benchmarks (`test_generated_benchmark`) are unchanged**, but a few of the rarer **18-state** ones (`test_large_generated_benchmark`) differ — still balanced and class-preserving, so still learnable, but re-verified by CI rather than by construction.

## Follow-up

The reachability precondition and its condition in `satisfies_preconditions` land in a separate PR stacked on top (#133).