### PR TITLE
Add the upstream CAPAL bridge + CI smoke tests

### DIFF
--- a/orthogonal_dfa/capal_official/__init__.py
+++ b/orthogonal_dfa/capal_official/__init__.py
@@ -1,0 +1,28 @@
+"""Adapter that runs the official CAPAL implementation against this repo's
+oracles.
+
+The upstream code lives at github.com/lkwargs/CAPAL, expected as a sibling
+checkout at `../capal` (override with $ORTHO_CAPAL_DIR). We import it via
+sys.path insertion -- it is a single-file module with no installable package
+layout -- after checking it sits at the pinned commit with a clean tree, so
+the numbers in data/capal_findings.md stay reproducible. This adapter:
+
+- Constructs the noiseless target DFA for each of our oracle creators (their
+  CAPALLearner needs a target DFA so PerfectEQ can do a BFS product
+  counterexample search).
+- Runs the official `CAPALLearner.fit()` with the user's eta and seed.
+- Returns a callable that evaluates the learned DFA against a noiseless
+  ground-truth sampler.
+"""
+
+from .adapter import (
+    DEFAULT_CAPAL_DIR,
+    PINNED_COMMIT,
+    build_modulo_dfa,
+    build_regex_dfa,
+    evaluate_official_dfa,
+    import_capal,
+    resolve_capal_dir,
+    run_official_capal,
+    verify_pinned,
+)

--- a/orthogonal_dfa/capal_official/__init__.py
+++ b/orthogonal_dfa/capal_official/__init__.py
@@ -18,11 +18,10 @@ the numbers in data/capal_findings.md stay reproducible. This adapter:
 from .adapter import (
     DEFAULT_CAPAL_DIR,
     PINNED_COMMIT,
-    build_modulo_dfa,
-    build_regex_dfa,
     evaluate_official_dfa,
     import_capal,
     resolve_capal_dir,
     run_official_capal,
     verify_pinned,
 )
+from .porters import build_modulo_dfa, build_regex_dfa

--- a/orthogonal_dfa/capal_official/__init__.py
+++ b/orthogonal_dfa/capal_official/__init__.py
@@ -10,18 +10,22 @@ the numbers in data/capal_findings.md stay reproducible. This adapter:
 - Constructs the noiseless target DFA for each of our oracle creators (their
   CAPALLearner needs a target DFA so PerfectEQ can do a BFS product
   counterexample search).
-- Runs the official `CAPALLearner.fit()` with the user's eta and seed.
-- Returns a callable that evaluates the learned DFA against a noiseless
-  ground-truth sampler.
+- Builds the official `CAPALLearner` with the user's eta and seed, and runs
+  `.fit()` with the iteration cap treated as a non-convergent result rather
+  than an error.
+
+Scoring the learned DFA is the caller's job -- see
+`orthogonal_dfa.experiments.capal_comparison`, which scores every learner on
+one shared word list.
 """
 
 from .adapter import (
     DEFAULT_CAPAL_DIR,
     PINNED_COMMIT,
-    evaluate_official_dfa,
+    fit_with_fallback,
     import_capal,
+    make_learner,
     resolve_capal_dir,
-    run_official_capal,
     verify_pinned,
 )
 from .porters import build_modulo_dfa, build_regex_dfa

--- a/orthogonal_dfa/capal_official/__init__.py
+++ b/orthogonal_dfa/capal_official/__init__.py
@@ -1,8 +1,8 @@
-"""Run the official CAPAL learner (github.com/lkwargs/CAPAL) against this repo's
-oracles.
+"""
+Run the baseline CAPAL learner (github.com/lkwargs/CAPAL) against this repo's oracles.
 
-Upstream is a pinned sibling checkout at `../capal`. Scoring the learned DFA is
-the caller's job -- see `orthogonal_dfa.experiments.capal_comparison`.
+Upstream is a pinned sibling checkout at `../capal`.
+Scoring the learned DFA is the caller's job, see `orthogonal_dfa.experiments.capal_comparison`.
 """
 
 from .adapter import (

--- a/orthogonal_dfa/capal_official/__init__.py
+++ b/orthogonal_dfa/capal_official/__init__.py
@@ -1,22 +1,9 @@
-"""Adapter that runs the official CAPAL implementation against this repo's
+"""Run the official CAPAL learner (github.com/lkwargs/CAPAL) against this repo's
 oracles.
 
-The upstream code lives at github.com/lkwargs/CAPAL, expected as a sibling
-checkout at `../capal` (override with $ORTHO_CAPAL_DIR). We import it via
-sys.path insertion -- it is a single-file module with no installable package
-layout -- after checking it sits at the pinned commit with a clean tree, so
-the numbers in data/capal_findings.md stay reproducible. This adapter:
-
-- Constructs the noiseless target DFA for each of our oracle creators (their
-  CAPALLearner needs a target DFA so PerfectEQ can do a BFS product
-  counterexample search).
-- Builds the official `CAPALLearner` with the user's eta and seed, and runs
-  `.fit()` with the iteration cap treated as a non-convergent result rather
-  than an error.
-
-Scoring the learned DFA is the caller's job -- see
-`orthogonal_dfa.experiments.capal_comparison`, which scores every learner on
-one shared word list.
+Upstream is a pinned sibling checkout at `../capal` ($ORTHO_CAPAL_DIR to
+override). Scoring the learned DFA is the caller's job -- see
+`orthogonal_dfa.experiments.capal_comparison`.
 """
 
 from .adapter import (

--- a/orthogonal_dfa/capal_official/__init__.py
+++ b/orthogonal_dfa/capal_official/__init__.py
@@ -1,9 +1,8 @@
 """Run the official CAPAL learner (github.com/lkwargs/CAPAL) against this repo's
 oracles.
 
-Upstream is a pinned sibling checkout at `../capal` ($ORTHO_CAPAL_DIR to
-override). Scoring the learned DFA is the caller's job -- see
-`orthogonal_dfa.experiments.capal_comparison`.
+Upstream is a pinned sibling checkout at `../capal`. Scoring the learned DFA is
+the caller's job -- see `orthogonal_dfa.experiments.capal_comparison`.
 """
 
 from .adapter import (

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -3,15 +3,13 @@
 Loads the upstream `capal` module from the pinned checkout (see
 `resolve_capal_dir`), then exposes:
 
-- build_modulo_dfa(modulo, allowed): the explicit modulo-counting DFA used by
-  BernoulliParityOracle, in the upstream `capal.DFA` format.
-- build_regex_dfa(regex, alphabet_size): regex -> upstream DFA via automata-lib
-  (NFA.from_regex -> DFA.from_nfa, then state-relabel).
 - run_official_capal(target, eta, ...): instantiate CAPALLearner with the
   PersistentNoisyMQ + PerfectEQ defaults and call .fit().
 - evaluate_official_dfa(dfa, oracle_creator, alphabet_chars, symbols): sample
   uniformly random words, query the noiseless oracle for ground truth, count
   matches.
+
+Building the target DFAs upstream needs lives in `porters`.
 """
 
 from __future__ import annotations
@@ -20,7 +18,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Iterable, Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import numpy as np
 
@@ -130,48 +128,6 @@ def import_capal(capal_dir: Optional[str] = None) -> Any:
 
 def _require_official() -> Any:
     return import_capal()
-
-
-def build_modulo_dfa(modulo: int, allowed: Iterable[int]) -> Any:
-    """The 'sum mod N in allowed?' DFA over {'0','1'}, in upstream format."""
-    M = _require_official()
-    delta = {}
-    for q in range(modulo):
-        delta[(q, "0")] = q
-        delta[(q, "1")] = (q + 1) % modulo
-    return M.DFA(
-        alphabet=["0", "1"],
-        num_states=modulo,
-        start=0,
-        accept={int(x) for x in allowed},
-        delta=delta,
-    )
-
-
-def build_regex_dfa(regex: str, alphabet_size: int = 2) -> Any:
-    """Compile `regex` to a minimal DFA in upstream format. Symbols are the
-    characters '0', '1', ... matching BernoulliRegex's int->str convention."""
-    from automata.fa.dfa import DFA as AutDFA
-    from automata.fa.nfa import NFA
-
-    M = _require_official()
-    syms = {str(i) for i in range(alphabet_size)}
-    nfa = NFA.from_regex(regex, input_symbols=syms)
-    aut = AutDFA.from_nfa(nfa, minify=True)
-
-    state_list = sorted(aut.states, key=lambda s: (str(type(s).__name__), str(s)))
-    sidx = {s: i for i, s in enumerate(state_list)}
-    delta = {}
-    for s in state_list:
-        for a, dest in aut.transitions[s].items():
-            delta[(sidx[s], a)] = sidx[dest]
-    return M.DFA(
-        alphabet=sorted(aut.input_symbols),
-        num_states=len(state_list),
-        start=sidx[aut.initial_state],
-        accept={sidx[s] for s in aut.final_states},
-        delta=delta,
-    )
 
 
 def run_official_capal(

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -30,6 +30,9 @@ PINNED_COMMIT = "57d877f6a083d58852660fac388ff49c052dc2d2"
 
 CAPAL_DIR_ENV = "ORTHO_CAPAL_DIR"
 
+#: What upstream's fit() says when it runs out of iterations (capal.py:1294).
+CAP_MESSAGE = "Maximum iterations reached without convergence"
+
 #: Default checkout: a sibling of the repo root.
 DEFAULT_CAPAL_DIR = Path(__file__).resolve().parents[2].parent / "capal"
 
@@ -183,6 +186,13 @@ def fit_with_fallback(learner: Any) -> Tuple[Optional[Any], bool]:
     """
     try:
         return learner.fit(), True
-    except RuntimeError:
+    except RuntimeError as exc:
+        # The cap is upstream's only RuntimeError, but RecursionError is a
+        # subclass of it, so without this the interpreter's own failures would
+        # be recorded as ordinary non-convergent runs. Matching on the message
+        # is safe here only because the pin locks it: it cannot change without
+        # verify_pinned failing first.
+        if CAP_MESSAGE not in str(exc):
+            raise
         last = getattr(learner, "_last_hyp", None)
         return getattr(last, "dfa", None), False

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -1,0 +1,257 @@
+"""Bridge between this repo's Oracle/test-harness and the official CAPAL repo.
+
+Loads the upstream `capal` module from the pinned checkout (see
+`resolve_capal_dir`), then exposes:
+
+- build_modulo_dfa(modulo, allowed): the explicit modulo-counting DFA used by
+  BernoulliParityOracle, in the upstream `capal.DFA` format.
+- build_regex_dfa(regex, alphabet_size): regex -> upstream DFA via automata-lib
+  (NFA.from_regex -> DFA.from_nfa, then state-relabel).
+- run_official_capal(target, eta, ...): instantiate CAPALLearner with the
+  PersistentNoisyMQ + PerfectEQ defaults and call .fit().
+- evaluate_official_dfa(dfa, oracle_creator, alphabet_chars, symbols): sample
+  uniformly random words, query the noiseless oracle for ground truth, count
+  matches.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+
+import numpy as np
+
+UPSTREAM_URL = "https://github.com/lkwargs/CAPAL"
+
+#: The single source of truth for the commit every number in
+#: `data/capal_findings.md` was measured against. Bumping it means re-measuring.
+PINNED_COMMIT = "57d877f6a083d58852660fac388ff49c052dc2d2"
+
+#: Env var to point at a checkout elsewhere; otherwise a sibling of the repo.
+CAPAL_DIR_ENV = "ORTHO_CAPAL_DIR"
+
+#: Default checkout location, resolved relative to the repo root rather than
+#: the cwd, so it does not matter where a caller is invoked from.
+DEFAULT_CAPAL_DIR = Path(__file__).resolve().parents[2].parent / "capal"
+
+_official: Any = None
+
+
+def resolve_capal_dir(capal_dir: Optional[str] = None) -> Path:
+    """Upstream checkout: explicit `capal_dir`, else $ORTHO_CAPAL_DIR, else
+    `../capal`."""
+    override = capal_dir or os.environ.get(CAPAL_DIR_ENV)
+    if override:
+        return Path(override).expanduser().resolve()
+    return DEFAULT_CAPAL_DIR
+
+
+def _git(path: Path, *args: str) -> str:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(path), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "git not found on PATH; cannot verify the pinned CAPAL checkout."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"`git {' '.join(args)}` failed in {path}: "
+            f"{exc.stderr.strip() or exc}. Expected a clone of {UPSTREAM_URL}."
+        ) from exc
+    return out.stdout.strip()
+
+
+def verify_pinned(path: Path) -> None:
+    """Raise unless `path` is a clean checkout at PINNED_COMMIT.
+
+    Reproducibility guard: `data/capal_findings.md` is only meaningful against
+    this exact commit with no local modifications.
+    """
+    if not path.exists():
+        raise RuntimeError(
+            f"No CAPAL checkout at {path}. Clone {UPSTREAM_URL} there and "
+            f"`git checkout {PINNED_COMMIT}`, or set ${CAPAL_DIR_ENV}."
+        )
+    if not (path / "capal.py").exists():
+        raise RuntimeError(
+            f"{path} contains no capal.py; expected a clone of {UPSTREAM_URL}."
+        )
+
+    head = _git(path, "rev-parse", "HEAD")
+    if head != PINNED_COMMIT:
+        raise RuntimeError(
+            f"CAPAL checkout at {path} is at the wrong commit "
+            f"(expected {PINNED_COMMIT}, found {head}). data/capal_findings.md "
+            f"was measured against the expected commit; others are not "
+            f"comparable. Run: git -C {path} checkout {PINNED_COMMIT}"
+        )
+
+    dirty = _git(path, "status", "--porcelain")
+    if dirty:
+        raise RuntimeError(
+            f"CAPAL checkout at {path} has local modifications, so results "
+            f"would not be reproducible:\n{dirty}"
+        )
+
+
+def import_capal(capal_dir: Optional[str] = None) -> Any:
+    """Verify the pin, then import upstream's single-file `capal` module.
+
+    Deliberately lazy and cached: importing this package must not fail just
+    because the checkout is missing, but *using* it against an unpinned tree
+    must.
+    """
+    global _official  # pylint: disable=global-statement
+    if _official is not None:
+        return _official
+    path = resolve_capal_dir(capal_dir)
+    verify_pinned(path)
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+    # Dynamic path-based import of upstream's single-file module; pylint cannot
+    # see it and there is nothing to import at module load time.
+    import capal  # type: ignore[import-not-found]  # pylint: disable=import-error,import-outside-toplevel
+
+    # A stray `capal` package/module elsewhere on sys.path would satisfy this
+    # import silently, giving wrong results rather than an error. Check.
+    loaded = getattr(capal, "__file__", None)
+    if loaded is None or Path(loaded).resolve().parent != path:
+        raise RuntimeError(
+            f"`import capal` resolved to {loaded or '<namespace package>'}, "
+            f"not the pinned checkout at {path}. Something on sys.path is "
+            f"shadowing upstream CAPAL."
+        )
+    _official = capal
+    return _official
+
+
+def _require_official() -> Any:
+    return import_capal()
+
+
+def build_modulo_dfa(modulo: int, allowed: Iterable[int]) -> Any:
+    """The 'sum mod N in allowed?' DFA over {'0','1'}, in upstream format."""
+    M = _require_official()
+    delta = {}
+    for q in range(modulo):
+        delta[(q, "0")] = q
+        delta[(q, "1")] = (q + 1) % modulo
+    return M.DFA(
+        alphabet=["0", "1"],
+        num_states=modulo,
+        start=0,
+        accept={int(x) for x in allowed},
+        delta=delta,
+    )
+
+
+def build_regex_dfa(regex: str, alphabet_size: int = 2) -> Any:
+    """Compile `regex` to a minimal DFA in upstream format. Symbols are the
+    characters '0', '1', ... matching BernoulliRegex's int->str convention."""
+    from automata.fa.dfa import DFA as AutDFA
+    from automata.fa.nfa import NFA
+
+    M = _require_official()
+    syms = {str(i) for i in range(alphabet_size)}
+    nfa = NFA.from_regex(regex, input_symbols=syms)
+    aut = AutDFA.from_nfa(nfa, minify=True)
+
+    state_list = sorted(aut.states, key=lambda s: (str(type(s).__name__), str(s)))
+    sidx = {s: i for i, s in enumerate(state_list)}
+    delta = {}
+    for s in state_list:
+        for a, dest in aut.transitions[s].items():
+            delta[(sidx[s], a)] = sidx[dest]
+    return M.DFA(
+        alphabet=sorted(aut.input_symbols),
+        num_states=len(state_list),
+        start=sidx[aut.initial_state],
+        accept={sidx[s] for s in aut.final_states},
+        delta=delta,
+    )
+
+
+def run_official_capal(
+    target: Any,
+    eta: float,
+    *,
+    max_iters: int = 200,
+    seed: int = 0,
+    verbose: bool = False,
+    K_pos: int = 10,
+    K_neg: int = 10,
+    max_same_samples: int = 60,
+    tau_cap: float = 0.2,
+    suffix_pool_init: int = 32,
+    suffix_pool_len_max: int = 8,
+    alpha: float = 1e-3,
+) -> Any:
+    """Instantiate CAPALLearner with upstream defaults (PersistentNoisyMQ +
+    PerfectEQ are built automatically from `target`) and return the learned
+    `capal.DFA`."""
+    M = _require_official()
+    cfg = M.LearnerConfig(
+        K_pos=K_pos,
+        K_neg=K_neg,
+        max_iters=max_iters,
+        seed=seed,
+        eta=eta,
+        alpha=alpha,
+        max_same_samples=max_same_samples,
+        tau_cap=tau_cap,
+        suffix_pool_init=suffix_pool_init,
+        suffix_pool_len_max=suffix_pool_len_max,
+        verbose=verbose,
+    )
+    learner = M.CAPALLearner(target=target, cfg=cfg)
+    try:
+        return learner.fit()
+    except RuntimeError:
+        # `fit()` raises when max_iters elapses without PerfectEQ accepting --
+        # under noise this is common because SAMESTATE may make a handful of
+        # false-DIFFERENT decisions, leaving the hypothesis larger than the
+        # target. Return the latest hypothesis so we can still measure its
+        # accuracy (the user wants accuracy at noise level, not just the
+        # converged/not bit).
+        last = getattr(learner, "_last_hyp", None)
+        if last is not None and getattr(last, "dfa", None) is not None:
+            last.dfa.converged = False  # type: ignore[attr-defined]
+            return last.dfa
+        raise
+
+
+def evaluate_official_dfa(
+    dfa: Any,
+    oracle_creator,
+    alphabet_chars: Sequence[str],
+    symbols: int,
+    *,
+    count: int = 5000,
+    rng_seed: int = 0x1234,
+) -> float:
+    """Sample random words via the repo's UniformSampler, ask the noiseless
+    oracle for the truth label, and ask the upstream DFA for its label.
+    Returns accuracy."""
+    from orthogonal_dfa.l_star.sampler import UniformSampler
+    from orthogonal_dfa.l_star.structures import SymmetricBernoulli
+
+    us = UniformSampler(40)
+    truth = oracle_creator(SymmetricBernoulli(p_correct=1.0), 0)
+    rng = np.random.default_rng(rng_seed)
+    correct = 0
+    for _ in range(count):
+        s = us.sample(rng, symbols)
+        truth_label = bool(truth.membership_query(s))
+        word = "".join(alphabet_chars[c] for c in s)
+        pred = bool(dfa.run(word))
+        if pred == truth_label:
+            correct += 1
+    return correct / count

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -3,11 +3,14 @@
 Loads the upstream `capal` module from the pinned checkout (see
 `resolve_capal_dir`), then exposes:
 
-- run_official_capal(target, eta, ...): instantiate CAPALLearner with the
-  PersistentNoisyMQ + PerfectEQ defaults and call .fit().
-- evaluate_official_dfa(dfa, oracle_creator, alphabet_chars, symbols): sample
-  uniformly random words, query the noiseless oracle for ground truth, count
-  matches.
+- make_learner(target, eta, ...): a CAPALLearner wired to the PersistentNoisyMQ
+  + PerfectEQ defaults, returned unfitted so callers can instrument it.
+- fit_with_fallback(learner): .fit(), plus whether it converged.
+
+The two are split because callers need to reach the learner in between -- to
+count queries by wrapping `learner.mq.query`, to time the fit, or to suppress
+upstream's stdout. Scoring is deliberately not here: a comparison must score
+every learner on one shared word list, which only the caller can build.
 
 Building the target DFAs upstream needs lives in `porters`.
 """
@@ -18,9 +21,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Optional, Sequence
-
-import numpy as np
+from typing import Any, Optional, Tuple
 
 UPSTREAM_URL = "https://github.com/lkwargs/CAPAL"
 
@@ -126,32 +127,35 @@ def import_capal(capal_dir: Optional[str] = None) -> Any:
     return _official
 
 
-def _require_official() -> Any:
-    return import_capal()
-
-
-def run_official_capal(
+def make_learner(
     target: Any,
     eta: float,
     *,
     max_iters: int = 200,
     seed: int = 0,
     verbose: bool = False,
-    K_pos: int = 10,
-    K_neg: int = 10,
+    k_pos: int = 10,
+    k_neg: int = 10,
     max_same_samples: int = 60,
     tau_cap: float = 0.2,
     suffix_pool_init: int = 32,
     suffix_pool_len_max: int = 8,
     alpha: float = 1e-3,
+    enum_depth: int = 3,
+    extra_len_max: int = 8,
 ) -> Any:
-    """Instantiate CAPALLearner with upstream defaults (PersistentNoisyMQ +
-    PerfectEQ are built automatically from `target`) and return the learned
-    `capal.DFA`."""
-    M = _require_official()
-    cfg = M.LearnerConfig(
-        K_pos=K_pos,
-        K_neg=K_neg,
+    """A CAPALLearner over `target`, unfitted (PersistentNoisyMQ + PerfectEQ are
+    built from `target` by upstream).
+
+    `enum_depth` / `extra_len_max` bound how many and how long the SAMESTATE
+    suffixes are -- the matched-query-budget knob. LearnerConfig does not
+    forward them, so they are set on the live SameStateConfig, which SAMESTATE
+    reads lazily during fit().
+    """
+    official = import_capal()
+    cfg = official.LearnerConfig(
+        K_pos=k_pos,
+        K_neg=k_neg,
         max_iters=max_iters,
         seed=seed,
         eta=eta,
@@ -162,43 +166,23 @@ def run_official_capal(
         suffix_pool_len_max=suffix_pool_len_max,
         verbose=verbose,
     )
-    learner = M.CAPALLearner(target=target, cfg=cfg)
+    learner = official.CAPALLearner(target=target, cfg=cfg)
+    learner.ss.cfg.enum_depth = enum_depth
+    learner.ss.cfg.extra_len_max = extra_len_max
+    return learner
+
+
+def fit_with_fallback(learner: Any) -> Tuple[Optional[Any], bool]:
+    """Fit `learner`, returning (dfa, converged).
+
+    fit() raises when max_iters elapses without PerfectEQ accepting, which under
+    noise is the common case rather than an error; the last hypothesis is still
+    worth scoring, so it comes back with converged=False. Only if there is no
+    hypothesis at all is the dfa None. Anything but the iteration cap
+    propagates.
+    """
     try:
-        return learner.fit()
+        return learner.fit(), True
     except RuntimeError:
-        # fit() raises when max_iters elapses without PerfectEQ accepting, common
-        # under noise. Keep the last hypothesis so its accuracy stays measurable.
         last = getattr(learner, "_last_hyp", None)
-        if last is not None and getattr(last, "dfa", None) is not None:
-            last.dfa.converged = False  # type: ignore[attr-defined]
-            return last.dfa
-        raise
-
-
-def evaluate_official_dfa(
-    dfa: Any,
-    oracle_creator,
-    alphabet_chars: Sequence[str],
-    symbols: int,
-    *,
-    count: int = 5000,
-    rng_seed: int = 0x1234,
-) -> float:
-    """Sample random words via the repo's UniformSampler, ask the noiseless
-    oracle for the truth label, and ask the upstream DFA for its label.
-    Returns accuracy."""
-    from orthogonal_dfa.l_star.sampler import UniformSampler
-    from orthogonal_dfa.l_star.structures import SymmetricBernoulli
-
-    us = UniformSampler(40)
-    truth = oracle_creator(SymmetricBernoulli(p_correct=1.0), 0)
-    rng = np.random.default_rng(rng_seed)
-    correct = 0
-    for _ in range(count):
-        s = us.sample(rng, symbols)
-        truth_label = bool(truth.membership_query(s))
-        word = "".join(alphabet_chars[c] for c in s)
-        pred = bool(dfa.run(word))
-        if pred == truth_label:
-            correct += 1
-    return correct / count
+        return getattr(last, "dfa", None), False

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -26,15 +26,12 @@ import numpy as np
 
 UPSTREAM_URL = "https://github.com/lkwargs/CAPAL"
 
-#: The single source of truth for the commit every number in
-#: `data/capal_findings.md` was measured against. Bumping it means re-measuring.
+#: Upstream CAPAL commit the checked-in results were measured against.
 PINNED_COMMIT = "57d877f6a083d58852660fac388ff49c052dc2d2"
 
-#: Env var to point at a checkout elsewhere; otherwise a sibling of the repo.
 CAPAL_DIR_ENV = "ORTHO_CAPAL_DIR"
 
-#: Default checkout location, resolved relative to the repo root rather than
-#: the cwd, so it does not matter where a caller is invoked from.
+#: Default checkout: a sibling of the repo root.
 DEFAULT_CAPAL_DIR = Path(__file__).resolve().parents[2].parent / "capal"
 
 _official: Any = None
@@ -116,12 +113,10 @@ def import_capal(capal_dir: Optional[str] = None) -> Any:
     verify_pinned(path)
     if str(path) not in sys.path:
         sys.path.insert(0, str(path))
-    # Dynamic path-based import of upstream's single-file module; pylint cannot
-    # see it and there is nothing to import at module load time.
     import capal  # type: ignore[import-not-found]  # pylint: disable=import-error,import-outside-toplevel
 
-    # A stray `capal` package/module elsewhere on sys.path would satisfy this
-    # import silently, giving wrong results rather than an error. Check.
+    # A stray `capal` elsewhere on sys.path would import silently and give wrong
+    # results; confirm we loaded the pinned checkout.
     loaded = getattr(capal, "__file__", None)
     if loaded is None or Path(loaded).resolve().parent != path:
         raise RuntimeError(
@@ -215,12 +210,8 @@ def run_official_capal(
     try:
         return learner.fit()
     except RuntimeError:
-        # `fit()` raises when max_iters elapses without PerfectEQ accepting --
-        # under noise this is common because SAMESTATE may make a handful of
-        # false-DIFFERENT decisions, leaving the hypothesis larger than the
-        # target. Return the latest hypothesis so we can still measure its
-        # accuracy (the user wants accuracy at noise level, not just the
-        # converged/not bit).
+        # fit() raises when max_iters elapses without PerfectEQ accepting, common
+        # under noise. Keep the last hypothesis so its accuracy stays measurable.
         last = getattr(learner, "_last_hyp", None)
         if last is not None and getattr(last, "dfa", None) is not None:
             last.dfa.converged = False  # type: ignore[attr-defined]

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -8,7 +8,6 @@ caller: a fair comparison scores every learner on one shared word list.
 from __future__ import annotations
 
 import importlib.util
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -19,8 +18,6 @@ UPSTREAM_URL = "https://github.com/lkwargs/CAPAL"
 #: Upstream CAPAL commit the checked-in results were measured against.
 PINNED_COMMIT = "57d877f6a083d58852660fac388ff49c052dc2d2"
 
-CAPAL_DIR_ENV = "ORTHO_CAPAL_DIR"
-
 #: What upstream's fit() says when it runs out of iterations (capal.py:1294).
 CAP_MESSAGE = "Maximum iterations reached without convergence"
 
@@ -30,11 +27,8 @@ DEFAULT_CAPAL_DIR = Path(__file__).resolve().parents[2].parent / "capal"
 _official: Any = None
 
 
-def resolve_capal_dir(capal_dir: Optional[str] = None) -> Path:
-    """Explicit `capal_dir`, else $ORTHO_CAPAL_DIR, else `../capal`."""
-    override = capal_dir or os.environ.get(CAPAL_DIR_ENV)
-    if override:
-        return Path(override).expanduser().resolve()
+def resolve_capal_dir() -> Path:
+    """The upstream checkout: a `capal` sibling of the repo root."""
     return DEFAULT_CAPAL_DIR
 
 
@@ -64,7 +58,7 @@ def verify_pinned(path: Path) -> None:
     if not path.exists():
         raise RuntimeError(
             f"No CAPAL checkout at {path}. Clone {UPSTREAM_URL} there and "
-            f"`git checkout {PINNED_COMMIT}`, or set ${CAPAL_DIR_ENV}."
+            f"`git checkout {PINNED_COMMIT}`."
         )
     if not (path / "capal.py").exists():
         raise RuntimeError(
@@ -88,7 +82,7 @@ def verify_pinned(path: Path) -> None:
         )
 
 
-def import_capal(capal_dir: Optional[str] = None) -> Any:
+def import_capal() -> Any:
     """Verify the pin and load upstream's `capal`, cached.
 
     Lazy so importing this package never requires the checkout, only using it
@@ -98,7 +92,7 @@ def import_capal(capal_dir: Optional[str] = None) -> Any:
     global _official  # pylint: disable=global-statement
     if _official is not None:
         return _official
-    path = resolve_capal_dir(capal_dir)
+    path = resolve_capal_dir()
     verify_pinned(path)
     spec = importlib.util.spec_from_file_location("capal", path / "capal.py")
     module = importlib.util.module_from_spec(spec)

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -24,13 +24,15 @@ from typing import Any, Optional, Tuple
 
 UPSTREAM_URL = "https://github.com/lkwargs/CAPAL"
 
-#: Upstream CAPAL commit the checked-in results were measured against.
+#: The single source of truth for the commit every number in
+#: `data/capal_findings.md` was measured against. Bumping it means re-measuring.
 PINNED_COMMIT = "57d877f6a083d58852660fac388ff49c052dc2d2"
 
 #: What upstream's fit() says when it runs out of iterations (capal.py:1294).
 CAP_MESSAGE = "Maximum iterations reached without convergence"
 
-#: Default checkout: a sibling of the repo root.
+#: Default checkout location, resolved relative to the repo root rather than
+#: the cwd, so it does not matter where a caller is invoked from.
 DEFAULT_CAPAL_DIR = Path(__file__).resolve().parents[2].parent / "capal"
 
 _official: Any = None
@@ -118,8 +120,6 @@ def make_learner(
     max_iters: int = 200,
     seed: int = 0,
     verbose: bool = False,
-    k_pos: int = 10,
-    k_neg: int = 10,
     max_same_samples: int = 60,
     tau_cap: float = 0.2,
     suffix_pool_init: int = 32,
@@ -132,11 +132,13 @@ def make_learner(
 
     `enum_depth`/`extra_len_max` are the matched-query-budget knob; LearnerConfig
     does not forward them, so they go straight on the live SameStateConfig.
+
+    LearnerConfig's K_pos/K_neg are left at their defaults: upstream reads them
+    only in its CLI, never in CAPALLearner or SameStateOracle, so setting them
+    would record a knob that cannot change a result.
     """
     official = import_capal()
     cfg = official.LearnerConfig(
-        K_pos=k_pos,
-        K_neg=k_neg,
         max_iters=max_iters,
         seed=seed,
         eta=eta,

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -2,7 +2,16 @@
 
 `make_learner` returns the learner unfitted so callers can instrument it (count
 queries, time the fit) before `fit_with_fallback`. Scoring stays with the
-caller: a fair comparison scores every learner on one shared word list.
+caller.
+
+The caller uses the target DFA as an Equivalence Query oracle, as in the paper's
+pMAT assumption (Section 3.1): counterexample labels are perfect information,
+which means
+    - some perfect information that the learner can utilize, leading to fewer queries
+    - the algorithm converging means exact equality.
+
+This is something that our methods do not have access to, so should be
+noted in reports.
 """
 
 from __future__ import annotations
@@ -138,6 +147,8 @@ def make_learner(
         suffix_pool_len_max=suffix_pool_len_max,
         verbose=verbose,
     )
+    # target= builds PersistentNoisyMQ + PerfectEQ (capal.py:907-914).
+    # See module docstring.
     learner = official.CAPALLearner(target=target, cfg=cfg)
     learner.ss.cfg.enum_depth = enum_depth
     learner.ss.cfg.extra_len_max = extra_len_max

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -1,18 +1,8 @@
-"""Bridge between this repo's Oracle/test-harness and the official CAPAL repo.
+"""Run the official CAPAL learner against this repo's targets.
 
-Loads the upstream `capal` module from the pinned checkout (see
-`resolve_capal_dir`), then exposes:
-
-- make_learner(target, eta, ...): a CAPALLearner wired to the PersistentNoisyMQ
-  + PerfectEQ defaults, returned unfitted so callers can instrument it.
-- fit_with_fallback(learner): .fit(), plus whether it converged.
-
-The two are split because callers need to reach the learner in between -- to
-count queries by wrapping `learner.mq.query`, to time the fit, or to suppress
-upstream's stdout. Scoring is deliberately not here: a comparison must score
-every learner on one shared word list, which only the caller can build.
-
-Building the target DFAs upstream needs lives in `porters`.
+`make_learner` returns the learner unfitted so callers can instrument it (count
+queries, time the fit) before `fit_with_fallback`. Scoring stays with the
+caller: a fair comparison scores every learner on one shared word list.
 """
 
 from __future__ import annotations
@@ -41,8 +31,7 @@ _official: Any = None
 
 
 def resolve_capal_dir(capal_dir: Optional[str] = None) -> Path:
-    """Upstream checkout: explicit `capal_dir`, else $ORTHO_CAPAL_DIR, else
-    `../capal`."""
+    """Explicit `capal_dir`, else $ORTHO_CAPAL_DIR, else `../capal`."""
     override = capal_dir or os.environ.get(CAPAL_DIR_ENV)
     if override:
         return Path(override).expanduser().resolve()
@@ -70,11 +59,8 @@ def _git(path: Path, *args: str) -> str:
 
 
 def verify_pinned(path: Path) -> None:
-    """Raise unless `path` is a clean checkout at PINNED_COMMIT.
-
-    Reproducibility guard: `data/capal_findings.md` is only meaningful against
-    this exact commit with no local modifications.
-    """
+    """Raise unless `path` is a clean checkout at PINNED_COMMIT -- the numbers
+    in data/capal_findings.md are only comparable against this exact tree."""
     if not path.exists():
         raise RuntimeError(
             f"No CAPAL checkout at {path}. Clone {UPSTREAM_URL} there and "
@@ -103,17 +89,11 @@ def verify_pinned(path: Path) -> None:
 
 
 def import_capal(capal_dir: Optional[str] = None) -> Any:
-    """Verify the pin, then load upstream's single-file `capal` module.
+    """Verify the pin and load upstream's `capal`, cached.
 
-    Deliberately lazy and cached: importing this package must not fail just
-    because the checkout is missing, but *using* it against an unpinned tree
-    must.
-
-    Loaded by file path, not by putting the checkout on sys.path: upstream is a
-    directory of loose modules, so a path insertion would put all of them ahead
-    of everything else and could shadow a like-named top-level import. capal.py
-    imports only stdlib, so loading the file alone is enough -- and there is no
-    longer a stray-`capal` to guard against, since we name the exact file.
+    Lazy so importing this package never requires the checkout, only using it
+    does. Loaded by exact file path rather than onto sys.path, so upstream's
+    loose sibling modules cannot shadow anything.
     """
     global _official  # pylint: disable=global-statement
     if _official is not None:
@@ -145,13 +125,10 @@ def make_learner(
     enum_depth: int = 3,
     extra_len_max: int = 8,
 ) -> Any:
-    """A CAPALLearner over `target`, unfitted (PersistentNoisyMQ + PerfectEQ are
-    built from `target` by upstream).
+    """An unfitted CAPALLearner over `target`.
 
-    `enum_depth` / `extra_len_max` bound how many and how long the SAMESTATE
-    suffixes are -- the matched-query-budget knob. LearnerConfig does not
-    forward them, so they are set on the live SameStateConfig, which SAMESTATE
-    reads lazily during fit().
+    `enum_depth`/`extra_len_max` are the matched-query-budget knob; LearnerConfig
+    does not forward them, so they go straight on the live SameStateConfig.
     """
     official = import_capal()
     cfg = official.LearnerConfig(
@@ -176,20 +153,16 @@ def make_learner(
 def fit_with_fallback(learner: Any) -> Tuple[Optional[Any], bool]:
     """Fit `learner`, returning (dfa, converged).
 
-    fit() raises when max_iters elapses without PerfectEQ accepting, which under
-    noise is the common case rather than an error; the last hypothesis is still
-    worth scoring, so it comes back with converged=False. Only if there is no
-    hypothesis at all is the dfa None. Anything but the iteration cap
-    propagates.
+    Under noise the iteration cap is a normal non-convergent outcome, not an
+    error: the last hypothesis comes back with converged=False, or dfa None if
+    there is none.
     """
     try:
         return learner.fit(), True
     except RuntimeError as exc:
-        # The cap is upstream's only RuntimeError, but RecursionError is a
-        # subclass of it, so without this the interpreter's own failures would
-        # be recorded as ordinary non-convergent runs. Matching on the message
-        # is safe here only because the pin locks it: it cannot change without
-        # verify_pinned failing first.
+        # RecursionError is a RuntimeError subclass; without this guard the
+        # interpreter's own failures would look like non-convergent runs.
+        # Matching the message is safe only because the pin locks it.
         if CAP_MESSAGE not in str(exc):
             raise
         last = getattr(learner, "_last_hyp", None)

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -17,6 +17,7 @@ Building the target DFAs upstream needs lives in `porters`.
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
@@ -102,31 +103,28 @@ def verify_pinned(path: Path) -> None:
 
 
 def import_capal(capal_dir: Optional[str] = None) -> Any:
-    """Verify the pin, then import upstream's single-file `capal` module.
+    """Verify the pin, then load upstream's single-file `capal` module.
 
     Deliberately lazy and cached: importing this package must not fail just
     because the checkout is missing, but *using* it against an unpinned tree
     must.
+
+    Loaded by file path, not by putting the checkout on sys.path: upstream is a
+    directory of loose modules, so a path insertion would put all of them ahead
+    of everything else and could shadow a like-named top-level import. capal.py
+    imports only stdlib, so loading the file alone is enough -- and there is no
+    longer a stray-`capal` to guard against, since we name the exact file.
     """
     global _official  # pylint: disable=global-statement
     if _official is not None:
         return _official
     path = resolve_capal_dir(capal_dir)
     verify_pinned(path)
-    if str(path) not in sys.path:
-        sys.path.insert(0, str(path))
-    import capal  # type: ignore[import-not-found]  # pylint: disable=import-error,import-outside-toplevel
-
-    # A stray `capal` elsewhere on sys.path would import silently and give wrong
-    # results; confirm we loaded the pinned checkout.
-    loaded = getattr(capal, "__file__", None)
-    if loaded is None or Path(loaded).resolve().parent != path:
-        raise RuntimeError(
-            f"`import capal` resolved to {loaded or '<namespace package>'}, "
-            f"not the pinned checkout at {path}. Something on sys.path is "
-            f"shadowing upstream CAPAL."
-        )
-    _official = capal
+    spec = importlib.util.spec_from_file_location("capal", path / "capal.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["capal"] = module  # so capal.DFA etc. resolve by module name
+    spec.loader.exec_module(module)
+    _official = module
     return _official
 
 

--- a/orthogonal_dfa/capal_official/porters.py
+++ b/orthogonal_dfa/capal_official/porters.py
@@ -1,0 +1,53 @@
+"""Port this repo's example targets into upstream CAPAL's `capal.DFA` format.
+
+Each builds the noiseless target DFA for one benchmark family, so upstream's
+PerfectEQ can run its product-BFS counterexample search against it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from .adapter import import_capal
+
+
+def build_modulo_dfa(modulo: int, allowed: Iterable[int]) -> Any:
+    """The 'sum mod N in allowed?' DFA over {'0','1'}, in upstream format."""
+    M = import_capal()
+    delta = {}
+    for q in range(modulo):
+        delta[(q, "0")] = q
+        delta[(q, "1")] = (q + 1) % modulo
+    return M.DFA(
+        alphabet=["0", "1"],
+        num_states=modulo,
+        start=0,
+        accept={int(x) for x in allowed},
+        delta=delta,
+    )
+
+
+def build_regex_dfa(regex: str, alphabet_size: int = 2) -> Any:
+    """Compile `regex` to a minimal DFA in upstream format. Symbols are the
+    characters '0', '1', ... matching BernoulliRegex's int->str convention."""
+    from automata.fa.dfa import DFA as AutDFA
+    from automata.fa.nfa import NFA
+
+    M = import_capal()
+    syms = {str(i) for i in range(alphabet_size)}
+    nfa = NFA.from_regex(regex, input_symbols=syms)
+    aut = AutDFA.from_nfa(nfa, minify=True)
+
+    state_list = sorted(aut.states, key=lambda s: (str(type(s).__name__), str(s)))
+    sidx = {s: i for i, s in enumerate(state_list)}
+    delta = {}
+    for s in state_list:
+        for a, dest in aut.transitions[s].items():
+            delta[(sidx[s], a)] = sidx[dest]
+    return M.DFA(
+        alphabet=sorted(aut.input_symbols),
+        num_states=len(state_list),
+        start=sidx[aut.initial_state],
+        accept={sidx[s] for s in aut.final_states},
+        delta=delta,
+    )

--- a/orthogonal_dfa/capal_official/porters.py
+++ b/orthogonal_dfa/capal_official/porters.py
@@ -38,15 +38,28 @@ def build_regex_dfa(regex: str, alphabet_size: int = 2) -> Any:
     nfa = NFA.from_regex(regex, input_symbols=syms)
     aut = AutDFA.from_nfa(nfa, minify=True)
 
+    alphabet = sorted(aut.input_symbols)
     state_list = sorted(aut.states, key=lambda s: (str(type(s).__name__), str(s)))
     sidx = {s: i for i, s in enumerate(state_list)}
+
+    # automata-lib rejects by dying, so any language with a dead end (e.g. `1*`,
+    # `0*1*`) comes back partial, while upstream's DFA requires a transition for
+    # every (state, symbol). Route the missing ones to an explicit sink.
+    sink = len(state_list)
     delta = {}
     for s in state_list:
-        for a, dest in aut.transitions[s].items():
-            delta[(sidx[s], a)] = sidx[dest]
+        for a in alphabet:
+            dest = aut.transitions[s].get(a)
+            delta[(sidx[s], a)] = sink if dest is None else sidx[dest]
+    num_states = len(state_list)
+    if sink in delta.values():
+        num_states += 1
+        for a in alphabet:
+            delta[(sink, a)] = sink
+
     return M.DFA(
-        alphabet=sorted(aut.input_symbols),
-        num_states=len(state_list),
+        alphabet=alphabet,
+        num_states=num_states,
         start=sidx[aut.initial_state],
         accept={sidx[s] for s in aut.final_states},
         delta=delta,

--- a/orthogonal_dfa/capal_official/porters.py
+++ b/orthogonal_dfa/capal_official/porters.py
@@ -1,8 +1,5 @@
-"""Port this repo's example targets into upstream CAPAL's `capal.DFA` format.
-
-Each builds the noiseless target DFA for one benchmark family, so upstream's
-PerfectEQ can run its product-BFS counterexample search against it.
-"""
+"""Build this repo's target languages as upstream `capal.DFA`s, so CAPAL's
+PerfectEQ can run its product-BFS counterexample search against them."""
 
 from __future__ import annotations
 

--- a/tests/test_capal_bridge.py
+++ b/tests/test_capal_bridge.py
@@ -140,6 +140,23 @@ class TestCapalBridge(unittest.TestCase):
         self.assertIsNotNone(learned)
         self.assertLess(learned.num_states, target.num_states)
 
+    def test_fit_propagates_errors_that_are_not_the_cap(self):
+        # RecursionError is a RuntimeError, so without the message guard an
+        # interpreter failure mid-fit would be recorded as an ordinary
+        # non-convergent run, hypothesis and accuracy and all.
+        learner = make_learner(build_modulo_dfa(9, (3, 6)), eta=0.1, seed=0)
+        inner = learner.mq.query
+        calls = itertools.count()
+
+        def flaky(word: str) -> bool:
+            if next(calls) == 100:
+                raise RecursionError("maximum recursion depth exceeded")
+            return inner(word)
+
+        learner.mq.query = flaky
+        with self.assertRaises(RecursionError):
+            fit_with_fallback(learner)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_capal_bridge.py
+++ b/tests/test_capal_bridge.py
@@ -69,8 +69,29 @@ class TestCapalBridge(unittest.TestCase):
 
     def test_build_regex_dfa(self):
         dfa = build_regex_dfa(r".*1010101.*")
+        self.assertEqual(dfa.num_states, 8)  # every state is live, so no sink
         self.assertTrue(dfa.run("1010101"))
         self.assertFalse(dfa.run("0000000"))
+
+    def test_build_regex_dfa_with_dead_end(self):
+        # automata-lib hands back a partial DFA here; the sink has to be added
+        # back or upstream's DFA rejects the transition table outright.
+        dfa = build_regex_dfa(r"1*")
+        self.assertEqual(dfa.num_states, 2)
+        self.assertTrue(dfa.run(""))
+        self.assertTrue(dfa.run("111"))
+        self.assertFalse(dfa.run("0"))
+        self.assertFalse(dfa.run("110"))  # dead: the sink never accepts again
+
+        dfa = build_regex_dfa(r"0*1*")
+        self.assertTrue(dfa.run("0011"))
+        self.assertFalse(dfa.run("10"))
+
+    def test_build_regex_dfa_three_symbols(self):
+        dfa = build_regex_dfa(r"(0|1)*2*", alphabet_size=3)
+        self.assertEqual(dfa.alphabet, ("0", "1", "2"))
+        self.assertTrue(dfa.run("01022"))
+        self.assertFalse(dfa.run("2201"))
 
     def test_end_to_end_fit_and_score(self):
         from orthogonal_dfa.l_star.examples.bernoulli_parity import (

--- a/tests/test_capal_bridge.py
+++ b/tests/test_capal_bridge.py
@@ -2,14 +2,16 @@
 
 Ensures a pinned CAPAL checkout exists at ``../capal`` -- cloning it in CI if
 absent -- then exercises the bridge end to end: verify the pin, import the
-upstream module, build target DFAs both ways, and run a tiny CAPALLearner fit
-and score it. Catches a broken adapter or upstream-commit drift.
+upstream module, build target DFAs both ways, check a ported DFA against the
+oracle it stands in for, and run a tiny CAPALLearner fit. Catches a broken
+adapter or upstream-commit drift.
 
 The clone is skipped (not failed) when no checkout exists and cloning is not
 possible (e.g. offline), so the suite still runs without network; CI has git
 and network, so it clones and runs for real.
 """
 
+import itertools
 import subprocess
 import unittest
 from pathlib import Path
@@ -18,10 +20,10 @@ from orthogonal_dfa.capal_official import (
     PINNED_COMMIT,
     build_modulo_dfa,
     build_regex_dfa,
-    evaluate_official_dfa,
+    fit_with_fallback,
     import_capal,
+    make_learner,
     resolve_capal_dir,
-    run_official_capal,
     verify_pinned,
 )
 from orthogonal_dfa.capal_official.adapter import UPSTREAM_URL
@@ -46,6 +48,14 @@ def _ensure_capal_checkout() -> Path:
         except (subprocess.CalledProcessError, FileNotFoundError) as exc:
             raise unittest.SkipTest(f"no CAPAL checkout and clone failed: {exc}")
     return path
+
+
+def _all_words(alphabet: str, max_len: int):
+    return [
+        "".join(w)
+        for n in range(max_len + 1)
+        for w in itertools.product(alphabet, repeat=n)
+    ]
 
 
 class TestCapalBridge(unittest.TestCase):
@@ -93,24 +103,42 @@ class TestCapalBridge(unittest.TestCase):
         self.assertTrue(dfa.run("01022"))
         self.assertFalse(dfa.run("2201"))
 
-    def test_end_to_end_fit_and_score(self):
+    def test_ported_dfa_matches_the_oracle(self):
+        # The head-to-head is only meaningful if the upstream DFA and the Oracle
+        # it stands in for denote the same language under the same symbol order.
         from orthogonal_dfa.l_star.examples.bernoulli_parity import (
             BernoulliParityOracle,
         )
+        from orthogonal_dfa.l_star.structures import SymmetricBernoulli
 
+        dfa = build_modulo_dfa(9, (3, 6))
+        oracle = BernoulliParityOracle(
+            SymmetricBernoulli(p_correct=1.0), 0, modulo=9, allowed_moduluses=(3, 6)
+        )
+        for word in _all_words("01", 8):
+            truth = oracle.membership_query([int(c) for c in word])
+            self.assertEqual(dfa.run(word), truth, word)
+
+    def test_end_to_end_fit(self):
         # Trivial noiseless target: CAPAL + PerfectEQ should learn it exactly.
         target = build_modulo_dfa(2, (1,))
-        learned = run_official_capal(target, eta=0.0, seed=0, max_iters=50)
-        acc = evaluate_official_dfa(
-            learned,
-            lambda nm, s: BernoulliParityOracle(
-                nm, s, modulo=2, allowed_moduluses=(1,)
-            ),
-            alphabet_chars=["0", "1"],
-            symbols=2,
-            count=500,
+        learned, converged = fit_with_fallback(
+            make_learner(target, eta=0.0, seed=0, max_iters=50)
         )
-        self.assertGreater(acc, 0.99)
+        self.assertTrue(converged)
+        for word in _all_words("01", 10):
+            self.assertEqual(learned.run(word), target.run(word), word)
+
+    def test_fit_falls_back_to_the_last_hypothesis(self):
+        # One iteration cannot learn a 9-state target, so fit() hits its cap and
+        # the hypothesis it held at that point comes back as non-convergent.
+        target = build_modulo_dfa(9, (3, 6))
+        learned, converged = fit_with_fallback(
+            make_learner(target, eta=0.0, seed=0, max_iters=1)
+        )
+        self.assertFalse(converged)
+        self.assertIsNotNone(learned)
+        self.assertLess(learned.num_states, target.num_states)
 
 
 if __name__ == "__main__":

--- a/tests/test_capal_bridge.py
+++ b/tests/test_capal_bridge.py
@@ -1,0 +1,96 @@
+"""Smoke tests for the upstream CAPAL bridge (orthogonal_dfa.capal_official).
+
+Ensures a pinned CAPAL checkout exists at ``../capal`` -- cloning it in CI if
+absent -- then exercises the bridge end to end: verify the pin, import the
+upstream module, build target DFAs both ways, and run a tiny CAPALLearner fit
+and score it. Catches a broken adapter or upstream-commit drift.
+
+The clone is skipped (not failed) when no checkout exists and cloning is not
+possible (e.g. offline), so the suite still runs without network; CI has git
+and network, so it clones and runs for real.
+"""
+
+import subprocess
+import unittest
+from pathlib import Path
+
+from orthogonal_dfa.capal_official import (
+    PINNED_COMMIT,
+    build_modulo_dfa,
+    build_regex_dfa,
+    evaluate_official_dfa,
+    import_capal,
+    resolve_capal_dir,
+    run_official_capal,
+    verify_pinned,
+)
+from orthogonal_dfa.capal_official.adapter import UPSTREAM_URL
+
+
+def _ensure_capal_checkout() -> Path:
+    path = resolve_capal_dir()
+    if not path.exists():
+        try:
+            subprocess.run(
+                ["git", "clone", "--quiet", UPSTREAM_URL, str(path)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(path), "checkout", "--quiet", PINNED_COMMIT],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            raise unittest.SkipTest(f"no CAPAL checkout and clone failed: {exc}")
+    return path
+
+
+class TestCapalBridge(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.path = _ensure_capal_checkout()
+
+    def test_pinned_checkout_verifies(self):
+        verify_pinned(self.path)  # raises if wrong commit or dirty tree
+
+    def test_import_capal(self):
+        upstream = import_capal()
+        self.assertTrue(hasattr(upstream, "CAPALLearner"))
+        self.assertTrue(hasattr(upstream, "DFA"))
+
+    def test_build_modulo_dfa(self):
+        dfa = build_modulo_dfa(9, (3, 6))
+        self.assertEqual(dfa.num_states, 9)
+        self.assertTrue(dfa.run("111"))  # three 1s -> 3 mod 9 in {3,6}
+        self.assertFalse(dfa.run("1"))  # one 1 -> 1 mod 9 not in {3,6}
+
+    def test_build_regex_dfa(self):
+        dfa = build_regex_dfa(r".*1010101.*")
+        self.assertTrue(dfa.run("1010101"))
+        self.assertFalse(dfa.run("0000000"))
+
+    def test_end_to_end_fit_and_score(self):
+        from orthogonal_dfa.l_star.examples.bernoulli_parity import (
+            BernoulliParityOracle,
+        )
+
+        # Trivial noiseless target: CAPAL + PerfectEQ should learn it exactly.
+        target = build_modulo_dfa(2, (1,))
+        learned = run_official_capal(target, eta=0.0, seed=0, max_iters=50)
+        acc = evaluate_official_dfa(
+            learned,
+            lambda nm, s: BernoulliParityOracle(
+                nm, s, modulo=2, allowed_moduluses=(1,)
+            ),
+            alphabet_chars=["0", "1"],
+            symbols=2,
+            count=500,
+        )
+        self.assertGreater(acc, 0.99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_capal_bridge.py
+++ b/tests/test_capal_bridge.py
@@ -1,14 +1,7 @@
-"""Smoke tests for the upstream CAPAL bridge (orthogonal_dfa.capal_official).
+"""Smoke tests for the CAPAL bridge (orthogonal_dfa.capal_official).
 
-Ensures a pinned CAPAL checkout exists at ``../capal`` -- cloning it in CI if
-absent -- then exercises the bridge end to end: verify the pin, import the
-upstream module, build target DFAs both ways, check a ported DFA against the
-oracle it stands in for, and run a tiny CAPALLearner fit. Catches a broken
-adapter or upstream-commit drift.
-
-The clone is skipped (not failed) when no checkout exists and cloning is not
-possible (e.g. offline), so the suite still runs without network; CI has git
-and network, so it clones and runs for real.
+Clones the pinned CAPAL checkout to ../capal if absent, skipping (not failing)
+when that is impossible, e.g. offline. Catches a broken adapter or commit drift.
 """
 
 import itertools


### PR DESCRIPTION
## What

Split off from the `capal-comparison` branch: the self-contained **CAPAL bridge** that everything in the comparison study sits on. It has no dependency on the experiments harness, so it lands cleanly on its own.

`orthogonal_dfa/capal_official/`:

- **`adapter.py`** — loads the pinned upstream CAPAL checkout (always `../capal`, a sibling of the repo root) *by file path*, not via `sys.path` insertion, so upstream's loose sibling modules can't shadow anything. The load is lazy: importing this package never requires the checkout, only using it does.
- **Reproducibility guard** — `verify_pinned` refuses anything but a clean tree at the pinned commit (`57d877f…`), so measured numbers are always tied to a known upstream.
- **`make_learner` / `fit_with_fallback`** — the learner comes back unfitted so callers can instrument it (count queries, time the fit) before fitting. Under noise the iteration cap is a normal non-convergent outcome, not an error, so `fit_with_fallback` returns `(last_hypothesis, False)` rather than raising. Scoring stays with the caller.
- **`porters.py`** — builds this repo's target languages as upstream `capal.DFA`s (`build_modulo_dfa`, `build_regex_dfa`) so CAPAL's `PerfectEQ` can run its product-BFS counterexample search against them.

Passing `target=` makes upstream construct `PersistentNoisyMQ` + `PerfectEQ`. The exact equivalence oracle is the paper's pMAT assumption (Section 3.1), not a handicap chosen here — counterexample labels are perfect information, which means a converged run is exact. Our own learners have no equivalent oracle, so this is noted in the module docstring and should be noted in any report.

## CI smoke test

`tests/test_capal_bridge.py` **clones CAPAL to `../capal` at the pinned commit if it isn't already present** (skips gracefully if offline), then exercises the bridge end to end:

- verify the pin,
- import the upstream module,
- build the modulo and regex target DFAs and check a few strings, including the dead-end (`1*`, `0*1*`) and 3-symbol cases,
- confirm a ported DFA agrees with the corresponding `Oracle` exhaustively to length 8,
- run a tiny noiseless `CAPALLearner` fit and check it learns the target exactly,
- check the iteration-cap fallback returns the last hypothesis, and that non-cap errors still propagate.

CI discovers test files automatically, so this runs as its own matrix job with no workflow change.
