### PR TITLE
satisfies_preconditions: return the reasons, not just a verdict

### DIFF
--- a/orthogonal_dfa/l_star/preconditions.py
+++ b/orthogonal_dfa/l_star/preconditions.py
@@ -1,8 +1,10 @@
 """
 Preconditions for E-L* learnability of a target DFA.
 
-satisfies_preconditions(dfa, *, length, ...) is the main check, checking
-the following conditions, for a particular length of uniform sampling:
+satisfies_preconditions(dfa, *, length, ...) is the main check. It returns a
+PreconditionReport -- truthy iff the DFA is admitted, and carrying the measured
+values and a reason per failed condition. The conditions, for a particular
+length of uniform sampling:
 
 - acceptance_rate: the language does not accept or reject nearly all strings
 - class_preserving_fraction: some fraction of suffixes map all accept
@@ -12,7 +14,8 @@ the following conditions, for a particular length of uniform sampling:
 """
 
 from collections import Counter
-from typing import List
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
 
 import numpy as np
 from automata.fa.dfa import DFA
@@ -113,6 +116,34 @@ def covered_accuracy_ceiling(
     return best
 
 
+@dataclass(frozen=True)
+class PreconditionReport:
+    """The verdict, plus the measurements and the reasons behind it.
+
+    Truthy iff every precondition holds, so ``if satisfies_preconditions(...)``
+    reads the same as when this was a bare bool. A measurement is ``None`` when
+    short-circuiting meant it was never taken.
+    """
+
+    length: int
+    acceptance_rate: float
+    class_preserving_fraction: Optional[float] = None
+    covered_accuracy_ceiling: Optional[float] = None
+    #: States no sampled prefix lands in, as strings -- populated when the
+    #: ceiling is measured, since that is the check they explain.
+    uncovered_states: Optional[List[str]] = None
+    #: One entry per failed precondition, naming the measured value and the
+    #: threshold it missed. Empty iff the DFA is admitted.
+    reasons: Tuple[str, ...] = ()
+
+    @property
+    def satisfied(self) -> bool:
+        return not self.reasons
+
+    def __bool__(self) -> bool:
+        return self.satisfied
+
+
 def satisfies_preconditions(
     dfa: DFA,
     *,
@@ -121,22 +152,44 @@ def satisfies_preconditions(
     min_class_preserving_frac: float = 0.05,
     min_covered_accuracy: float = 0.99,
     num_samples: int = DEFAULT_NUM_SAMPLES,
-) -> bool:
-    """True iff ``dfa`` meets every learnability precondition, all under
-    length-``length`` uniform sampling:
+    short_circuit: bool = True,
+) -> PreconditionReport:
+    """Does ``dfa`` meet every learnability precondition, and if not, why not?
+
+    All under length-``length`` uniform sampling:
 
     - acceptance rate in ``[min_accept_or_reject, 1 - min_accept_or_reject]``;
     - class-preserving fraction at least ``min_class_preserving_frac``;
     - covered-accuracy ceiling at least ``min_covered_accuracy``
 
-    Checks run in increasing cost and short-circuit on the first failure.
+    Checks run in increasing cost. By default they stop at the first failure,
+    which is what a caller wanting only a verdict should do; pass
+    ``short_circuit=False`` to measure everything and collect every reason.
     """
-
+    reasons: List[str] = []
     rate = acceptance_rate(dfa, length=length, num_samples=num_samples)
     if not min_accept_or_reject <= rate <= 1 - min_accept_or_reject:
-        return False
+        reasons.append(
+            f"acceptance rate {rate:.3f} outside "
+            f"[{min_accept_or_reject}, {1 - min_accept_or_reject}]"
+        )
+        if short_circuit:
+            return PreconditionReport(length, rate, reasons=tuple(reasons))
+
     cp = class_preserving_fraction(dfa, length=length, num_samples=num_samples)
     if cp < min_class_preserving_frac:
-        return False
+        reasons.append(
+            f"class-preserving fraction {cp:.3f} below {min_class_preserving_frac}"
+        )
+        if short_circuit:
+            return PreconditionReport(length, rate, cp, reasons=tuple(reasons))
+
     ceiling = covered_accuracy_ceiling(dfa, length=length, num_samples=num_samples)
-    return ceiling >= min_covered_accuracy
+    if ceiling < min_covered_accuracy:
+        reasons.append(
+            f"covered-accuracy ceiling {ceiling:.3f} below "
+            f"{min_covered_accuracy} (an uncovered state carries a decision)"
+        )
+    covered = covered_states(dfa, length=length, num_samples=num_samples)
+    uncovered = sorted(str(q) for q in dfa.states if q not in covered)
+    return PreconditionReport(length, rate, cp, ceiling, uncovered, tuple(reasons))


### PR DESCRIPTION
Split off `capal-comparison`. One file, no dependencies on the rest of that branch.

## Why

`satisfies_preconditions` returned a bare `bool`, so a caller that got `False` had no way to say *what* failed. Anything wanting to explain a rejection had to re-measure all three quantities and re-apply the thresholds itself — which is exactly what the CAPAL comparison harness was doing, in a copy of this logic that could drift from the real check.

## What changes

It now returns a `PreconditionReport`:

```python
@dataclass(frozen=True)
class PreconditionReport:
    length: int
    acceptance_rate: float
    class_preserving_fraction: Optional[float] = None
    covered_accuracy_ceiling: Optional[float] = None
    uncovered_states: Optional[List[str]] = None
    reasons: Tuple[str, ...] = ()

    @property
    def satisfied(self) -> bool: return not self.reasons
    def __bool__(self) -> bool: return self.satisfied
```

A reason names the measured value and the threshold it missed, e.g. `covered-accuracy ceiling 0.853 below 0.99 (an uncovered state carries a decision)`.

## Compatibility

**`__bool__` is load-bearing, not decoration.** Both existing callers use the result as a boolean:

- `tests/test_preconditions.py` — `assertTrue` / `assertFalse`
- `tests/test_random_dfa_validation.py:58` — `if not P.satisfies_preconditions(...)`

A dataclass without `__bool__` is unconditionally truthy, which would have flipped that second call site to admitting every random DFA while still passing its own assertion. Both callers are unmodified by this PR and pass.

## Short-circuiting

Preserved as the default: the checks run in increasing cost and stop at the first failure, so a caller wanting only a verdict doesn't pay for the expensive ones. Unmeasured fields come back `None`. Pass `short_circuit=False` to measure everything and collect every reason — for recording an auditable rejection rather than just acting on one.

## Verification

- `tests/test_preconditions.py`: 9 passed, unmodified.
- `tests/test_random_dfa_validation.py`: passed — 600 random DFAs through the full E-L\* loop, 47 minutes. This is the test that would catch a broken truthiness contract, so it was run rather than assumed.
- Downstream, the CAPAL harness produces byte-identical regime output for all 33 of its targets against the pre-change implementation.

## Not covered

`reasons` has no direct test — `test_preconditions.py` asserts verdicts only. Happy to add assertions on the reason strings if you'd like them pinned before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)