### PR TITLE
Diagnostics renderer for direct-L* against a known DFA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,9 @@ jobs:
         uses: astral-sh/setup-uv@v4
       - name: Set up Python
         run: uv python install 3.12
+      - name: Install graphviz
+        # `dot` lays out the diagnostics graphs in orthogonal_dfa.l_star.visualize.
+        run: sudo apt-get update && sudo apt-get install -y graphviz
       - name: Install dependencies
         run: |
           uv venv --python 3.12

--- a/orthogonal_dfa/l_star/visualize.py
+++ b/orthogonal_dfa/l_star/visualize.py
@@ -55,11 +55,18 @@ def _class_colors(classes) -> Dict[int, str]:
 
 
 def sample_class_distribution(
-    learner, true_dfa, *, rng, num_samples=500, per_state=60
+    classify, true_dfa, *, pst, rng, num_samples=500, per_state=60, prefill=None
 ):
     """For each true state, the distribution of learned classes that random
-    strings *reaching* that state sift to.  ``None`` keys the indecisive
+    strings *reaching* that state classify to.  ``None`` keys the indecisive
     (false-negative) share.  Returns ``{true_state: Counter}``.
+
+    ``classify`` maps a string to a class id or ``None``, and ``pst`` supplies the
+    sampler and alphabet, so this works for any learner: pass
+    ``learner.sift`` for direct-L*, or ``lambda s: dt.classify(s, oracle)`` for a
+    resolver-built decision tree.  ``prefill`` is an optional hook that warms a
+    whole batch of strings at once (e.g. ``learner._sift_prefill``); without it
+    the classifications simply cost more oracle calls.
 
     Every prefix is bucketed by the state it reaches, not just each sampled
     string's end state: the sampler draws one fixed length, so a transient state
@@ -69,7 +76,7 @@ def sample_class_distribution(
     buckets: Dict[int, List[tuple]] = {s: [] for s in true_dfa.states}
     seen: Dict[int, set] = {s: set() for s in true_dfa.states}
     for _ in range(num_samples):
-        w = list(learner.pst.sampler.sample(rng, learner.pst.alphabet_size))
+        w = list(pst.sampler.sample(rng, pst.alphabet_size))
         state = true_dfa.initial_state
         for i, c in enumerate([None] + w):
             if c is not None:
@@ -78,16 +85,12 @@ def sample_class_distribution(
             if len(buckets[state]) < per_state and key not in seen[state]:
                 seen[state].add(key)
                 buckets[state].append(key)
-    chosen = [list(p) for ps in buckets.values() for p in ps]
-    # If the learner can batch a sift, warm the whole sample in one pass so every
-    # sift below is a cache hit; without it the sifts just cost more oracle calls.
-    prefill = getattr(learner, "_sift_prefill", None)
     if prefill is not None:
-        prefill(chosen)
+        prefill([list(p) for ps in buckets.values() for p in ps])
     dist: Dict[int, Counter] = {s: Counter() for s in true_dfa.states}
     for state, ps in buckets.items():
         for p in ps:
-            dist[state][learner.sift(list(p))] += 1
+            dist[state][classify(list(p))] += 1
     return dist
 
 
@@ -328,6 +331,7 @@ def render_diagnostics(
     *,
     rng,
     path,
+    pst=None,
     num_samples: int = 500,
     per_state: int = 60,
     final_states: Optional[set] = None,
@@ -335,11 +339,20 @@ def render_diagnostics(
     scale: float = 1.0,
     dpi: int = 220,
 ) -> str:
-    """Write the three panels, stacked, to ``path``.  Returns the path."""
+    """Write the three panels, stacked, to ``path``.  Returns the path.
+
+    ``pst`` defaults to the learner's own; pass it explicitly when the learner
+    does not carry one."""
     import matplotlib.pyplot as plt  # pylint: disable=import-outside-toplevel
 
     dist = sample_class_distribution(
-        learner, true_dfa, rng=rng, num_samples=num_samples, per_state=per_state
+        learner.sift,
+        true_dfa,
+        pst=pst if pst is not None else learner.pst,
+        rng=rng,
+        num_samples=num_samples,
+        per_state=per_state,
+        prefill=getattr(learner, "_sift_prefill", None),
     )
     colors = _class_colors(set(range(learner.num_states)))
     panels = [

--- a/orthogonal_dfa/l_star/visualize.py
+++ b/orthogonal_dfa/l_star/visualize.py
@@ -118,7 +118,7 @@ def _dot_layout(nodes, edges, *, rankdir="LR", nodesep=0.45, ranksep=0.6) -> dic
     inches, y pointing up -- ready to draw at equal aspect."""
     lines = [
         "digraph {",
-        f'  rankdir={rankdir}; nodesep={nodesep}; ranksep={ranksep};',
+        f"  rankdir={rankdir}; nodesep={nodesep}; ranksep={ranksep};",
         '  node [shape=circle, fixedsize=true, label=""];',
     ]
     for name, (w, h) in nodes.items():
@@ -128,8 +128,11 @@ def _dot_layout(nodes, edges, *, rankdir="LR", nodesep=0.45, ranksep=0.6) -> dic
         lines.append(f'  "{tail}" -> "{head}"{lab};')
     lines.append("}")
     plain = subprocess.run(
-        ["dot", "-Tplain"], input="\n".join(lines), text=True,
-        capture_output=True, check=True,
+        ["dot", "-Tplain"],
+        input="\n".join(lines),
+        text=True,
+        capture_output=True,
+        check=True,
     ).stdout
 
     out = {"nodes": {}, "edges": [], "size": (1.0, 1.0)}
@@ -147,11 +150,13 @@ def _dot_layout(nodes, edges, *, rankdir="LR", nodesep=0.45, ranksep=0.6) -> dic
         elif f[0] == "edge":
             n = int(f[3])
             pts = [(float(f[4 + 2 * i]), float(f[5 + 2 * i])) for i in range(n)]
-            rest = f[4 + 2 * n:]
+            rest = f[4 + 2 * n :]
             label = None
             if rest and rest[0] not in ("solid", "dashed", "dotted", "bold"):
                 label = (rest[0], (float(rest[1]), float(rest[2])))
-            out["edges"].append({"tail": f[1], "head": f[2], "pts": pts, "label": label})
+            out["edges"].append(
+                {"tail": f[1], "head": f[2], "pts": pts, "label": label}
+            )
     return out
 
 
@@ -161,21 +166,40 @@ def _draw_edges(ax, layout, *, fontsize):
         # dot emits a cubic B-spline: one anchor then triplets of control points.
         verts, codes = [pts[0]], [Path.MOVETO]
         for i in range(1, len(pts) - 2, 3):
-            verts += pts[i:i + 3]
+            verts += pts[i : i + 3]
             codes += [Path.CURVE4] * 3
-        ax.add_patch(PathPatch(Path(verts, codes), fill=False,
-                               edgecolor=_MUTED, lw=0.9, zorder=1))
+        ax.add_patch(
+            PathPatch(
+                Path(verts, codes), fill=False, edgecolor=_MUTED, lw=0.9, zorder=1
+            )
+        )
         tip, prev = np.array(verts[-1]), np.array(verts[-2])
         d = tip - prev
         if np.hypot(*d):
             d = d / np.hypot(*d)
-            ax.add_patch(FancyArrowPatch(
-                tuple(tip - d * 0.06), tuple(tip), arrowstyle="-|>",
-                mutation_scale=8, color=_MUTED, lw=0, zorder=1))
+            ax.add_patch(
+                FancyArrowPatch(
+                    tuple(tip - d * 0.06),
+                    tuple(tip),
+                    arrowstyle="-|>",
+                    mutation_scale=8,
+                    color=_MUTED,
+                    lw=0,
+                    zorder=1,
+                )
+            )
         if e["label"]:
             text, (lx, ly) = e["label"]
-            ax.text(lx, ly, text, fontsize=fontsize, color=_MUTED,
-                    ha="center", va="center", zorder=2)
+            ax.text(
+                lx,
+                ly,
+                text,
+                fontsize=fontsize,
+                color=_MUTED,
+                ha="center",
+                va="center",
+                zorder=2,
+            )
 
 
 def _pie_node(ax, xy, r, shares, *, double=False, lw=1.0):
@@ -185,13 +209,15 @@ def _pie_node(ax, xy, r, shares, *, double=False, lw=1.0):
         if frac <= 0:
             continue
         end = start - 360.0 * frac
-        ax.add_patch(Wedge(xy, r, end, start, facecolor=colour,
-                           edgecolor="none", zorder=3))
+        ax.add_patch(
+            Wedge(xy, r, end, start, facecolor=colour, edgecolor="none", zorder=3)
+        )
         start = end
     ax.add_patch(Circle(xy, r, fill=False, edgecolor=_INK, lw=lw, zorder=4))
     if double:
-        ax.add_patch(Circle(xy, r * 0.84, fill=False, edgecolor=_INK,
-                            lw=lw * 0.8, zorder=4))
+        ax.add_patch(
+            Circle(xy, r * 0.84, fill=False, edgecolor=_INK, lw=lw * 0.8, zorder=4)
+        )
 
 
 def _finish(ax, layout, pad=0.35):
@@ -229,13 +255,36 @@ def _panel_true_dfa(ax, true_dfa, dist, colors):
         ] or [(_INDECISIVE, 1.0)]
         impure = len([c for c in counter if c is not None]) > 1 or counter.get(None)
         xy = layout["nodes"][str(s)]["xy"]
-        _pie_node(ax, xy, r, shares,
-                  double=s in true_dfa.final_states, lw=2.0 if impure else 1.0)
-        ax.text(xy[0], xy[1], str(s), fontsize=8.5, weight="bold", color="white",
-                ha="center", va="center", zorder=5,
-                path_effects=_halo())
-        ax.text(xy[0], xy[1] - r - 0.13, _breakdown(counter), fontsize=5.6,
-                color=_MUTED, ha="center", va="top", zorder=5)
+        _pie_node(
+            ax,
+            xy,
+            r,
+            shares,
+            double=s in true_dfa.final_states,
+            lw=2.0 if impure else 1.0,
+        )
+        ax.text(
+            xy[0],
+            xy[1],
+            str(s),
+            fontsize=8.5,
+            weight="bold",
+            color="white",
+            ha="center",
+            va="center",
+            zorder=5,
+            path_effects=_halo(),
+        )
+        ax.text(
+            xy[0],
+            xy[1] - r - 0.13,
+            _breakdown(counter),
+            fontsize=5.6,
+            color=_MUTED,
+            ha="center",
+            va="top",
+            zorder=5,
+        )
     _finish(ax, layout, pad=0.5)
 
 
@@ -266,19 +315,50 @@ def _panel_tree(ax, dt, colors):
         xy = layout["nodes"][name]["xy"]
         w, h = layout["nodes"][name]["wh"]
         if kind == "leaf":
-            ax.add_patch(matplotlib.patches.FancyBboxPatch(
-                (xy[0] - w / 2, xy[1] - h / 2), w, h,
-                boxstyle="round,pad=0,rounding_size=0.08",
-                facecolor=colour, edgecolor="none", zorder=3))
-            ax.text(*xy, text, fontsize=7.5, color="white", weight="bold",
-                    ha="center", va="center", zorder=4)
+            ax.add_patch(
+                matplotlib.patches.FancyBboxPatch(
+                    (xy[0] - w / 2, xy[1] - h / 2),
+                    w,
+                    h,
+                    boxstyle="round,pad=0,rounding_size=0.08",
+                    facecolor=colour,
+                    edgecolor="none",
+                    zorder=3,
+                )
+            )
+            ax.text(
+                *xy,
+                text,
+                fontsize=7.5,
+                color="white",
+                weight="bold",
+                ha="center",
+                va="center",
+                zorder=4,
+            )
         else:
-            ax.add_patch(matplotlib.patches.FancyBboxPatch(
-                (xy[0] - w / 2, xy[1] - h / 2), w, h,
-                boxstyle="square,pad=0", facecolor="#ffffff",
-                edgecolor=_INK, lw=0.9, zorder=3))
-            ax.text(*xy, text, fontsize=7.5, color=_INK, family="monospace",
-                    ha="center", va="center", zorder=4)
+            ax.add_patch(
+                matplotlib.patches.FancyBboxPatch(
+                    (xy[0] - w / 2, xy[1] - h / 2),
+                    w,
+                    h,
+                    boxstyle="square,pad=0",
+                    facecolor="#ffffff",
+                    edgecolor=_INK,
+                    lw=0.9,
+                    zorder=3,
+                )
+            )
+            ax.text(
+                *xy,
+                text,
+                fontsize=7.5,
+                color=_INK,
+                family="monospace",
+                ha="center",
+                va="center",
+                zorder=4,
+            )
     _finish(ax, layout, pad=0.3)
 
 
@@ -302,20 +382,47 @@ def _panel_class_dfa(ax, learner, colors, final_states, flipped):
     _draw_edges(ax, layout, fontsize=6.5)
     for s in sorted(transitions):
         xy = layout["nodes"][str(s)]["xy"]
-        ax.add_patch(Circle(xy, r, facecolor=colors.get(s, _OTHER),
-                            edgecolor="none", zorder=3))
-        ax.add_patch(Circle(xy, r, fill=False, zorder=4,
-                            edgecolor="#c0392f" if s in flipped else _INK,
-                            lw=2.4 if s in flipped else 1.0))
+        ax.add_patch(
+            Circle(xy, r, facecolor=colors.get(s, _OTHER), edgecolor="none", zorder=3)
+        )
+        ax.add_patch(
+            Circle(
+                xy,
+                r,
+                fill=False,
+                zorder=4,
+                edgecolor="#c0392f" if s in flipped else _INK,
+                lw=2.4 if s in flipped else 1.0,
+            )
+        )
         if s in finals:
-            ax.add_patch(Circle(xy, r * 0.84, fill=False, edgecolor=_INK,
-                                lw=0.8, zorder=4))
-        ax.text(xy[0], xy[1], f"q{s}", fontsize=8, weight="bold", color="white",
-                ha="center", va="center", zorder=5, path_effects=_halo())
+            ax.add_patch(
+                Circle(xy, r * 0.84, fill=False, edgecolor=_INK, lw=0.8, zorder=4)
+            )
+        ax.text(
+            xy[0],
+            xy[1],
+            f"q{s}",
+            fontsize=8,
+            weight="bold",
+            color="white",
+            ha="center",
+            va="center",
+            zorder=5,
+            path_effects=_halo(),
+        )
         access = learner.access.get(s)
         if access is not None:
-            ax.text(xy[0], xy[1] - r - 0.11, _fmt(access)[:16], fontsize=5.4,
-                    color=_MUTED, ha="center", va="top", zorder=5)
+            ax.text(
+                xy[0],
+                xy[1] - r - 0.11,
+                _fmt(access)[:16],
+                fontsize=5.4,
+                color=_MUTED,
+                ha="center",
+                va="top",
+                zorder=5,
+            )
     _finish(ax, layout, pad=0.4)
 
 
@@ -356,12 +463,18 @@ def render_diagnostics(
     )
     colors = _class_colors(set(range(learner.num_states)))
     panels = [
-        ("true DFA — shaded by the classes its strings sift to",
-         lambda a: _panel_true_dfa(a, true_dfa, dist, colors)),
-        ("discrimination tree — every internal node is a midfix",
-         lambda a: _panel_tree(a, learner.dt, colors)),
-        ("learned Myhill–Nerode classes",
-         lambda a: _panel_class_dfa(a, learner, colors, final_states, flipped)),
+        (
+            "true DFA — shaded by the classes its strings sift to",
+            lambda a: _panel_true_dfa(a, true_dfa, dist, colors),
+        ),
+        (
+            "discrimination tree — every internal node is a midfix",
+            lambda a: _panel_tree(a, learner.dt, colors),
+        ),
+        (
+            "learned Myhill–Nerode classes",
+            lambda a: _panel_class_dfa(a, learner, colors, final_states, flipped),
+        ),
     ]
 
     # Measure every panel first.  Each is then drawn at the *same* scale (one
@@ -380,7 +493,9 @@ def render_diagnostics(
     sheet_w = max(w for w, _ in extents) * scale
     heights = [h * scale for _, h in extents]
     fig, axes = plt.subplots(
-        3, 1, figsize=(sheet_w, sum(heights) + 1.0),
+        3,
+        1,
+        figsize=(sheet_w, sum(heights) + 1.0),
         gridspec_kw={"height_ratios": heights, "hspace": 0.10},
     )
     fig.patch.set_facecolor("white")

--- a/orthogonal_dfa/l_star/visualize.py
+++ b/orthogonal_dfa/l_star/visualize.py
@@ -1,0 +1,383 @@
+"""Diagnostics renderer for a :class:`DirectLStarLearner` against a known DFA.
+
+Produces three panels, all keyed by one colour per learned Myhill-Nerode class:
+
+  1. the *true* DFA, each state drawn as a pie over the classes that random
+     strings reaching that state actually sift to (plus an indecisive slice --
+     the family's false negatives, which sift to ``None``);
+  2. the discrimination tree, every internal node annotated with its midfix
+     (the ``prepend`` that sits between a prefix and each base suffix);
+  3. the DFA over the learned classes.
+
+``dot`` does the graph layout (via its ``plain`` output, which is just node and
+spline coordinates) and matplotlib does the drawing, so the panels keep an equal
+aspect and stay sharp at any dpi.
+"""
+
+import shlex
+import subprocess
+from collections import Counter
+from typing import Dict, List, Optional
+
+import matplotlib
+import numpy as np
+from matplotlib.patches import Circle, FancyArrowPatch, PathPatch, Wedge
+from matplotlib.path import Path
+
+# Categorical slots, in the fixed order that clears the CVD gates.  Classes past
+# the eighth fold into OTHER rather than inventing a hue.
+_PALETTE = [
+    "#2a78d6",
+    "#eb6834",
+    "#1baf7a",
+    "#eda100",
+    "#e87ba4",
+    "#008300",
+    "#4a3aa7",
+    "#e34948",
+]
+_OTHER = "#8a8a86"
+_INDECISIVE = "#d9d9d4"  # the family can't place these -- the FN slice
+_INK = "#1a1a1a"
+_MUTED = "#6d6d68"
+
+
+def _fmt(seq) -> str:
+    """A midfix/access string as text; the empty string renders as epsilon."""
+    return "".join(str(c) for c in seq) if len(seq) else "ε"
+
+
+def _class_colors(classes) -> Dict[int, str]:
+    return {
+        c: (_PALETTE[i] if i < len(_PALETTE) else _OTHER)
+        for i, c in enumerate(sorted(classes))
+    }
+
+
+def sample_class_distribution(
+    learner, true_dfa, *, rng, num_samples=500, per_state=60
+):
+    """For each true state, the distribution of learned classes that random
+    strings *reaching* that state sift to.  ``None`` keys the indecisive
+    (false-negative) share.  Returns ``{true_state: Counter}``.
+
+    Every prefix is bucketed by the state it reaches, not just each sampled
+    string's end state: the sampler draws one fixed length, so a transient state
+    -- one no string of that length can end in -- would otherwise draw no samples
+    at all and its classes would vanish from the picture.  Buckets are deduped and
+    capped so a rare state is represented as well as a common one."""
+    buckets: Dict[int, List[tuple]] = {s: [] for s in true_dfa.states}
+    seen: Dict[int, set] = {s: set() for s in true_dfa.states}
+    for _ in range(num_samples):
+        w = list(learner.pst.sampler.sample(rng, learner.pst.alphabet_size))
+        state = true_dfa.initial_state
+        for i, c in enumerate([None] + w):
+            if c is not None:
+                state = true_dfa.transitions[state][c]
+            key = tuple(w[:i])
+            if len(buckets[state]) < per_state and key not in seen[state]:
+                seen[state].add(key)
+                buckets[state].append(key)
+    chosen = [list(p) for ps in buckets.values() for p in ps]
+    # If the learner can batch a sift, warm the whole sample in one pass so every
+    # sift below is a cache hit; without it the sifts just cost more oracle calls.
+    prefill = getattr(learner, "_sift_prefill", None)
+    if prefill is not None:
+        prefill(chosen)
+    dist: Dict[int, Counter] = {s: Counter() for s in true_dfa.states}
+    for state, ps in buckets.items():
+        for p in ps:
+            dist[state][learner.sift(list(p))] += 1
+    return dist
+
+
+def _breakdown(counter: Counter) -> str:
+    total = sum(counter.values())
+    if not total:
+        return "no samples"
+    parts = "  ".join(
+        ("ind" if cls is None else f"q{cls}") + f" {100 * n / total:.0f}%"
+        for cls, n in counter.most_common()
+    )
+    return f"{parts}  n={total}"
+
+
+# ---------------------------------------------------------------------------
+# layout: dot computes it, we only read the coordinates back
+# ---------------------------------------------------------------------------
+
+
+def _dot_layout(nodes, edges, *, rankdir="LR", nodesep=0.45, ranksep=0.6) -> dict:
+    """Run ``dot`` over a node/edge list and parse its ``plain`` output.
+
+    ``nodes`` is ``{name: (width, height)}`` in inches, ``edges`` a list of
+    ``(tail, head, label)``.  Returns node centres/sizes and edge splines in
+    inches, y pointing up -- ready to draw at equal aspect."""
+    lines = [
+        "digraph {",
+        f'  rankdir={rankdir}; nodesep={nodesep}; ranksep={ranksep};',
+        '  node [shape=circle, fixedsize=true, label=""];',
+    ]
+    for name, (w, h) in nodes.items():
+        lines.append(f'  "{name}" [width={w:.4f}, height={h:.4f}];')
+    for tail, head, label in edges:
+        lab = f' [label="{label}"]' if label else ""
+        lines.append(f'  "{tail}" -> "{head}"{lab};')
+    lines.append("}")
+    plain = subprocess.run(
+        ["dot", "-Tplain"], input="\n".join(lines), text=True,
+        capture_output=True, check=True,
+    ).stdout
+
+    out = {"nodes": {}, "edges": [], "size": (1.0, 1.0)}
+    for line in plain.splitlines():
+        f = shlex.split(line)
+        if not f:
+            continue
+        if f[0] == "graph":
+            out["size"] = (float(f[2]), float(f[3]))
+        elif f[0] == "node":
+            out["nodes"][f[1]] = {
+                "xy": (float(f[2]), float(f[3])),
+                "wh": (float(f[4]), float(f[5])),
+            }
+        elif f[0] == "edge":
+            n = int(f[3])
+            pts = [(float(f[4 + 2 * i]), float(f[5 + 2 * i])) for i in range(n)]
+            rest = f[4 + 2 * n:]
+            label = None
+            if rest and rest[0] not in ("solid", "dashed", "dotted", "bold"):
+                label = (rest[0], (float(rest[1]), float(rest[2])))
+            out["edges"].append({"tail": f[1], "head": f[2], "pts": pts, "label": label})
+    return out
+
+
+def _draw_edges(ax, layout, *, fontsize):
+    for e in layout["edges"]:
+        pts = e["pts"]
+        # dot emits a cubic B-spline: one anchor then triplets of control points.
+        verts, codes = [pts[0]], [Path.MOVETO]
+        for i in range(1, len(pts) - 2, 3):
+            verts += pts[i:i + 3]
+            codes += [Path.CURVE4] * 3
+        ax.add_patch(PathPatch(Path(verts, codes), fill=False,
+                               edgecolor=_MUTED, lw=0.9, zorder=1))
+        tip, prev = np.array(verts[-1]), np.array(verts[-2])
+        d = tip - prev
+        if np.hypot(*d):
+            d = d / np.hypot(*d)
+            ax.add_patch(FancyArrowPatch(
+                tuple(tip - d * 0.06), tuple(tip), arrowstyle="-|>",
+                mutation_scale=8, color=_MUTED, lw=0, zorder=1))
+        if e["label"]:
+            text, (lx, ly) = e["label"]
+            ax.text(lx, ly, text, fontsize=fontsize, color=_MUTED,
+                    ha="center", va="center", zorder=2)
+
+
+def _pie_node(ax, xy, r, shares, *, double=False, lw=1.0):
+    """A node drawn as a pie over ``shares`` -- a list of (colour, fraction)."""
+    start = 90.0
+    for colour, frac in shares:
+        if frac <= 0:
+            continue
+        end = start - 360.0 * frac
+        ax.add_patch(Wedge(xy, r, end, start, facecolor=colour,
+                           edgecolor="none", zorder=3))
+        start = end
+    ax.add_patch(Circle(xy, r, fill=False, edgecolor=_INK, lw=lw, zorder=4))
+    if double:
+        ax.add_patch(Circle(xy, r * 0.84, fill=False, edgecolor=_INK,
+                            lw=lw * 0.8, zorder=4))
+
+
+def _finish(ax, layout, pad=0.35):
+    w, h = layout["size"]
+    ax.set_xlim(-pad, w + pad)
+    ax.set_ylim(-pad, h + pad)
+    ax.set_aspect("equal")
+    ax.axis("off")
+
+
+# ---------------------------------------------------------------------------
+# the three panels
+# ---------------------------------------------------------------------------
+
+
+def _panel_true_dfa(ax, true_dfa, dist, colors):
+    r = 0.30
+    nodes = {str(s): (2 * r, 2 * r) for s in sorted(true_dfa.states)}
+    nodes["__start"] = (0.06, 0.06)
+    edges = [("__start", str(true_dfa.initial_state), None)]
+    for s in sorted(true_dfa.states):
+        merged: Dict[int, List[int]] = {}
+        for c, t in sorted(true_dfa.transitions[s].items()):
+            merged.setdefault(t, []).append(c)
+        for t, syms in merged.items():
+            edges.append((str(s), str(t), ",".join(str(c) for c in syms)))
+    layout = _dot_layout(nodes, edges, rankdir="LR", nodesep=0.9, ranksep=1.3)
+    _draw_edges(ax, layout, fontsize=6.5)
+    for s in sorted(true_dfa.states):
+        counter = dist.get(s, Counter())
+        total = sum(counter.values()) or 1
+        shares = [
+            (_INDECISIVE if cls is None else colors.get(cls, _OTHER), n / total)
+            for cls, n in counter.most_common()
+        ] or [(_INDECISIVE, 1.0)]
+        impure = len([c for c in counter if c is not None]) > 1 or counter.get(None)
+        xy = layout["nodes"][str(s)]["xy"]
+        _pie_node(ax, xy, r, shares,
+                  double=s in true_dfa.final_states, lw=2.0 if impure else 1.0)
+        ax.text(xy[0], xy[1], str(s), fontsize=8.5, weight="bold", color="white",
+                ha="center", va="center", zorder=5,
+                path_effects=_halo())
+        ax.text(xy[0], xy[1] - r - 0.13, _breakdown(counter), fontsize=5.6,
+                color=_MUTED, ha="center", va="top", zorder=5)
+    _finish(ax, layout, pad=0.5)
+
+
+def _walk_tree(node, colors, nodes, edges, labels, *, uid=None):
+    uid = [0] if uid is None else uid
+    uid[0] += 1
+    name = f"n{uid[0]}"
+    if isinstance(node, int):
+        nodes[name] = (0.44, 0.30)
+        labels[name] = ("leaf", f"q{node}", colors.get(node, _OTHER))
+        return name
+    prepend, lookup = node
+    text = _fmt(prepend)
+    nodes[name] = (max(0.52, 0.16 + 0.085 * len(text)), 0.30)
+    labels[name] = ("mid", text, None)
+    for side in (True, False):
+        child = _walk_tree(lookup[side], colors, nodes, edges, labels, uid=uid)
+        edges.append((name, child, "A" if side else "R"))
+    return name
+
+
+def _panel_tree(ax, dt, colors):
+    nodes, edges, labels = {}, [], {}
+    _walk_tree(dt, colors, nodes, edges, labels)
+    layout = _dot_layout(nodes, edges, rankdir="TB", nodesep=0.3, ranksep=0.45)
+    _draw_edges(ax, layout, fontsize=6)
+    for name, (kind, text, colour) in labels.items():
+        xy = layout["nodes"][name]["xy"]
+        w, h = layout["nodes"][name]["wh"]
+        if kind == "leaf":
+            ax.add_patch(matplotlib.patches.FancyBboxPatch(
+                (xy[0] - w / 2, xy[1] - h / 2), w, h,
+                boxstyle="round,pad=0,rounding_size=0.08",
+                facecolor=colour, edgecolor="none", zorder=3))
+            ax.text(*xy, text, fontsize=7.5, color="white", weight="bold",
+                    ha="center", va="center", zorder=4)
+        else:
+            ax.add_patch(matplotlib.patches.FancyBboxPatch(
+                (xy[0] - w / 2, xy[1] - h / 2), w, h,
+                boxstyle="square,pad=0", facecolor="#ffffff",
+                edgecolor=_INK, lw=0.9, zorder=3))
+            ax.text(*xy, text, fontsize=7.5, color=_INK, family="monospace",
+                    ha="center", va="center", zorder=4)
+    _finish(ax, layout, pad=0.3)
+
+
+def _panel_class_dfa(ax, learner, colors, final_states, flipped):
+    # Prefer the learner's totalised transition function; fall back to whatever
+    # edges it has resolved so far, which is all a diagnostic needs.
+    complete = getattr(learner, "_completed_transitions", None)
+    transitions = complete() if complete is not None else learner.transitions
+    finals = set(final_states or ())
+    r = 0.26
+    nodes = {str(s): (2 * r, 2 * r) for s in sorted(transitions)}
+    nodes["__start"] = (0.06, 0.06)
+    edges = [("__start", "0", None)]
+    for s in sorted(transitions):
+        merged: Dict[int, List[int]] = {}
+        for c, t in sorted(transitions[s].items()):
+            merged.setdefault(t, []).append(c)
+        for t, syms in merged.items():
+            edges.append((str(s), str(t), ",".join(str(c) for c in syms)))
+    layout = _dot_layout(nodes, edges, rankdir="LR", nodesep=0.7, ranksep=1.0)
+    _draw_edges(ax, layout, fontsize=6.5)
+    for s in sorted(transitions):
+        xy = layout["nodes"][str(s)]["xy"]
+        ax.add_patch(Circle(xy, r, facecolor=colors.get(s, _OTHER),
+                            edgecolor="none", zorder=3))
+        ax.add_patch(Circle(xy, r, fill=False, zorder=4,
+                            edgecolor="#c0392f" if s in flipped else _INK,
+                            lw=2.4 if s in flipped else 1.0))
+        if s in finals:
+            ax.add_patch(Circle(xy, r * 0.84, fill=False, edgecolor=_INK,
+                                lw=0.8, zorder=4))
+        ax.text(xy[0], xy[1], f"q{s}", fontsize=8, weight="bold", color="white",
+                ha="center", va="center", zorder=5, path_effects=_halo())
+        access = learner.access.get(s)
+        if access is not None:
+            ax.text(xy[0], xy[1] - r - 0.11, _fmt(access)[:16], fontsize=5.4,
+                    color=_MUTED, ha="center", va="top", zorder=5)
+    _finish(ax, layout, pad=0.4)
+
+
+def _halo():
+    from matplotlib import patheffects  # pylint: disable=import-outside-toplevel
+
+    return [patheffects.withStroke(linewidth=1.6, foreground="#00000055")]
+
+
+def render_diagnostics(
+    learner,
+    true_dfa,
+    *,
+    rng,
+    path,
+    num_samples: int = 500,
+    per_state: int = 60,
+    final_states: Optional[set] = None,
+    flipped=(),
+    scale: float = 1.0,
+    dpi: int = 220,
+) -> str:
+    """Write the three panels, stacked, to ``path``.  Returns the path."""
+    import matplotlib.pyplot as plt  # pylint: disable=import-outside-toplevel
+
+    dist = sample_class_distribution(
+        learner, true_dfa, rng=rng, num_samples=num_samples, per_state=per_state
+    )
+    colors = _class_colors(set(range(learner.num_states)))
+    panels = [
+        ("true DFA — shaded by the classes its strings sift to",
+         lambda a: _panel_true_dfa(a, true_dfa, dist, colors)),
+        ("discrimination tree — every internal node is a midfix",
+         lambda a: _panel_tree(a, learner.dt, colors)),
+        ("learned Myhill–Nerode classes",
+         lambda a: _panel_class_dfa(a, learner, colors, final_states, flipped)),
+    ]
+
+    # Measure every panel first.  Each is then drawn at the *same* scale (one
+    # layout inch to one figure inch) rather than stretched to a shared width,
+    # so nodes are the same size in all three and nothing is distorted.
+    probe = plt.figure()
+    extents = []
+    for _, draw in panels:
+        ax = probe.add_subplot(111)
+        draw(ax)
+        (x0, x1), (y0, y1) = ax.get_xlim(), ax.get_ylim()
+        extents.append((x1 - x0, y1 - y0))
+        probe.clf()
+    plt.close(probe)
+
+    sheet_w = max(w for w, _ in extents) * scale
+    heights = [h * scale for _, h in extents]
+    fig, axes = plt.subplots(
+        3, 1, figsize=(sheet_w, sum(heights) + 1.0),
+        gridspec_kw={"height_ratios": heights, "hspace": 0.10},
+    )
+    fig.patch.set_facecolor("white")
+    for ax, (title, draw), (w, _h) in zip(axes, panels, extents):
+        draw(ax)
+        # Widen the view to the sheet so every panel shares one scale, centred.
+        x0, x1 = ax.get_xlim()
+        slack = (sheet_w / scale - w) / 2
+        ax.set_xlim(x0 - slack, x1 + slack)
+        ax.set_title(title, fontsize=8, color=_MUTED, loc="left", pad=6)
+    fig.savefig(path, dpi=dpi, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    return path

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -89,8 +89,9 @@ class TestClassColors(unittest.TestCase):
 
 class TestSampleClassDistribution(unittest.TestCase):
     def test_covers_transient_states_and_counts_indecisives(self):
+        learner = _StubLearner()
         dist = sample_class_distribution(
-            _StubLearner(), PARITY, rng=np.random.default_rng(0),
+            learner.sift, PARITY, pst=learner.pst, rng=np.random.default_rng(0),
             num_samples=40, per_state=25,
         )
         # Bucketing by prefix (not by end state) must reach every true state.
@@ -99,6 +100,30 @@ class TestSampleClassDistribution(unittest.TestCase):
             self.assertGreater(sum(dist[state].values()), 0)
         # The stub sifts length-3 prefixes indecisively, so None must show up.
         self.assertTrue(any(None in c for c in dist.values()))
+
+    def test_accepts_any_classifier_and_an_explicit_pst(self):
+        # A resolver-style classifier: no learner, no .sift, just a callable.
+        seen = []
+        dist = sample_class_distribution(
+            lambda s: seen.append(s) or len(s) % 2,
+            PARITY,
+            pst=_StubPst(),
+            rng=np.random.default_rng(1),
+            num_samples=20,
+            per_state=8,
+        )
+        self.assertEqual(set(dist), set(PARITY.states))
+        self.assertTrue(seen)
+
+    def test_prefill_sees_every_sampled_string(self):
+        learner = _StubLearner()
+        batches = []
+        dist = sample_class_distribution(
+            learner.sift, PARITY, pst=learner.pst, rng=np.random.default_rng(2),
+            num_samples=20, per_state=8, prefill=batches.append,
+        )
+        self.assertEqual(len(batches), 1)  # one batched pass, not one per string
+        self.assertEqual(len(batches[0]), sum(sum(c.values()) for c in dist.values()))
 
 
 class TestRenderDiagnostics(unittest.TestCase):

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,0 +1,118 @@
+import os
+import tempfile
+import unittest
+
+import matplotlib
+import numpy as np
+from automata.fa.dfa import DFA
+
+from orthogonal_dfa.l_star.visualize import (
+    _class_colors,
+    _dot_layout,
+    render_diagnostics,
+    sample_class_distribution,
+)
+
+# render_diagnostics imports pyplot lazily, so this lands before any backend is
+# selected -- the tests must not need a display.
+matplotlib.use("Agg")
+
+# Parity over {0,1}: state 0 accepts an even number of 1s.
+PARITY = DFA(
+    states={0, 1},
+    input_symbols={0, 1},
+    transitions={0: {0: 0, 1: 1}, 1: {0: 1, 1: 0}},
+    initial_state=0,
+    final_states={0},
+    allow_partial=False,
+)
+
+
+class _StubSampler:
+    """Fixed-length uniform strings, like the learner's own sampler."""
+
+    length = 6
+
+    def sample(self, rng, alphabet_size):
+        return [int(c) for c in rng.integers(0, alphabet_size, self.length)]
+
+
+class _StubPst:
+    alphabet_size = 2
+    sampler = _StubSampler()
+
+
+class _StubLearner:
+    """The duck type ``visualize`` consumes -- no DirectLStarLearner needed."""
+
+    pst = _StubPst()
+    num_states = 2
+    dt = ((), {True: 0, False: 1})
+    access = {0: [], 1: [1]}
+    transitions = {0: {0: 0, 1: 1}, 1: {0: 1, 1: 0}}
+
+    def sift(self, seq):
+        if len(seq) == 3:  # exercise the indecisive (false-negative) slice
+            return None
+        return sum(seq) % 2
+
+
+class TestDotLayout(unittest.TestCase):
+    def test_parses_nodes_and_edges(self):
+        layout = _dot_layout(
+            {"a": (0.5, 0.5), "b": (0.5, 0.5)}, [("a", "b", "0,1")]
+        )
+        self.assertEqual(set(layout["nodes"]), {"a", "b"})
+        self.assertEqual(len(layout["edges"]), 1)
+        edge = layout["edges"][0]
+        self.assertEqual((edge["tail"], edge["head"]), ("a", "b"))
+        self.assertGreaterEqual(len(edge["pts"]), 4)  # a cubic spline
+        self.assertEqual(edge["label"][0], "0,1")
+        w, h = layout["size"]
+        self.assertGreater(w, 0)
+        self.assertGreater(h, 0)
+
+    def test_unlabelled_edge_has_no_label(self):
+        layout = _dot_layout({"a": (0.2, 0.2), "b": (0.2, 0.2)}, [("a", "b", None)])
+        self.assertIsNone(layout["edges"][0]["label"])
+
+
+class TestClassColors(unittest.TestCase):
+    def test_distinct_within_the_palette(self):
+        colors = _class_colors(range(8))
+        self.assertEqual(len(set(colors.values())), 8)
+
+    def test_folds_past_the_palette(self):
+        colors = _class_colors(range(11))
+        self.assertEqual(colors[8], colors[10])  # both the "other" slot
+
+
+class TestSampleClassDistribution(unittest.TestCase):
+    def test_covers_transient_states_and_counts_indecisives(self):
+        dist = sample_class_distribution(
+            _StubLearner(), PARITY, rng=np.random.default_rng(0),
+            num_samples=40, per_state=25,
+        )
+        # Bucketing by prefix (not by end state) must reach every true state.
+        self.assertEqual(set(dist), set(PARITY.states))
+        for state in PARITY.states:
+            self.assertGreater(sum(dist[state].values()), 0)
+        # The stub sifts length-3 prefixes indecisively, so None must show up.
+        self.assertTrue(any(None in c for c in dist.values()))
+
+
+class TestRenderDiagnostics(unittest.TestCase):
+    def test_writes_an_image(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "diag.png")
+            path = render_diagnostics(
+                _StubLearner(), PARITY, rng=np.random.default_rng(0), path=out,
+                num_samples=20, per_state=10, final_states={0}, flipped={1},
+                dpi=60,
+            )
+            self.assertEqual(path, out)
+            self.assertGreater(os.path.getsize(out), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -16,6 +17,9 @@ from orthogonal_dfa.l_star.visualize import (
 # render_diagnostics imports pyplot lazily, so this lands before any backend is
 # selected -- the tests must not need a display.
 matplotlib.use("Agg")
+
+# `dot` does the graph layout; without it there is nothing to draw into.
+needs_dot = unittest.skipIf(shutil.which("dot") is None, "graphviz `dot` not installed")
 
 # Parity over {0,1}: state 0 accepts an even number of 1s.
 PARITY = DFA(
@@ -57,11 +61,10 @@ class _StubLearner:
         return sum(seq) % 2
 
 
+@needs_dot
 class TestDotLayout(unittest.TestCase):
     def test_parses_nodes_and_edges(self):
-        layout = _dot_layout(
-            {"a": (0.5, 0.5), "b": (0.5, 0.5)}, [("a", "b", "0,1")]
-        )
+        layout = _dot_layout({"a": (0.5, 0.5), "b": (0.5, 0.5)}, [("a", "b", "0,1")])
         self.assertEqual(set(layout["nodes"]), {"a", "b"})
         self.assertEqual(len(layout["edges"]), 1)
         edge = layout["edges"][0]
@@ -91,8 +94,12 @@ class TestSampleClassDistribution(unittest.TestCase):
     def test_covers_transient_states_and_counts_indecisives(self):
         learner = _StubLearner()
         dist = sample_class_distribution(
-            learner.sift, PARITY, pst=learner.pst, rng=np.random.default_rng(0),
-            num_samples=40, per_state=25,
+            learner.sift,
+            PARITY,
+            pst=learner.pst,
+            rng=np.random.default_rng(0),
+            num_samples=40,
+            per_state=25,
         )
         # Bucketing by prefix (not by end state) must reach every true state.
         self.assertEqual(set(dist), set(PARITY.states))
@@ -119,20 +126,32 @@ class TestSampleClassDistribution(unittest.TestCase):
         learner = _StubLearner()
         batches = []
         dist = sample_class_distribution(
-            learner.sift, PARITY, pst=learner.pst, rng=np.random.default_rng(2),
-            num_samples=20, per_state=8, prefill=batches.append,
+            learner.sift,
+            PARITY,
+            pst=learner.pst,
+            rng=np.random.default_rng(2),
+            num_samples=20,
+            per_state=8,
+            prefill=batches.append,
         )
         self.assertEqual(len(batches), 1)  # one batched pass, not one per string
         self.assertEqual(len(batches[0]), sum(sum(c.values()) for c in dist.values()))
 
 
+@needs_dot
 class TestRenderDiagnostics(unittest.TestCase):
     def test_writes_an_image(self):
         with tempfile.TemporaryDirectory() as d:
             out = os.path.join(d, "diag.png")
             path = render_diagnostics(
-                _StubLearner(), PARITY, rng=np.random.default_rng(0), path=out,
-                num_samples=20, per_state=10, final_states={0}, flipped={1},
+                _StubLearner(),
+                PARITY,
+                rng=np.random.default_rng(0),
+                path=out,
+                num_samples=20,
+                per_state=10,
+                final_states={0},
+                flipped={1},
                 dpi=60,
             )
             self.assertEqual(path, out)


### PR DESCRIPTION
A renderer for inspecting what a direct-L* learner actually did, when the true DFA is known. Three stacked panels share one colour per learned Myhill–Nerode class:

1. **True DFA**, each state drawn as a pie over the classes that random strings *reaching* that state sift to — plus a slice for the indecisive ones (`sift -> None`) the suffix family cannot place.
2. **Discrimination tree**, every internal node labelled with its midfix (the `prepend` sitting between a prefix and each base suffix).
3. **Learned Myhill–Nerode classes**, the DFA over the leaves.

Sharing the colour key is the point: it shows at a glance whether a true state is captured cleanly by one class or smeared across several, and which midfix drew the line.

## Notes

- **Prefixes are bucketed by the state they reach**, not each sample by its end state. The sampler draws a single fixed length, so a transient state can never be an endpoint — bucketing by endpoint silently drops those states and their classes vanish from the picture. Buckets are deduped and capped (`per_state`) so a rare state gets the same support as a common one.
- **`dot` lays out, matplotlib draws.** Layout comes from `dot -Tplain` (node centres + edge splines); matplotlib renders it. That keeps an equal aspect per panel, one shared scale across all three, and output that stays sharp at any dpi — graphviz's own raster output stretched the wide panels and pixelated.
- **Colours** are the categorical palette in a CVD-validated order; classes past the eighth fold into a shared "other" slot rather than inventing hues.

## Dependency

Targets `DirectLStarLearner` from #134, but consumes it **duck-typed** and imports nothing from it. The two private hooks it can use — batched sifting and a totalised transition function — are optional via `getattr`, so this merges independently and works once #134 lands.

## Tests

`tests/test_visualize.py` covers the layout parser, the colour assignment and its fold-over, the prefix-bucketing invariant (every true state represented, indecisives counted), and an end-to-end render — all against a stub learner, so no dependency on #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)