### PR TITLE
Move the E-L* entry point out of the test suite

### DIFF
--- a/orthogonal_dfa/l_star/learn.py
+++ b/orthogonal_dfa/l_star/learn.py
@@ -1,0 +1,107 @@
+"""Run E-L* against an oracle: the configuration entry point.
+
+`counterexample_driven_synthesis` in `lstar` learns from a populated
+PrefixSuffixTracker. Getting to one means sizing the suffix population, the
+evidence margin and the prefix count from the noise level, which is what this
+module does -- so a caller only has to say how much signal the oracle carries.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+import numpy as np
+
+from .lstar import do_counterexample_driven_synthesis
+from .prefix_suffix_tracker import PrefixSuffixTracker, SearchConfig
+from .sampler import UniformSampler
+from .statistics import (
+    compute_suffix_size_counterexample_gen,
+    population_size_and_evidence_margin,
+)
+from .structures import SymmetricBernoulli
+
+#: All of E-L*'s signal comes from words drawn at this length.
+DEFAULT_SAMPLE_LENGTH = 40
+
+#: Accuracy the synthesis loop drives the hypothesis to before stopping.
+DEFAULT_ACC_THRESHOLD = 0.98
+
+#: Prefixes to start from, and counterexamples to add per synthesis round.
+NUM_PREFIXES = 200
+NUM_ADDITIONAL_COUNTEREXAMPLES = 200
+
+
+def build_pst(
+    oracle_creator: Callable[[Any, int], Any],
+    *,
+    min_signal_strength: float,
+    seed: int,
+    noise_model: Optional[Any] = None,
+    min_suffix_frequency: float = 0.05,
+    sample_length: int = DEFAULT_SAMPLE_LENGTH,
+) -> PrefixSuffixTracker:
+    """A PrefixSuffixTracker sized for an oracle carrying `min_signal_strength`.
+
+    The oracle answers correctly with probability `0.5 + min_signal_strength`,
+    and every population size here is derived from that: too small and the
+    row statistics cannot separate states, too large and every query is spent
+    on evidence nobody needs.
+    """
+    effective_p_acc = 0.5 + min_signal_strength
+    if noise_model is None:
+        noise_model = SymmetricBernoulli(p_correct=effective_p_acc)
+    oracle = oracle_creator(noise_model, seed)
+    n, eps = population_size_and_evidence_margin(
+        signal_strength=min_signal_strength, acceptable_fpr=0.01, acceptable_fnr=0.01
+    )
+    config = SearchConfig(
+        suffix_family_size=n,
+        evidence_margin=eps,
+        decision_rule_fpr=0.01,
+        suffix_size_counterexample_gen=compute_suffix_size_counterexample_gen(
+            0.01, effective_p_acc
+        ),
+        min_signal_strength=min_signal_strength,
+        num_addtl_prefixes=NUM_PREFIXES,
+        min_suffix_frequency=min_suffix_frequency,
+    )
+    return PrefixSuffixTracker.create(
+        UniformSampler(sample_length),
+        np.random.default_rng(0),
+        oracle,
+        config,
+        num_prefixes=NUM_PREFIXES,
+    )
+
+
+def learn_dfa(
+    oracle_creator: Callable[[Any, int], Any],
+    *,
+    min_signal_strength: float,
+    seed: int,
+    noise_model: Optional[Any] = None,
+    min_suffix_frequency: float = 0.05,
+    sample_length: int = DEFAULT_SAMPLE_LENGTH,
+    acc_threshold: float = DEFAULT_ACC_THRESHOLD,
+):
+    """Learn a DFA from `oracle_creator`, and return it.
+
+    `oracle_creator(noise_model, seed)` builds the oracle to query; it is a
+    factory rather than an oracle so callers can count or wrap the queries.
+    Returns None when synthesis produced no hypothesis.
+    """
+    pst = build_pst(
+        oracle_creator,
+        min_signal_strength=min_signal_strength,
+        seed=seed,
+        noise_model=noise_model,
+        min_suffix_frequency=min_suffix_frequency,
+        sample_length=sample_length,
+    )
+    dfa, _ = do_counterexample_driven_synthesis(
+        pst,
+        additional_counterexamples=NUM_ADDITIONAL_COUNTEREXAMPLES,
+        acc_threshold=acc_threshold,
+    )
+    return dfa

--- a/scripts/count_queries.py
+++ b/scripts/count_queries.py
@@ -94,7 +94,8 @@ def _measure(root: str, names: list[str]) -> dict:
         BernoulliParityOracle, BernoulliRegex,
     )
     from orthogonal_dfa.l_star.structures import Oracle, AsymmetricBernoulli
-    from tests.test_lstar import compute_dfa_for_oracle, evaluate_accuracy
+    from orthogonal_dfa.l_star.learn import learn_dfa
+    from tests.test_lstar import evaluate_accuracy
 
     class CountingOracle(Oracle):
         def __init__(self, inner):
@@ -153,7 +154,7 @@ def _measure(root: str, names: list[str]) -> dict:
         t0 = time.time()
         # Silence the synthesis chatter; we only want the JSON on stdout.
         with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
-            _, dfa, _ = compute_dfa_for_oracle(
+            dfa = learn_dfa(
                 counting_creator, min_signal_strength=bench["signal"], seed=0,
                 noise_model=noise_model)
             acc = evaluate_accuracy(dfa, creator, symbols=bench["symbols"])

--- a/scripts/profile_query_origins.py
+++ b/scripts/profile_query_origins.py
@@ -29,7 +29,8 @@ from orthogonal_dfa.l_star.examples.bernoulli_parity import (
     BernoulliRegex,
 )
 from orthogonal_dfa.l_star.structures import Oracle
-from tests.test_lstar import compute_dfa_for_oracle, evaluate_accuracy
+from orthogonal_dfa.l_star.learn import learn_dfa
+from tests.test_lstar import evaluate_accuracy
 
 _ANOTHER_POOR_DFA = DFA(
     states=set(range(10)),
@@ -175,7 +176,7 @@ def profile_one(name: str) -> None:
         holder["o"] = o
         return o
 
-    _, dfa, _ = compute_dfa_for_oracle(creator, min_signal_strength=signal, seed=0)
+    dfa = learn_dfa(creator, min_signal_strength=signal, seed=0)
     acc = evaluate_accuracy(dfa, oracle_creator, symbols=symbols)
     o = holder["o"]
 

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -106,72 +106,56 @@ class TestLStar(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, dfa, oracle_creator)
 
     def test_modulo_harder(self):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.2, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.2, seed=0)
         assertDFA(self, dfa, oracle_creator)
 
     def test_modulo_even_harder(self):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.1, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.1, seed=0)
         assertDFA(self, dfa, oracle_creator)
 
     def test_specific_subsequence(self):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*1010101.*"
         )
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, dfa, oracle_creator)
 
     def test_two_subsequences(self):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*1111.*1111.*"
         )
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, dfa, oracle_creator)
 
     def test_two_subsequences_with_alternation(self):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*1111.*(1111|0000)11.*"
         )
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, dfa, oracle_creator)
 
     def test_specific_alternation(self):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*(1111|0000)11.*"
         )
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, dfa, oracle_creator, exclude_pattern=lambda s: s[:5] == [1] * 5)
 
     def test_specific_alternation_with_nothing_at_end_3_syms(self):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*(111|000).*", alphabet_size=3
         )
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, dfa, oracle_creator, symbols=3)
 
     def test_specific_alternation_with_nothing_at_end_does_not_meet_property(self):
@@ -219,9 +203,7 @@ class TestLStar(unittest.TestCase):
             allow_partial=False,
         )
         oracle_creator = lambda nm, s, _dfa=dfa: DFAOracle(nm, s, _dfa)
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, dfa, oracle_creator)
 
     def test_another_countexample_poor_case(self):
@@ -245,9 +227,7 @@ class TestLStar(unittest.TestCase):
             allow_partial=False,
         )
         oracle_creator = lambda nm, s, _dfa=dfa: DFAOracle(nm, s, _dfa)
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, dfa, oracle_creator)
 
     def test_transient_states_terminate(self):
@@ -473,9 +453,7 @@ class TestLStarORF(unittest.TestCase):
     @parameterized.expand([(signal,) for signal in (0.3, 0.2)])
     def test_no_orf(self, signal):
         oracle_creator = AllFramesClosedOracle
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=signal, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=signal, seed=0)
         assertDFA(self, dfa, oracle_creator, symbols=4)
 
 
@@ -492,9 +470,7 @@ class TestLStarOnGeneratedBenchmarks(unittest.TestCase):
         )
         print(outer)
         oracle_creator = lambda nm, s, _dfa=outer: DFAOracle(nm, s, _dfa)
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         accuracy, fp, fn = compute_dfa_accuracy(dfa, oracle_creator)
         if accuracy < 1 - assertion_allowed_error:
             self.fail(
@@ -524,9 +500,7 @@ class TestLStarOnLargeGeneratedBenchmarks(unittest.TestCase):
         )
         print(outer)
         oracle_creator = lambda nm, s, _dfa=outer: DFAOracle(nm, s, _dfa)
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         accuracy, fp, fn = compute_dfa_accuracy(dfa, oracle_creator)
         if accuracy < 1 - assertion_allowed_error:
             self.fail(
@@ -587,9 +561,7 @@ class TestLStarBimodalReproducer(unittest.TestCase):
 
     def test_bimodal_reproducer(self):
         oracle_creator = lambda nm, s, _dfa=self.DFA: DFAOracle(nm, s, _dfa)
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         accuracy, fp, fn = compute_dfa_accuracy(dfa, oracle_creator)
         if accuracy < 1 - assertion_allowed_error:
             self.fail(
@@ -625,9 +597,7 @@ class TestLStarDeepCounter(unittest.TestCase):
             allow_partial=False,
         )
         oracle_creator = lambda nm, s, _d=dfa: DFAOracle(nm, s, _d)
-        learned = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        learned = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, learned, oracle_creator)
 
 
@@ -699,7 +669,5 @@ class TestLStarIndistinguishablePair(unittest.TestCase):
                 f"{self.HARD_PAIR_FRACTION} of length-40 suffixes in 10000 seeds"
             )
         oracle_creator = lambda nm, s, _d=outer: DFAOracle(nm, s, _d)
-        learned = learn_dfa(
-            oracle_creator, min_signal_strength=0.3, seed=0
-        )
+        learned = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, learned, oracle_creator)

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -14,23 +14,13 @@ from orthogonal_dfa.l_star.examples.bernoulli_parity import (
     BernoulliParityOracle,
     BernoulliRegex,
 )
-from orthogonal_dfa.l_star.lstar import do_counterexample_driven_synthesis
-from orthogonal_dfa.l_star.prefix_suffix_tracker import (
-    PrefixSuffixTracker,
-    SearchConfig,
-)
+from orthogonal_dfa.l_star.learn import learn_dfa
 from orthogonal_dfa.l_star.sampler import UniformSampler
-from orthogonal_dfa.l_star.statistics import (
-    compute_prefix_set_size,
-    compute_suffix_size_counterexample_gen,
-    give_up_check,
-    population_size_and_evidence_margin,
-)
+from orthogonal_dfa.l_star.statistics import give_up_check
 from orthogonal_dfa.l_star.structures import AsymmetricBernoulli, SymmetricBernoulli
 
 us = UniformSampler(40)
 
-allowed_error = 0.02
 # assertDFA tolerance — slightly looser than the synthesis target so we don't
 # flake when synthesis converges near the threshold.  See GitHub issue on
 # tightening synthesis output.
@@ -90,70 +80,6 @@ def assertDFA(
         )
 
 
-def compute_dfa_for_oracle(
-    oracle_creator,
-    *,
-    min_signal_strength,
-    seed,
-    noise_model=None,
-    min_suffix_frequency=0.05,
-):
-    pst = compute_pst(
-        oracle_creator,
-        min_signal_strength,
-        seed,
-        noise_model=noise_model,
-        min_suffix_frequency=min_suffix_frequency,
-    )
-    dfa, dt = do_counterexample_driven_synthesis(
-        pst, additional_counterexamples=200, acc_threshold=1 - allowed_error
-    )
-    return pst, dfa, dt
-
-
-def compute_pst(
-    oracle_creator,
-    min_signal_strength,
-    seed,
-    *,
-    use_dynamic=True,
-    noise_model=None,
-    min_suffix_frequency=0.05,
-):
-    effective_p_acc = 0.5 + min_signal_strength
-    if noise_model is None:
-        noise_model = SymmetricBernoulli(p_correct=effective_p_acc)
-    oracle = oracle_creator(noise_model, seed)
-    n, eps = population_size_and_evidence_margin(
-        signal_strength=min_signal_strength, acceptable_fpr=0.01, acceptable_fnr=0.01
-    )
-    k = compute_prefix_set_size(0.05, effective_p_acc, 0.05)
-    suffix_size = compute_suffix_size_counterexample_gen(0.01, effective_p_acc)
-    num_prefixes = 200 if use_dynamic else k
-    config = SearchConfig(
-        suffix_family_size=n,
-        evidence_margin=eps,
-        decision_rule_fpr=0.01,
-        suffix_size_counterexample_gen=suffix_size,
-        min_signal_strength=min_signal_strength,
-        num_addtl_prefixes=200 if use_dynamic else None,
-        min_suffix_frequency=min_suffix_frequency,
-    )
-    print(
-        f"Using suffix population size {n}, eps {eps}, and {k} prefixes "
-        f"(signal strength {min_signal_strength})."
-    )
-    pst = PrefixSuffixTracker.create(
-        us,
-        np.random.default_rng(0),
-        oracle,
-        config,
-        num_prefixes=num_prefixes,
-    )
-
-    return pst
-
-
 def assertDoesNotMeetProperty(
     testcase, oracle_creator, counterexample_generator, count=10_000
 ):
@@ -180,7 +106,7 @@ class TestLStar(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, dfa, oracle_creator)
@@ -189,7 +115,7 @@ class TestLStar(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.2, seed=0
         )
         assertDFA(self, dfa, oracle_creator)
@@ -198,7 +124,7 @@ class TestLStar(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliParityOracle(
             noise_model, seed, modulo=9, allowed_moduluses=(3, 6)
         )
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.1, seed=0
         )
         assertDFA(self, dfa, oracle_creator)
@@ -207,7 +133,7 @@ class TestLStar(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*1010101.*"
         )
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, dfa, oracle_creator)
@@ -216,7 +142,7 @@ class TestLStar(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*1111.*1111.*"
         )
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, dfa, oracle_creator)
@@ -225,7 +151,7 @@ class TestLStar(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*1111.*(1111|0000)11.*"
         )
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, dfa, oracle_creator)
@@ -234,7 +160,7 @@ class TestLStar(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*(1111|0000)11.*"
         )
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, dfa, oracle_creator, exclude_pattern=lambda s: s[:5] == [1] * 5)
@@ -243,7 +169,7 @@ class TestLStar(unittest.TestCase):
         oracle_creator = lambda noise_model, seed: BernoulliRegex(
             noise_model, seed, regex=r".*(111|000).*", alphabet_size=3
         )
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, dfa, oracle_creator, symbols=3)
@@ -293,7 +219,7 @@ class TestLStar(unittest.TestCase):
             allow_partial=False,
         )
         oracle_creator = lambda nm, s, _dfa=dfa: DFAOracle(nm, s, _dfa)
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, dfa, oracle_creator)
@@ -319,7 +245,7 @@ class TestLStar(unittest.TestCase):
             allow_partial=False,
         )
         oracle_creator = lambda nm, s, _dfa=dfa: DFAOracle(nm, s, _dfa)
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, dfa, oracle_creator)
@@ -361,7 +287,7 @@ class TestLStar(unittest.TestCase):
         previous = signal.signal(signal.SIGALRM, _timeout)
         signal.alarm(60)
         try:
-            compute_dfa_for_oracle(oracle_creator, min_signal_strength=0.45, seed=0)
+            learn_dfa(oracle_creator, min_signal_strength=0.45, seed=0)
         finally:
             signal.alarm(0)
             signal.signal(signal.SIGALRM, previous)
@@ -374,7 +300,7 @@ class TestLStarAsymmetric(unittest.TestCase):
         )
         noise_model = AsymmetricBernoulli(p_0=0.05, p_1=0.85)
         # signal = (0.85 - 0.05) / 2 = 0.4, but for now we're using 0.35 to be safe.
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.35, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
@@ -385,7 +311,7 @@ class TestLStarAsymmetric(unittest.TestCase):
         )
         noise_model = AsymmetricBernoulli(p_0=0.25, p_1=0.95)
         # signal = (0.95 - 0.25) / 2 = 0.35, but for now we're using 0.25 to be safe.
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.25, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
@@ -396,7 +322,7 @@ class TestLStarAsymmetric(unittest.TestCase):
         )
         noise_model = AsymmetricBernoulli(p_0=0.15, p_1=0.7)
         # signal = (0.7 - 0.15) / 2 = 0.275, but for now we're using 0.2 to be safe.
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.2, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
@@ -408,7 +334,7 @@ class TestLStarAsymmetric(unittest.TestCase):
         )
         noise_model = AsymmetricBernoulli(p_0=p_0, p_1=p_1)
         # signal = (p_1 - p_0) / 2, so 0.15 in both cases.
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.15, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
@@ -420,7 +346,7 @@ class TestLStarAsymmetric(unittest.TestCase):
         )
         noise_model = AsymmetricBernoulli(p_0=0.50, p_1=0.80)
         # signal = 0.15, boundary = 0.65
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.15, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
@@ -432,7 +358,7 @@ class TestLStarAsymmetric(unittest.TestCase):
         )
         noise_model = AsymmetricBernoulli(p_0=0.15, p_1=0.75)
         # signal = 0.30, boundary = 0.45
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.25, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
@@ -449,7 +375,7 @@ class TestLStarAsymmetric(unittest.TestCase):
         )
         noise_model = AsymmetricBernoulli(p_0=0.02, p_1=0.42)
         # signal = 0.20, boundary = 0.22
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.15, seed=0, noise_model=noise_model
         )
         assertDFA(self, dfa, oracle_creator)
@@ -535,7 +461,7 @@ class TestGiveUpThreshold(unittest.TestCase):
         )
         noise_model = AsymmetricBernoulli(p_0=0.5, p_1=0.5)
         with self.assertRaises(GaveUpOnSuffixSearch):
-            compute_dfa_for_oracle(
+            learn_dfa(
                 oracle_creator,
                 min_signal_strength=0.3,
                 seed=0,
@@ -547,7 +473,7 @@ class TestLStarORF(unittest.TestCase):
     @parameterized.expand([(signal,) for signal in (0.3, 0.2)])
     def test_no_orf(self, signal):
         oracle_creator = AllFramesClosedOracle
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=signal, seed=0
         )
         assertDFA(self, dfa, oracle_creator, symbols=4)
@@ -566,7 +492,7 @@ class TestLStarOnGeneratedBenchmarks(unittest.TestCase):
         )
         print(outer)
         oracle_creator = lambda nm, s, _dfa=outer: DFAOracle(nm, s, _dfa)
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         accuracy, fp, fn = compute_dfa_accuracy(dfa, oracle_creator)
@@ -598,7 +524,7 @@ class TestLStarOnLargeGeneratedBenchmarks(unittest.TestCase):
         )
         print(outer)
         oracle_creator = lambda nm, s, _dfa=outer: DFAOracle(nm, s, _dfa)
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         accuracy, fp, fn = compute_dfa_accuracy(dfa, oracle_creator)
@@ -661,7 +587,7 @@ class TestLStarBimodalReproducer(unittest.TestCase):
 
     def test_bimodal_reproducer(self):
         oracle_creator = lambda nm, s, _dfa=self.DFA: DFAOracle(nm, s, _dfa)
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         accuracy, fp, fn = compute_dfa_accuracy(dfa, oracle_creator)
@@ -699,7 +625,7 @@ class TestLStarDeepCounter(unittest.TestCase):
             allow_partial=False,
         )
         oracle_creator = lambda nm, s, _d=dfa: DFAOracle(nm, s, _d)
-        _, learned, _ = compute_dfa_for_oracle(
+        learned = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, learned, oracle_creator)
@@ -773,7 +699,7 @@ class TestLStarIndistinguishablePair(unittest.TestCase):
                 f"{self.HARD_PAIR_FRACTION} of length-40 suffixes in 10000 seeds"
             )
         oracle_creator = lambda nm, s, _d=outer: DFAOracle(nm, s, _d)
-        _, learned, _ = compute_dfa_for_oracle(
+        learned = learn_dfa(
             oracle_creator, min_signal_strength=0.3, seed=0
         )
         assertDFA(self, learned, oracle_creator)

--- a/tests/test_random_dfa_validation.py
+++ b/tests/test_random_dfa_validation.py
@@ -35,9 +35,7 @@ def _elstar_accuracy(aut) -> float:
     old = signal.signal(signal.SIGALRM, _timeout)
     signal.alarm(PER_DFA_TIMEOUT)
     try:
-        dfa = learn_dfa(
-            oracle_creator, min_signal_strength=0.5 - ETA, seed=0
-        )
+        dfa = learn_dfa(oracle_creator, min_signal_strength=0.5 - ETA, seed=0)
         if dfa is None:
             return 0.0
         acc, _, _ = compute_dfa_accuracy(dfa, oracle_creator)

--- a/tests/test_random_dfa_validation.py
+++ b/tests/test_random_dfa_validation.py
@@ -12,7 +12,8 @@ from orthogonal_dfa.l_star.examples.benchmark_generator import (
     DFAOracle,
     sample_random_dfa,
 )
-from tests.test_lstar import compute_dfa_accuracy, compute_dfa_for_oracle
+from orthogonal_dfa.l_star.learn import learn_dfa
+from tests.test_lstar import compute_dfa_accuracy
 
 NUM_DFAS = 600
 ETA = 0.05
@@ -34,7 +35,7 @@ def _elstar_accuracy(aut) -> float:
     old = signal.signal(signal.SIGALRM, _timeout)
     signal.alarm(PER_DFA_TIMEOUT)
     try:
-        _, dfa, _ = compute_dfa_for_oracle(
+        dfa = learn_dfa(
             oracle_creator, min_signal_strength=0.5 - ETA, seed=0
         )
         if dfa is None:


### PR DESCRIPTION
Split off `capal-comparison`. Independent of #138.

## The problem

`compute_dfa_for_oracle` is *the* way to run E-L\*: it derives `SearchConfig` from the statistics helpers and calls `do_counterexample_driven_synthesis`, which already lives in the package. But it sat in `tests/test_lstar.py`, so three non-test consumers imported it from the test suite:

```
scripts/count_queries.py         → from tests.test_lstar import compute_dfa_for_oracle
scripts/profile_query_origins.py → from tests.test_lstar import compute_dfa_for_oracle
orthogonal_dfa/experiments/capal_comparison/core.py → same, via a lazy import
```

The package depended on its own test suite to learn a DFA. Install without `tests/` on the path and `scripts/` breaks.

## What's here

`orthogonal_dfa/l_star/learn.py`:

- `learn_dfa(oracle_creator, *, min_signal_strength, seed, ...) -> DFA`
- `build_pst(...) -> PrefixSuffixTracker` for callers that want the tracker

`tests/test_lstar.py` no longer defines either; its call sites are `dfa = learn_dfa(...)`.

## Four deliberate changes

1. **Returns the DFA, not `(pst, dfa, dt)`.** All 27 call sites were `_, dfa, _ = ...` — the triple exported test-internal plumbing as the public shape.
2. **`allowed_error = 0.02`** was a module-level test tolerance feeding `acc_threshold=1 - allowed_error`. It becomes `DEFAULT_ACC_THRESHOLD = 0.98`, a real library default.
3. **`use_dynamic` removed.** Nothing ever passed `False`, so `compute_prefix_set_size` was called on every single learn purely to compute a value for a branch that never ran.
4. **The stdout `print` removed.** A library shouldn't narrate; it's why the CAPAL harness wrapped the call in `redirect_stdout`.

## Behaviour

Otherwise identical. Worth one note: the original passed a single module-level `us = UniformSampler(40)` to every call and this constructs one per call. That's equivalent — `UniformSampler` is a frozen dataclass holding only `length`, with the rng passed into `sample`. Had it carried rng state, this would have silently changed every result, so I checked rather than assumed.

## Verification

`tests/test_lstar.py` + `tests/test_random_dfa_validation.py`: **47 passed, 1 xfailed** (57 minutes) — the full E-L\* suite plus the 600-random-DFA precondition validation, both unmodified except at their call sites.

## Not addressed

`scripts/` still imports `evaluate_accuracy`, and `test_random_dfa_validation` still imports `compute_dfa_accuracy`, from `tests.test_lstar`. Those are genuinely test helpers, so this reduces the dependency on the test suite rather than eliminating it. Say the word if you want them moved too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)