### PR TITLE
Narrow the acceptance-rate precondition to a degeneracy check

### DIFF
--- a/orthogonal_dfa/l_star/preconditions.py
+++ b/orthogonal_dfa/l_star/preconditions.py
@@ -6,7 +6,7 @@ PreconditionReport -- truthy iff the DFA is admitted, and carrying the measured
 values and a reason per failed condition. The conditions, for a particular
 length of uniform sampling:
 
-- acceptance_rate: the language does not accept or reject nearly all strings
+- acceptance_rate: the sampled strings are not all accepted or all rejected
 - class_preserving_fraction: some fraction of suffixes map all accept
   states to an accept state and all reject states to a reject state
 - covered_accuracy_ceiling: re-rooting the target at the best *covered* start
@@ -148,7 +148,6 @@ def satisfies_preconditions(
     dfa: DFA,
     *,
     length: int,
-    min_accept_or_reject: float = 0.15,
     min_class_preserving_frac: float = 0.05,
     min_covered_accuracy: float = 0.99,
     num_samples: int = DEFAULT_NUM_SAMPLES,
@@ -158,9 +157,14 @@ def satisfies_preconditions(
 
     All under length-``length`` uniform sampling:
 
-    - acceptance rate in ``[min_accept_or_reject, 1 - min_accept_or_reject]``;
+    - acceptance rate strictly between 0 and 1;
     - class-preserving fraction at least ``min_class_preserving_frac``;
     - covered-accuracy ceiling at least ``min_covered_accuracy``
+
+    The acceptance-rate check only rejects degeneracy -- a language that is
+    constant over the sampled strings, which E-L* cannot get signal from and
+    which the other two checks pass trivially. It carries no balance
+    requirement: an imbalanced language is the class-preserving check's business.
 
     Checks run in increasing cost. By default they stop at the first failure,
     which is what a caller wanting only a verdict should do; pass
@@ -168,10 +172,10 @@ def satisfies_preconditions(
     """
     reasons: List[str] = []
     rate = acceptance_rate(dfa, length=length, num_samples=num_samples)
-    if not min_accept_or_reject <= rate <= 1 - min_accept_or_reject:
+    if rate in (0.0, 1.0):
         reasons.append(
-            f"acceptance rate {rate:.3f} outside "
-            f"[{min_accept_or_reject}, {1 - min_accept_or_reject}]"
+            f"acceptance rate {rate} degenerate: every sampled string of length "
+            f"{length} has the same label"
         )
         if short_circuit:
             return PreconditionReport(length, rate, reasons=tuple(reasons))

--- a/tests/test_preconditions.py
+++ b/tests/test_preconditions.py
@@ -53,6 +53,19 @@ RECURRENT_BUT_UNCOVERED = DFA(
 )
 
 
+# Counts 1s mod 9 and accepts one residue: strongly connected and learnable,
+# but only ~13% of length-40 strings are accepted, so a balance requirement on
+# the acceptance rate would reject it.
+MOD9_SKEWED = DFA(
+    states=set(range(9)),
+    input_symbols={0, 1},
+    transitions={q: {0: q, 1: (q + 1) % 9} for q in range(9)},
+    initial_state=0,
+    final_states={1},
+    allow_partial=False,
+)
+
+
 def _constant_dfa(final_states):
     return DFA(
         states={0},
@@ -106,13 +119,24 @@ class TestSatisfiesPreconditions(unittest.TestCase):
         self.assertTrue(P.satisfies_preconditions(MOD3, length=40))
 
     def test_degenerate_acceptance_rate_fails(self):
-        self.assertFalse(P.satisfies_preconditions(_constant_dfa({0}), length=40))
-        self.assertFalse(P.satisfies_preconditions(_constant_dfa(set()), length=40))
+        # The other two checks pass a constant language trivially, so the
+        # acceptance rate is the only one that can reject it.
+        for finals in ({0}, set()):
+            report = P.satisfies_preconditions(_constant_dfa(finals), length=40)
+            self.assertFalse(report)
+            self.assertIn("degenerate", report.reasons[0])
+
+    def test_skewed_but_non_degenerate_target_passes(self):
+        # Only 13% accepted, so the acceptance-rate check must not impose
+        # balance: E-L* learns this one to accuracy 1.0.
+        self.assertLess(P.acceptance_rate(MOD9_SKEWED, length=40), 0.15)
+        self.assertTrue(P.satisfies_preconditions(MOD9_SKEWED, length=40))
 
     def test_ceiling_catches_transient_states(self):
-        # Difficult09 is balanced and class-preserving, so only the covered-
-        # accuracy ceiling catches it: the decision lives in transient states.
-        self.assertTrue(0.15 <= P.acceptance_rate(DIFFICULT09, length=40) <= 0.85)
+        # Difficult09 is non-degenerate and class-preserving, so only the
+        # covered-accuracy ceiling catches it: the decision lives in transient
+        # states.
+        self.assertNotIn(P.acceptance_rate(DIFFICULT09, length=40), (0.0, 1.0))
         self.assertGreaterEqual(
             P.class_preserving_fraction(DIFFICULT09, length=40), 0.05
         )


### PR DESCRIPTION
`satisfies_preconditions` required the acceptance rate to sit in `[0.15, 0.85]`. That band is a **balance** requirement, and balance is not what E-L* needs — it needs signal, which the class-preserving check already measures. This replaces it with the degeneracy check it was standing in for: reject only a rate of exactly 0 or 1, where every sampled string of the given length carries the same label.

`min_accept_or_reject` leaves the signature. The identically named argument to `sample_balanced_benchmark` is untouched — that one is a rejection-sampling filter for generating a balanced benchmark distribution, not an admission criterion.

## Why the band was the wrong shape

The band's job turns out to be entirely degeneracy rejection. Measured on the 600 random 2–5 state DFAs of `tests/test_random_dfa_validation.py`, dropping the acceptance-rate criterion *entirely* takes admissions from 35 to 194, and all 159 newly-admitted DFAs have an acceptance rate of exactly 0.0 or 1.0:

```
 145  truly constant (minify to 1 state)
   0  constant language, >1 state
  14  non-constant language, constant at length 40
```

Nothing else can catch these: a one-state DFA is trivially class-preserving (`cp = 1.0`) and trivially covered (`ceiling = 1.0`), so the acceptance rate is the only criterion that can express "this language is degenerate". The criterion has to stay.

But nothing in the band's *interior* is doing work. A degeneracy-only gate admits **the identical 35/600** — and since it is strictly weaker than the band, equal counts means equal sets, so `test_random_dfa_validation` sees exactly the same DFAs. Every target the band rejects on rate grounds but a degeneracy check would admit is caught by the class-preserving check instead.

## Effect on the benchmark suites

Verdicts are unchanged on both families used by the CAPAL comparison — 3/28 of CAPAL's `.taf` targets and 4/5 of this repo's oracles, exactly as today. The targets that sit outside `[0.15, 0.85]` without being degenerate (`Difficult02` at 0.108, `Simple05` at 0.923, `regex_alt_111_or_000_3sym` at 0.879) all fail the class-preserving check anyway.

## What does change

One thing the band rejected that a degeneracy check admits, and should: a mod-9 counter accepting a single residue. It accepts 13% of length-40 strings — under the old floor — is strongly connected, `cp = 0.112`, `ceiling = 1.0`, and E-L* learns it to **accuracy 1.0**. That is the new regression test, alongside a tightened degenerate-language test that now asserts the reason string as well as the verdict.

## Verification

`tests/test_preconditions.py` 10/10 pass; pylint 10.00/10 on both touched files.

Note that `data/capal/*.json` on #114/#138 records `reasons` strings produced by the old criterion, so those regime reports will re-render on the next sweep. No admitted/excluded cell changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)