### PR TITLE
Stop the counterexample search on its own yield, not on hypothesis accuracy

### DIFF
--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -28,7 +28,7 @@ from .dfa_utils import (
     sample_string_reaching_state,
     states_intermediate,
 )
-from .statistics import binomial_side_of_boundary, unlikely_this_many_agreements
+from .statistics import binomial_side_of_boundary, counterexample_search_exhausted
 from .structures import DecisionTree, DecisionTreeLeafNode, TriPredicate, classify_many
 from .transition_resolver import resolve_dfa
 
@@ -116,7 +116,7 @@ def denoise_accept_labels(pst, dfa, *, max_samples=200, block_size=32):
     )
 
 
-def add_counterexample_prefixes(pst, dt, dfa, count, *, expected_acc):
+def add_counterexample_prefixes(pst, dt, dfa, count):
     results = generate_counterexamples(
         pst,
         pst.sampler,
@@ -124,7 +124,6 @@ def add_counterexample_prefixes(pst, dt, dfa, count, *, expected_acc):
         dt,
         dfa,
         count=count,
-        expected_acc=expected_acc,
     )
     if results:
         pst.table.add_prefixes(results)
@@ -156,7 +155,17 @@ def locate_incorrect_point(oracle, dt, dfa, x, y, *, s0, s_end):
     return x + y[: correct_idx + 1], y[correct_idx + 1]
 
 
-def generate_counterexamples(pst, us, oracle, dt, dfa, *, count, expected_acc):
+#: Draws allowed per counterexample search, as a multiple of the prefixes asked
+#: for. The search yields only where the tree and the DFA disagree, so it needs
+#: room for a low hit rate without running unbounded.
+SAMPLES_PER_COUNTEREXAMPLE = 50
+
+
+def counterexample_sample_budget(count: int) -> int:
+    return SAMPLES_PER_COUNTEREXAMPLE * count
+
+
+def generate_counterexamples(pst, us, oracle, dt, dfa, *, count):
     boundary = pst.decision_boundary
     # The counterexample pipeline classifies strings many times: ~log2(string_len)
     # binary search steps + 2 decisive checks, each traversing the full DT.  A
@@ -182,7 +191,9 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count, expected_acc):
     pbar = tqdm.tqdm(total=count)
     additional_prefixes = []
     num_samples = 0
-    num_agreements = 0
+    #: Draw budget for one call. The search only terminates on `count` or on
+    #: running out of yield, so it needs a ceiling of its own.
+    max_samples = counterexample_sample_budget(count)
     while True:
         num_samples += 1
         x = us.sample(pst.rng, pst.alphabet_size)
@@ -203,18 +214,18 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count, expected_acc):
                 else None
             ),
         )
+        if counterexample_search_exhausted(
+            len(additional_prefixes), num_samples, count, max_samples
+        ):
+            warnings.warn(
+                f"Counterexample search yielded {len(additional_prefixes)}/{count}"
+                f" prefixes in {num_samples} samples; the decision tree and the"
+                f" DFA disagree too rarely to reach {count} within"
+                f" {max_samples} samples"
+            )
+            pbar.close()
+            return additional_prefixes
         if prefix is None:
-            num_agreements += sym == "no inconsistency"
-            if unlikely_this_many_agreements(num_agreements, num_samples, expected_acc):
-                warnings.warn(
-                    f"Observed {num_agreements} 'no inconsistency' results in"
-                    f" {num_samples} samples, which is unlikely given expected"
-                    f" accuracy {expected_acc:.3f}; stopping counterexample"
-                    f" search early with {len(additional_prefixes)}/{count}"
-                    f" prefixes"
-                )
-                pbar.close()
-                return additional_prefixes
             continue
         if prefix in additional_prefixes or pst.table.contains_prefix(prefix):
             continue
@@ -269,9 +280,9 @@ def estimate_agreement_rate(
 
     Sampling stops early as soon as a one-sided binomial test is confident which
     side of *acc_threshold* the true rate lies on.  The estimate is consumed only
-    to decide ``true_acc >= acc_threshold`` (the termination test) and as a loose
-    ``expected_acc`` guard for counterexample search, so settling that decision is
-    all the precision required.  When the true rate is far from the threshold a few
+    to decide ``true_acc >= acc_threshold`` (the termination test), so settling
+    that decision is all the precision required.  When the true rate is far from
+    the threshold a few
     dozen samples settle it, but near the threshold it can run to the full
     *num_samples* budget (e.g. on the poor_case guard it hits the cap on most
     calls), which is why that budget caps the cost.
@@ -470,7 +481,7 @@ def counterexample_driven_synthesis(
             yield dfa, dt, None
             return
         ce = add_counterexample_prefixes(
-            pst, dt, dfa, additional_counterexamples, expected_acc=true_acc
+            pst, dt, dfa, additional_counterexamples
         )
         enriched = enrich_underrepresented_leaves(
             pst, dt_decisive, count=additional_counterexamples

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -480,9 +480,7 @@ def counterexample_driven_synthesis(
             )
             yield dfa, dt, None
             return
-        ce = add_counterexample_prefixes(
-            pst, dt, dfa, additional_counterexamples
-        )
+        ce = add_counterexample_prefixes(pst, dt, dfa, additional_counterexamples)
         enriched = enrich_underrepresented_leaves(
             pst, dt_decisive, count=additional_counterexamples
         )

--- a/orthogonal_dfa/l_star/lstar.py
+++ b/orthogonal_dfa/l_star/lstar.py
@@ -155,9 +155,7 @@ def locate_incorrect_point(oracle, dt, dfa, x, y, *, s0, s_end):
     return x + y[: correct_idx + 1], y[correct_idx + 1]
 
 
-#: Draws allowed per counterexample search, as a multiple of the prefixes asked
-#: for. The search yields only where the tree and the DFA disagree, so it needs
-#: room for a low hit rate without running unbounded.
+#: Draws allowed per counterexample search, per prefix asked for.
 SAMPLES_PER_COUNTEREXAMPLE = 50
 
 
@@ -191,8 +189,6 @@ def generate_counterexamples(pst, us, oracle, dt, dfa, *, count):
     pbar = tqdm.tqdm(total=count)
     additional_prefixes = []
     num_samples = 0
-    #: Draw budget for one call. The search only terminates on `count` or on
-    #: running out of yield, so it needs a ceiling of its own.
     max_samples = counterexample_sample_budget(count)
     while True:
         num_samples += 1
@@ -282,10 +278,9 @@ def estimate_agreement_rate(
     side of *acc_threshold* the true rate lies on.  The estimate is consumed only
     to decide ``true_acc >= acc_threshold`` (the termination test), so settling
     that decision is all the precision required.  When the true rate is far from
-    the threshold a few
-    dozen samples settle it, but near the threshold it can run to the full
-    *num_samples* budget (e.g. on the poor_case guard it hits the cap on most
-    calls), which is why that budget caps the cost.
+    the threshold a few dozen samples settle it, but near the threshold it can run
+    to the full *num_samples* budget (e.g. on the poor_case guard it hits the cap
+    on most calls), which is why that budget caps the cost.
 
     Samples whose ``y`` classifications are independent are drawn in a chunk and
     classified through ``classify_many`` -- one oracle call per tree level for the

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -234,12 +234,32 @@ def compute_suffix_size_counterexample_gen(acceptable_misclassification, noise_l
     raise ValueError("not reachable")
 
 
-def unlikely_this_many_agreements(num_agreements, num_samples, expected_acc):
+def counterexample_search_exhausted(
+    num_found, num_samples, count, max_samples, *, failure_prob=1e-5
+):
+    """Whether the counterexample search cannot plausibly reach ``count``
+    prefixes within ``max_samples`` draws.
+
+    Conditioned on the rate at which the decision tree and the DFA actually
+    disagree -- the thing this search samples -- rather than on the
+    hypothesis's accuracy against the target. The two coincide only while the
+    tree is a good proxy for the target: a degenerate tree agrees with an
+    equally degenerate DFA nearly everywhere while both are wrong, so accuracy
+    is not evidence about this search's yield, and reading it as such stops the
+    search exactly when the prefixes it would add are most needed.
     """
-    Computes whether observing num_agreements or more agreements in num_samples samples is unlikely given expected_acc.
-    """
-    pval = 1 - scipy.stats.binom.cdf(num_agreements - 1, num_samples, expected_acc)
-    return pval < 1e-5
+    remaining = max_samples - num_samples
+    if remaining <= 0:
+        return True
+    still_wanted = count - num_found
+    if still_wanted <= 0:
+        return False
+    # Optimistic (upper) bound on the yield rate given what we have seen, so we
+    # stop only once even a lucky continuation could not get there.
+    yield_hi = scipy.stats.beta.ppf(
+        1 - failure_prob, num_found + 1, max(num_samples - num_found, 1)
+    )
+    return yield_hi * remaining < still_wanted
 
 
 def binomial_side_of_boundary(num_accepts, num_samples, boundary, *, failure_prob=1e-5):

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -237,20 +237,8 @@ def compute_suffix_size_counterexample_gen(acceptable_misclassification, noise_l
 def counterexample_search_exhausted(
     num_found, num_samples, count, max_samples, *, failure_prob=1e-5
 ):
-    """Whether the search is yielding too slowly to reach ``count`` prefixes in
-    ``max_samples`` draws.
-
-    One-sided binomial test of the hits so far against ``count / max_samples``,
-    the rate the search has to sustain.
-
-    The null is the rate at which the decision tree and the DFA actually
-    disagree -- the thing this search samples -- not the hypothesis's accuracy
-    against the target. Those coincide only while the tree is a good proxy for
-    the target: a degenerate tree agrees with an equally degenerate DFA nearly
-    everywhere while both are wrong, so accuracy is not evidence about this
-    search's yield, and testing against it stops the search exactly when the
-    prefixes it would add are most needed.
-    """
+    """Whether the hits so far are too far below ``count / max_samples``, the
+    rate the search has to sustain to reach ``count``."""
     needed_rate = count / max_samples
     pval = scipy.stats.binom.cdf(num_found, num_samples, needed_rate)
     return pval < failure_prob

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -237,29 +237,23 @@ def compute_suffix_size_counterexample_gen(acceptable_misclassification, noise_l
 def counterexample_search_exhausted(
     num_found, num_samples, count, max_samples, *, failure_prob=1e-5
 ):
-    """Whether the counterexample search cannot plausibly reach ``count``
-    prefixes within ``max_samples`` draws.
+    """Whether the search is yielding too slowly to reach ``count`` prefixes in
+    ``max_samples`` draws.
 
-    Conditioned on the rate at which the decision tree and the DFA actually
-    disagree -- the thing this search samples -- rather than on the
-    hypothesis's accuracy against the target. The two coincide only while the
-    tree is a good proxy for the target: a degenerate tree agrees with an
-    equally degenerate DFA nearly everywhere while both are wrong, so accuracy
-    is not evidence about this search's yield, and reading it as such stops the
-    search exactly when the prefixes it would add are most needed.
+    One-sided binomial test of the hits so far against ``count / max_samples``,
+    the rate the search has to sustain.
+
+    The null is the rate at which the decision tree and the DFA actually
+    disagree -- the thing this search samples -- not the hypothesis's accuracy
+    against the target. Those coincide only while the tree is a good proxy for
+    the target: a degenerate tree agrees with an equally degenerate DFA nearly
+    everywhere while both are wrong, so accuracy is not evidence about this
+    search's yield, and testing against it stops the search exactly when the
+    prefixes it would add are most needed.
     """
-    remaining = max_samples - num_samples
-    if remaining <= 0:
-        return True
-    still_wanted = count - num_found
-    if still_wanted <= 0:
-        return False
-    # Optimistic (upper) bound on the yield rate given what we have seen, so we
-    # stop only once even a lucky continuation could not get there.
-    yield_hi = scipy.stats.beta.ppf(
-        1 - failure_prob, num_found + 1, max(num_samples - num_found, 1)
-    )
-    return yield_hi * remaining < still_wanted
+    needed_rate = count / max_samples
+    pval = scipy.stats.binom.cdf(num_found, num_samples, needed_rate)
+    return pval < failure_prob
 
 
 def binomial_side_of_boundary(num_accepts, num_samples, boundary, *, failure_prob=1e-5):

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -696,23 +696,29 @@ class TestCounterexampleSearchExhausted(unittest.TestCase):
             counterexample_search_exhausted(30, 400, self.COUNT, self.BUDGET)
         )
 
-    def test_fires_once_the_budget_is_spent(self):
-        self.assertTrue(
-            counterexample_search_exhausted(5, self.BUDGET, self.COUNT, self.BUDGET)
-        )
-
-    def test_fires_when_the_yield_cannot_reach_count(self):
-        # Nothing found with almost the whole budget gone: no continuation gets
-        # to COUNT, so spending the rest is waste.
-        self.assertTrue(
-            counterexample_search_exhausted(
-                0, self.BUDGET - 10, self.COUNT, self.BUDGET
-            )
-        )
-
-    def test_never_fires_once_count_is_reached(self):
+    def test_does_not_fire_on_a_search_running_to_pace(self):
+        # Exactly the needed rate, nearly the whole budget spent.
         self.assertFalse(
             counterexample_search_exhausted(
                 self.COUNT, self.BUDGET - 1, self.COUNT, self.BUDGET
             )
+        )
+
+    def test_fires_on_a_dry_search_long_before_the_budget(self):
+        # Nothing at all: no need to spend the remaining draws to know.
+        self.assertTrue(
+            counterexample_search_exhausted(0, 600, self.COUNT, self.BUDGET)
+        )
+        self.assertFalse(
+            counterexample_search_exhausted(0, 100, self.COUNT, self.BUDGET)
+        )
+
+    def test_fires_on_a_yield_too_far_below_the_needed_rate(self):
+        # Half the rate the search has to sustain to reach COUNT.
+        self.assertTrue(
+            counterexample_search_exhausted(40, 4000, self.COUNT, self.BUDGET)
+        )
+        # ...but not on the same shortfall before it is established.
+        self.assertFalse(
+            counterexample_search_exhausted(4, 400, self.COUNT, self.BUDGET)
         )

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -15,8 +15,8 @@ from orthogonal_dfa.l_star.examples.bernoulli_parity import (
     BernoulliRegex,
 )
 from orthogonal_dfa.l_star.learn import learn_dfa
-from orthogonal_dfa.l_star.sampler import UniformSampler
 from orthogonal_dfa.l_star.lstar import counterexample_sample_budget
+from orthogonal_dfa.l_star.sampler import UniformSampler
 from orthogonal_dfa.l_star.statistics import (
     counterexample_search_exhausted,
     give_up_check,
@@ -691,9 +691,7 @@ class TestCounterexampleSearchExhausted(unittest.TestCase):
 
     def test_does_not_fire_on_a_search_that_is_still_productive(self):
         # 2 found in 8 draws is the yield that used to trigger the abort.
-        self.assertFalse(
-            counterexample_search_exhausted(2, 8, self.COUNT, self.BUDGET)
-        )
+        self.assertFalse(counterexample_search_exhausted(2, 8, self.COUNT, self.BUDGET))
         self.assertFalse(
             counterexample_search_exhausted(30, 400, self.COUNT, self.BUDGET)
         )

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -16,7 +16,11 @@ from orthogonal_dfa.l_star.examples.bernoulli_parity import (
 )
 from orthogonal_dfa.l_star.learn import learn_dfa
 from orthogonal_dfa.l_star.sampler import UniformSampler
-from orthogonal_dfa.l_star.statistics import give_up_check
+from orthogonal_dfa.l_star.lstar import counterexample_sample_budget
+from orthogonal_dfa.l_star.statistics import (
+    counterexample_search_exhausted,
+    give_up_check,
+)
 from orthogonal_dfa.l_star.structures import AsymmetricBernoulli, SymmetricBernoulli
 
 us = UniformSampler(40)
@@ -671,3 +675,46 @@ class TestLStarIndistinguishablePair(unittest.TestCase):
         oracle_creator = lambda nm, s, _d=outer: DFAOracle(nm, s, _d)
         learned = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, learned, oracle_creator)
+
+
+class TestCounterexampleSearchExhausted(unittest.TestCase):
+    """The stop is about this search's own yield, not the hypothesis's accuracy.
+
+    The case that motivated it: a degenerate hypothesis agrees with an equally
+    degenerate tree nearly everywhere, so the old accuracy-based test aborted
+    after a handful of samples with 2/200 prefixes -- starving the enrichment
+    that would have split the collapsed state.
+    """
+
+    COUNT = 200
+    BUDGET = counterexample_sample_budget(COUNT)
+
+    def test_does_not_fire_on_a_search_that_is_still_productive(self):
+        # 2 found in 8 draws is the yield that used to trigger the abort.
+        self.assertFalse(
+            counterexample_search_exhausted(2, 8, self.COUNT, self.BUDGET)
+        )
+        self.assertFalse(
+            counterexample_search_exhausted(30, 400, self.COUNT, self.BUDGET)
+        )
+
+    def test_fires_once_the_budget_is_spent(self):
+        self.assertTrue(
+            counterexample_search_exhausted(5, self.BUDGET, self.COUNT, self.BUDGET)
+        )
+
+    def test_fires_when_the_yield_cannot_reach_count(self):
+        # Nothing found with almost the whole budget gone: no continuation gets
+        # to COUNT, so spending the rest is waste.
+        self.assertTrue(
+            counterexample_search_exhausted(
+                0, self.BUDGET - 10, self.COUNT, self.BUDGET
+            )
+        )
+
+    def test_never_fires_once_count_is_reached(self):
+        self.assertFalse(
+            counterexample_search_exhausted(
+                self.COUNT, self.BUDGET - 1, self.COUNT, self.BUDGET
+            )
+        )

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -678,26 +678,17 @@ class TestLStarIndistinguishablePair(unittest.TestCase):
 
 
 class TestCounterexampleSearchExhausted(unittest.TestCase):
-    """The stop is about this search's own yield, not the hypothesis's accuracy.
-
-    The case that motivated it: a degenerate hypothesis agrees with an equally
-    degenerate tree nearly everywhere, so the old accuracy-based test aborted
-    after a handful of samples with 2/200 prefixes -- starving the enrichment
-    that would have split the collapsed state.
-    """
-
     COUNT = 200
     BUDGET = counterexample_sample_budget(COUNT)
 
     def test_does_not_fire_on_a_search_that_is_still_productive(self):
-        # 2 found in 8 draws is the yield that used to trigger the abort.
+        # 2 found in 8 draws is what used to trigger the old abort.
         self.assertFalse(counterexample_search_exhausted(2, 8, self.COUNT, self.BUDGET))
         self.assertFalse(
             counterexample_search_exhausted(30, 400, self.COUNT, self.BUDGET)
         )
 
     def test_does_not_fire_on_a_search_running_to_pace(self):
-        # Exactly the needed rate, nearly the whole budget spent.
         self.assertFalse(
             counterexample_search_exhausted(
                 self.COUNT, self.BUDGET - 1, self.COUNT, self.BUDGET
@@ -705,7 +696,6 @@ class TestCounterexampleSearchExhausted(unittest.TestCase):
         )
 
     def test_fires_on_a_dry_search_long_before_the_budget(self):
-        # Nothing at all: no need to spend the remaining draws to know.
         self.assertTrue(
             counterexample_search_exhausted(0, 600, self.COUNT, self.BUDGET)
         )
@@ -714,11 +704,11 @@ class TestCounterexampleSearchExhausted(unittest.TestCase):
         )
 
     def test_fires_on_a_yield_too_far_below_the_needed_rate(self):
-        # Half the rate the search has to sustain to reach COUNT.
+        # Half the needed rate, established...
         self.assertTrue(
             counterexample_search_exhausted(40, 4000, self.COUNT, self.BUDGET)
         )
-        # ...but not on the same shortfall before it is established.
+        # ...and the same shortfall, too early to tell.
         self.assertFalse(
             counterexample_search_exhausted(4, 400, self.COUNT, self.BUDGET)
         )


### PR DESCRIPTION
`generate_counterexamples` aborted the search when it observed more DT/DFA agreements than the hypothesis's estimated accuracy predicted:

```python
if unlikely_this_many_agreements(num_agreements, num_samples, expected_acc):
    warnings.warn(...); return additional_prefixes
```

That test is only meaningful while the decision tree is a good proxy for the target — then DT-vs-DFA disagreement tracks hypothesis error, and `expected_acc` is a reasonable null. When the tree is degenerate the two quantities come apart: a collapsed tree and a collapsed DFA agree with *each other* almost everywhere while both are wrong about the language. So the guard fired hardest exactly when the prefixes it was cutting off were most needed.

## What it was doing

Found on a 5-state target with an absorbing accepting sink (CAPAL's `Simple05`, reachable only through one state `q3`). Every round:

```
Observed 6 'no inconsistency' results in 8 samples, which is unlikely given
expected accuracy 0.067; stopping counterexample search early with 2/200 prefixes
```

The search was aborting after **8 draws with 2 of the 200 requested prefixes**. The prefixes it did return were well aimed — instrumenting it over 400 samples, **97% of what it kept landed on `q3`**, the one state that needed splitting — there were simply never enough of them to move the clustering. Synthesis looped to 13,042 prefixes and returned a 2-state constant-reject DFA at ~0.05 accuracy against a language that accepts 92%.

With the guard replaced, the same target recovers **all 5 states at accuracy 1.0** in 365s.

This is not specific to E-L*: #134's `default_refine` calls the same `add_counterexample_prefixes` with the same `expected_acc=true_acc`, and on this target the guard fires **20 times** over a direct-L* run, which likewise collapses to 2 states.

## The change

`unlikely_this_many_agreements` → `counterexample_search_exhausted(num_found, num_samples, count, max_samples)`. Same one-sided binomial test as before, with the null corrected — the search has to sustain `count / max_samples` hits per draw, so the hits are tested against *that* rate rather than against accuracy versus the target:

```python
needed_rate = count / max_samples
pval = scipy.stats.binom.cdf(num_found, num_samples, needed_rate)
return pval < failure_prob
```

Since the old test doubled as the loop's termination condition, the search also gets an explicit draw budget (`50 × count`). `expected_acc` is no longer threaded into the counterexample path at all.

## Regression

Same oracles, `min_suffix_frequency=0.05`, against the pre-fix baseline. **No change in states or accuracy anywhere.** Query cost:

| target | states | acc | MQ before | MQ after | ratio |
| --- | --- | --- | ---: | ---: | ---: |
| `parity_mod9_allowed_3_6` | 9 | 1.0 | 320,886 | 320,886 | 1.00× |
| `regex_two_1111` | 9 | 1.0 | 508,281 | 508,281 | 1.00× |
| `regex_alt_1111_or_0000_11` | 10 | 0.990 | 328,929 | 328,929 | 1.00× |
| `Simple05` | — | GaveUp | 517,592 | 517,592 | 1.00× |
| `regex_subseq_1010101` | 8 | 1.0 | 879,542 | **299,040** | **0.34×** |
| `regex_alt_111_or_000_3sym` | 6 | 1.0 | 852,852 | **1,107,150** | **1.30×** |

Four are bit-identical — where the old guard never misfired, behaviour is unchanged. One improves 2.9×: the old guard was cutting enrichment short there too, costing extra synthesis rounds.

**One costs 30% more queries.** `regex_alt_111_or_000_3sym` learns the same 6-state DFA at accuracy 1.0, but the search now delivers all 200 requested prefixes per round where the old guard cut it short. The stop is not the binding constraint there — `count` is — so this is the price of the enrichment actually running, not of wasted draws. Whether `additional_counterexamples=200` is the right ask for that target is a separate question from this fix.

A dry search now stops after ~570 draws (the test fires as soon as the shortfall is established, rather than waiting for the budget), so `SAMPLES_PER_COUNTEREXAMPLE = 50` only bounds the pathological case.

(`regex_alt_1111_or_0000_11` is a pre-existing false positive — 10 of 11 states — unrelated to this change; identical query count confirms an identical trajectory.)

Four new unit tests cover the predicate, including the 2-found-in-8-draws case that triggered the old abort. pylint 10.00 on all three touched files. Leaving the longer benchmark suites to CI.

## Note for #134

That branch's `default_refine` passes `expected_acc=true_acc` to `add_counterexample_prefixes`, whose signature loses that parameter here. One-line fix on merge.

## What this does *not* fix

`Simple05` still fails at the default `min_suffix_frequency=0.05` — the table above shows it giving up with an identical query count, because it dies earlier in `_give_up_check` at the suffix-family stage (`Top-4 mean agreement 0.924 <= 0.926`, a 0.002 margin). The accuracy-1.0 result is at `r=0.02`, which clears that first guard. So this removes one of two premature aborts on that target; the give-up check looks miscalibrated too, and is worth its own investigation.

## Query count — `fix-counterexample-early-stop` vs `main`

|   | task | queries `main` | queries `fix-counterexample-early-stop` | ratio | acc `main` | acc `fix-counterexample-early-stop` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 875,691 | 875,691 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 1,281,289 | 1,281,289 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 912,121 | 912,121 | 1.00x | 1.000 | 1.000 | 9 |
| 🟢 | poor_case | 6,880,895 | 2,415,604 | 0.35x | 0.977 | 0.977 | 9 |
| ⚪ | modulo_hard | 1,383,779 | 1,383,779 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 3,821,724 | 3,821,724 | 1.00x | 1.000 | 1.000 | 9 |
| 🟢 | **geomean** |  |  | **0.84x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

### Forward passes — `fix-counterexample-early-stop` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 27,584 → 27,584 (1.00x, 99% packed) | 7,076 → 7,076 (1.00x, 97% packed) | 1,164 → 1,164 (1.00x, 74% packed) |
| subseq | 45,273 → 45,273 (1.00x, 88% packed) | 17,160 → 17,160 (1.00x, 58% packed) | 9,320 → 9,320 (1.00x, 13% packed) |
| two_subseq | 30,802 → 30,802 (1.00x, 93% packed) | 10,396 → 10,396 (1.00x, 69% packed) | 4,657 → 4,657 (1.00x, 19% packed) |
| poor_case | 223,921 → 81,822 (0.37x, 92% packed) | 75,728 → 28,164 (0.37x, 67% packed) | 38,993 → 13,460 (0.35x, 18% packed) |
| modulo_hard | 44,131 → 44,131 (1.00x, 98% packed) | 11,874 → 11,874 (1.00x, 91% packed) | 2,366 → 2,366 (1.00x, 57% packed) |
| modulo_asym | 120,332 → 120,332 (1.00x, 99% packed) | 31,128 → 31,128 (1.00x, 96% packed) | 4,847 → 4,847 (1.00x, 77% packed) |

