### PR TITLE
Neural DFA learning: amortised state predictor and table surrogate

### DIFF
--- a/docs/neural_surrogate_findings.md
+++ b/docs/neural_surrogate_findings.md
@@ -130,6 +130,12 @@ Matched at exactly 36,000 oracle queries, parity, model fidelity:
 A prefix is placed by its response across 24 suffixes that 1,499 other prefixes already
 calibrated. With one column there is nothing to triangulate against.
 
+Caveat: modulo9 scores 0.5000 in *both* arms of this test, which contradicts the plain-GRU
+control (0.787) and is unexplained. The likely suspect is that this harness derives the accept
+rate through the column encoder as `sigma(<u_s, phi(eps)>)` rather than from a free per-state
+scalar -- the same reparameterisation that was independently found to flatten every state's
+rate at once. So the parity row is the load-bearing one here.
+
 ---
 
 ## Data regime
@@ -156,6 +162,29 @@ not the mean.
 points. Cells 6,000 → 246,000, and **no change** (parity/modulo9 both 0.5 either way; subseq
 0.9994 → 0.9936). The 41 splits carry the *same* label — 41 copies of one bit, no new
 information. Querying each prefix separately gives 41 *different* labels and is what matters.
+
+### Modulus sweep — terminal supervision, 6,000 strings, length 40
+
+| language | balanced |
+|---|---|
+| mod 4, accept {0,1} (contiguous) | 0.4733 |
+| mod 4, accept {0,2} (alternating) | 0.4626 |
+| mod 2 / 3 / 5 / 7, accept {0} | 0.463 / 0.517 / 0.493 / 0.490 |
+| mod 9, accept {0} | **0.7672** |
+
+Run to test whether difficulty tracks the *frequency* of the accept function in count-space.
+It does not: contiguous vs alternating at fixed modulus is the decisive comparison and shows
+no difference, and the trend across `k` is not monotone (mod 7 fails, mod 9 works).
+
+A hypothesis that does fit all seven numbers, untested: over length-40 strings the sum
+concentrates near 20±3, and accepting sums in that range number ~8 for mod 2, 6 for mod 3, 3
+for mod 5 and 7, but only {18, 27} for mod 9 -- with 27 deep in the tail. So mod 9 reduces to
+roughly "is the sum about 18", a single unimodal bump, while the rest need an oscillating
+readout.
+
+This entire sweep is in the terminal-supervision regime, which the pipeline never encounters
+(it gives ~24 labels per prefix). Treat it as a fact about the harness, not about the
+pipeline.
 
 ### Architecture controls — 6,000 strings, one label each, length 40
 

--- a/docs/neural_surrogate_findings.md
+++ b/docs/neural_surrogate_findings.md
@@ -1,0 +1,231 @@
+# Neural approaches to noisy L*: findings
+
+Two attempts to replace the discrimination-tree + suffix-family machinery with a learned
+model. **Neither beats L\*.** This records what was measured, so the negative results are not
+re-derived.
+
+Code: `orthogonal_dfa/l_star/neural/`. Scripts: `scripts/train_neural_dfa.py`,
+`scripts/bench_surrogate.py`, `scripts/diagnose_surrogate.py`.
+
+Throughout, two different quantities are reported and must not be compared with each other:
+
+* **model fidelity** — the neural model's own balanced accuracy on held-out data.
+* **pipeline accuracy** — the extracted DFA against a noiseless oracle, via
+  `tests.test_lstar.evaluate_accuracy` (10k uniform length-40 strings).
+
+A pipeline number can be high while the model underneath is poor, because the split/accept
+decisions are statistical tests on observed cells and the model only proposes.
+
+Base rates (a constant predictor scores this): subseq 0.813, two_subseq 0.631,
+modulo9 0.773, parity 0.500.
+
+---
+
+## Approach 1 — amortised state predictor
+
+`model.py`, `objective.py`, `train.py`. `m(x)` gives a distribution over latent states for
+every prefix in one pass, trained on `J_internal` (determinism) + `J_external` (labels).
+Nothing backpropagates through 40 soft transition matrices, unlike `utils/pdfa.py`.
+
+**Result:** parity exactly (1.0, 2 states, 25k distinct queries). Every language whose Nerode
+partition is finer than its acceptance partition fails at base rate.
+
+**Cause, measured.** `J_external` sees `m` only through a per-state accept scalar, so it is
+*exactly invariant* under any refinement of the acceptance partition — zero gradient toward
+refining it. `J_internal` is then left to choose among all refinements, where the Nerode
+partition beats the bare acceptance partition by **0.015** (0.9853 vs 1.0, the residual
+nondeterminism carrying little mass) while language-independent congruences like length-mod-k
+win by ~**log 2**. The larger signal wins.
+
+Not an information shortage: the same encoder *without* the state bottleneck reaches 1.0
+prefix accuracy on the same 88k labels.
+
+Four bugs that had to be fixed before parity worked at all:
+
+| bug | symptom | fix |
+|---|---|---|
+| trivial-congruence lock-in | learns "length mod 2", acc 0.50 | warmup: `J_external` alone first |
+| Gram penalty `‖G−I/S‖²` | forces state *duplication*, caps `J_int` at 0.97 | off |
+| empty prefix is a population of size 1 | one noise-flipped label inverts the whole trajectory | inverse-multiplicity weighting; initial state by self-consistency |
+| `accept_logits = 0` | `p` constant in `m`, softmax Jacobian zeroes the gradient exactly | random init |
+
+---
+
+## Approach 2 — table surrogate
+
+`surrogate.py`. Models the observation table directly:
+
+```
+M[p][v] = Σ_s m(p)[s] · σ(⟨u_s, φ(v)⟩)
+```
+
+Rows and columns are **encoders over strings**, not free per-row embeddings, so the model
+generalises to prefixes and suffixes never queried — the difference from ordinary matrix
+completion.
+
+### Why the table is the right object
+
+`scripts/profile_query_origins.py` on subseq, 1,277,963 queries:
+
+| queries | share | origin |
+|---|---|---|
+| 641,680 | **50.2%** | one new suffix column × all 14,584 prefixes ← `_resolve` |
+| 180,255 | 14.1% | same, ← `_sample_suffix` |
+| 135,000 | 10.6% | new prefix row × all suffixes |
+| 320,475 | 25.1% | DT classification |
+
+~75% is literally filling cells of `M`; the rest is the same cells for rows not yet in the
+table. The final table is 14,584 × 61 ≈ 890k cells with **only 8 distinct rows**.
+
+### Model fidelity
+
+| claim | measurement |
+|---|---|
+| it denoises | held-out cells **0.973** vs **0.8** for reading each cell's own noisy label, at 50% density |
+| recovers state structure | MI **1.95 / 2.45** bits, purity **0.866** (subseq, 8 states) |
+| over-provision `num_states` | `S=32` purity 0.861 vs `S=8` 0.663 — matching the true count is *worse* |
+
+### Pipeline accuracy, 3 seeds
+
+| config | parity | modulo9 | subseq | two_subseq |
+|---|---|---|---|---|
+| merge path (committed) | 1.0 ×3 | **1.0**/0.888/0.773 | 0.813/**1.0**/0.813 | 0.631 ✗ |
+| split-from-blob | 1.0 ×3 | 0.888/0.505/0.888 | 0.813 ✗ | 0.631 ✗ |
+
+14 targets (6 hand-written + 8 generated at 10 and 18 states): **4/14 ≥ 0.97**, median 0.855,
+median ~34k queries. L\* spends 869k (modulo) and 1.23M (subseq) distinct queries.
+
+Variance is high enough that single-seed results are meaningless — an early "modulo9 solved at
+1.0" did not replicate.
+
+---
+
+## The two robust principles
+
+### 1. Max over columns, never mean
+
+Separating two states typically needs **one specific suffix out of forty**. Any average
+divides that signal by 40 and buries it. This one distinction explains four separate failures:
+
+* `merge_by_row` (mean row distance) — over-merges; subseq collapses to 1 state.
+* successor assignment by mean distance — most blocks unreachable.
+* lagged targets `A[s,k]` marginalised over all length-`k` suffixes — nearly invariant.
+* `J_external`'s scalar accept head — exactly invariant.
+
+Measured on subseq: model gap on distinguishing columns **0.510**, elsewhere **0.031**. Each
+column separates ~12 of 28 state pairs; 22/28 pairs are covered.
+
+**Not** implicated: averaging *within* a column (over cells at a fixed suffix) is the pooling
+that denoises, and is load-bearing.
+
+### 2. Column structure beats quantity
+
+Matched at exactly 36,000 oracle queries, parity, model fidelity:
+
+| layout | balanced |
+|---|---|
+| 36,000 rows × 1 column | 0.476 |
+| 1,500 rows × 24 columns | **1.0000** |
+
+A prefix is placed by its response across 24 suffixes that 1,499 other prefixes already
+calibrated. With one column there is nothing to triangulate against.
+
+---
+
+## Data regime
+
+### Short prefixes are required (seeded)
+
+Prefix-length distribution, fixed 36,000-query budget, success = fraction of seeds > 0.9:
+
+| cell | `long` (11–40) | `mixed` (0–40) |
+|---|---|---|
+| GRU | 1/9 | 8/8 |
+| LSTM | 0/4 | 4/4 |
+
+**Not an architecture limitation** — LSTM fails identically. Short prefixes act as a
+curriculum into the counting behaviour. This gives `short_prefix_closure` a second
+justification beyond transient-state coverage.
+
+Outcomes here are bimodal (≈0.5 or ≈1.0), so the success *rate* is the meaningful statistic,
+not the mean.
+
+### Hankel augmentation does nothing
+
+`M[p][v]` depends only on `p+v`, so one query on a length-40 string populates all 41 split
+points. Cells 6,000 → 246,000, and **no change** (parity/modulo9 both 0.5 either way; subseq
+0.9994 → 0.9936). The 41 splits carry the *same* label — 41 copies of one bit, no new
+information. Querying each prefix separately gives 41 *different* labels and is what matters.
+
+### Architecture controls — 6,000 strings, one label each, length 40
+
+| | plain GRU | + softmax bottleneck | + clamp to [0.2, 0.8] |
+|---|---|---|---|
+| parity | 0.463 | 0.477 | 0.507 |
+| modulo9 | **0.787** | 0.751 | **0.500** |
+
+**The clamp breaks modulo9.** It was added to stop memorisation (predicted rates piling at
+0.0/1.0 instead of the noise rates, found by plotting) and it does — at the cost of flattening
+the loss landscape by 0.6× through the head. Memorisation should be prevented by cluster
+population instead.
+
+Per-step supervision (41 labels per string, one per prefix) gives parity **1.0000** and
+modulo9 **0.9985**, versus 0.497/0.574 with terminal supervision.
+
+---
+
+## Rejected variants
+
+Each is retained as a defaulted-off knob with the measurement that rejected it.
+
+| variant | why it fails |
+|---|---|
+| `counterexample_prefixes` | compares the DFA against the surrogate it was *extracted from* — measures extraction error, not language error. 4/14 → 3/14. |
+| `error_boost` | the flag is 48% precise (DFA errs 18.7%, noise flips 20%); per-string noise cannot be averaged, so boosting re-amplifies single fixed labels. Breaks parity at every level. |
+| `merge_by_row` | mean over 40 suffixes dilutes a single distinguishing column. |
+| `refine_partition` | Moore refinement splitting on *any* successor disagreement; the assignment is a noisy nearest-centroid classification, so blocks shatter. Parity → 14–21 states at 0.49. |
+| MI-form `J_internal` | refuses collapse as designed, then selects language-independent congruences (exactly `log 2`, `~log 3`). |
+| `resolve_transitions` | assigning a successor to any group it *fails to reject* — failing to reject is not evidence of sameness. Parity 1.0 → 0.500; → 0.875 with a best-match rule. |
+| `minify` | merges behaviourally equivalent states, which assumes the transition table is correct. Here it is estimated, so states whose transitions are wrong *in the same way* get merged — turning a transition error into total collapse. `transition_resolver` does not minify either; its DT leaves are separated by real distinguishing suffixes. Replaced by `trim_unreachable`. |
+
+---
+
+## Open
+
+* **Transitions.** With `trim_unreachable` and the max-over-columns assignment, blocks reach
+  the true state count (modulo9 8–11 vs true 9) but accuracy does not follow. On modulo9 the
+  blocks are 83% residue-pure yet systematically merge `r` with `r+3`. Not power (z ≈ 11.7
+  available) and not missing columns (2/9 of random suffixes separate those pairs).
+* **Splitting vs merging.** Splitting from one blob is better founded — merging does 496
+  pairwise tests corrected only across columns, so chance differences become permanent states
+  — but measures worse end to end.
+* **Held-out testing for splits.** Proposing and testing on the same cells is circular and
+  inflates splits; testing on held-out cells removes that and under-splits. Cross-fitting
+  (4 folds) did not resolve it.
+* **Dead code.** `merge_by_row`, `merge_by_conformal`, `merge_by_counts`, `refine_partition`
+  are no longer on the live path; `q_hat` from `conformal_rate_bound` is computed and feeds no
+  decision.
+* **Unvalidated upstream heuristics.** Enrichment, suffix proposal and uncertainty sampling
+  were each added mid-investigation and never A/B'd.
+
+---
+
+## Corrections
+
+Claims made during this work that later measurement refuted, recorded so they are not
+repeated:
+
+* "Training on all prefixes covers transient states for free" — true of *frequency*, false of
+  *information*. Short prefixes are tiny noise-dominated populations; the empty prefix is a
+  population of size one.
+* "Cell cross-entropy buries the 3-of-40 signal" — refuted. The model's gap on distinguishing
+  columns is 0.510 vs 0.031 elsewhere. The objective was never the problem; the decision rules
+  downstream were.
+* "DFA extraction needs an exactly correct partition" — false; L\* makes population decisions
+  throughout and tolerates misclassification.
+* "The encoder cannot represent sum mod 9" — contradicted by block purity 0.831.
+* "Counting languages are hard for gradient descent" (leap complexity, then spectral bias) —
+  both refuted. A plain GRU learns modulo9 at length 40 (0.787), and per-step supervision
+  gives parity 1.0000. The failures came from a fidelity harness that gave 1 bit per prefix
+  where the pipeline gives ~24.
+* "mod 4 contiguous vs alternating should differ" — no difference (0.473 vs 0.463).

--- a/orthogonal_dfa/l_star/neural/__init__.py
+++ b/orthogonal_dfa/l_star/neural/__init__.py
@@ -1,0 +1,5 @@
+from orthogonal_dfa.l_star.neural.extract import extract_dfa
+from orthogonal_dfa.l_star.neural.model import NeuralDFA
+from orthogonal_dfa.l_star.neural.train import NeuralConfig, train_neural_dfa
+
+__all__ = ["NeuralConfig", "NeuralDFA", "extract_dfa", "train_neural_dfa"]

--- a/orthogonal_dfa/l_star/neural/extract.py
+++ b/orthogonal_dfa/l_star/neural/extract.py
@@ -1,0 +1,104 @@
+"""Turn a trained :class:`NeuralDFA` into an ``automata-lib`` DFA."""
+
+import numpy as np
+import torch
+from automata.fa.dfa import DFA
+
+from orthogonal_dfa.l_star.dfa_utils import (
+    count_paths_to_state,
+    sample_string_reaching_state,
+)
+from orthogonal_dfa.l_star.statistics import binomial_side_of_boundary
+
+
+def accept_threshold(accept_probs, weights):
+    """Boundary between the accepting and rejecting clusters of accept probabilities.
+
+    The learned rates sit at the two *noise* rates, not at 0 and 1, and those are not
+    symmetric about 0.5 — ``AsymmetricBernoulli(p_0=0.10, p_1=0.40)`` puts the boundary
+    at 0.25. So the split is found by a frequency-weighted 1-D 2-means (brute force over
+    cut points; there are at most a few dozen states) rather than assumed.
+    """
+    order = np.argsort(accept_probs)
+    values, mass = accept_probs[order], weights[order]
+    keep = mass > 0
+    values, mass = values[keep], mass[keep]
+    if len(values) < 2 or values[-1] - values[0] < 1e-6:
+        return 0.5
+    best, cut = None, None
+    for i in range(1, len(values)):
+        lo, hi = slice(0, i), slice(i, None)
+        if mass[lo].sum() <= 0 or mass[hi].sum() <= 0:
+            continue
+        mu_lo = (values[lo] * mass[lo]).sum() / mass[lo].sum()
+        mu_hi = (values[hi] * mass[hi]).sum() / mass[hi].sum()
+        cost = (mass[lo] * (values[lo] - mu_lo) ** 2).sum() + (
+            mass[hi] * (values[hi] - mu_hi) ** 2
+        ).sum()
+        if best is None or cost < best:
+            best, cut = cost, (mu_lo + mu_hi) / 2
+    return 0.5 if cut is None else float(cut)
+
+
+def extract_dfa(model, stats, *, initial, minify=True):
+    """``(dfa, boundary)`` for the current model. Unreachable states are dropped by
+    ``minify``, which also collapses any deterministic refinement of Nerode back onto
+    the minimal DFA — which is why over-provisioning ``num_states`` is safe."""
+    with torch.no_grad():
+        # The empty continuation is acceptance of the prefix itself; the longer ones exist
+        # only to supervise the state partition.
+        accept_probs = model.accept_probs().cpu().numpy()
+        frequency = stats.support().mean(0).cpu().numpy()
+    boundary = accept_threshold(accept_probs, frequency)
+    dfa = DFA(
+        states=set(range(model.num_states)),
+        input_symbols=set(range(model.alphabet_size)),
+        transitions=stats.transitions(),
+        initial_state=initial,
+        final_states={s for s in range(model.num_states) if accept_probs[s] > boundary},
+        allow_partial=False,
+    )
+    return (dfa.minify(retain_names=False) if minify else dfa), boundary
+
+
+def denoise_accept_labels(dfa, oracle, rng, length, *, boundary, max_samples=200):
+    """Re-vote each state's accept label from strings sampled to *reach* that state.
+
+    A state's conditional accept rate is the one quantity a frequency-weighted
+    ``J_external`` can get wrong, because low-support states are exactly where the noise
+    wins. Same correction as :func:`orthogonal_dfa.l_star.lstar.denoise_accept_labels`,
+    and the same path-counting sampler; labels change, transitions do not.
+    """
+
+    def relabel(state):
+        counts = count_paths_to_state(dfa, state, length)
+        cap = min(max_samples, counts[length][dfa.initial_state])
+        seen, accepts = set(), 0
+        while len(seen) < cap:
+            string = sample_string_reaching_state(dfa, counts, rng)
+            if tuple(string) in seen:
+                continue  # distinct strings only: the noise is fixed per string
+            seen.add(tuple(string))
+            accepts += int(oracle.membership_query(string))
+            decision = binomial_side_of_boundary(accepts, len(seen), boundary)
+            if decision is not None:
+                return decision
+        return None
+
+    labels = {state: relabel(state) for state in dfa.states}
+    # Undecided states keep the label training gave them.
+    final = {
+        s
+        for s in dfa.states
+        if (s in dfa.final_states if labels[s] is None else labels[s])
+    }
+    if final == set(dfa.final_states):
+        return dfa
+    return DFA(
+        states=set(dfa.states),
+        input_symbols=set(dfa.input_symbols),
+        transitions={s: dict(v) for s, v in dfa.transitions.items()},
+        initial_state=dfa.initial_state,
+        final_states=final,
+        allow_partial=False,
+    ).minify(retain_names=False)

--- a/orthogonal_dfa/l_star/neural/model.py
+++ b/orthogonal_dfa/l_star/neural/model.py
@@ -1,0 +1,135 @@
+import torch
+from torch import nn
+
+
+class NeuralDFA(nn.Module):
+    """Amortised state predictor ``m(x)`` over prefixes, plus a per-state accept rate.
+
+    ``m`` is a distribution over ``num_states`` latent states for *every* prefix of the
+    input, produced in one pass. This is the difference from the unrolled relaxations in
+    ``orthogonal_dfa/utils/pdfa.py`` and ``orthogonal_dfa/deep_dfa``: nothing is
+    backpropagated through 40 soft transition matrices, so the transition function is
+    fit from a local consistency constraint rather than an end-to-end rollout.
+
+    The accept head is ``sigma(<u_s, phi(v)>)``: the probability that state ``s`` followed
+    by continuation ``v`` is accepted. It is unconstrained, so it converges to the *noisy*
+    rate (``p_1`` / ``p_0`` under :class:`AsymmetricBernoulli`) and the noise parameters
+    never have to be supplied.
+
+    Conditioning on ``v`` is what makes ``J_external`` able to see state structure at all.
+    A per-state scalar ``a[s]`` is *exactly invariant* under splitting a state into two
+    halves with equal accept rates, so it contributes literally zero gradient toward
+    refining the acceptance partition -- and marginalising over ``v`` by continuation
+    *length* only (an earlier version of this head) is nearly as invariant, because on
+    ``.*1010101.*`` the sub-states of "not yet matched" differ in accept-after-k-random-steps
+    by O(2^-7). Indexing by the continuation itself removes the invariance: two states must
+    now agree on *specific* ``v``, which is the Myhill-Nerode condition.
+
+    ``phi`` is a compact learned recurrent encoding, not one column per suffix: nothing is
+    enumerated, and only the continuations that actually occur in the data are evaluated.
+    The empty continuation keeps a free per-state scalar instead of going through ``phi``,
+    for the reason noted at ``accept_logits``.
+    """
+
+    def __init__(
+        self,
+        alphabet_size,
+        num_states,
+        hidden_size=128,
+        num_layers=1,
+        *,
+        num_lags=8,
+        suffix_dim=16,
+    ):
+        super().__init__()
+        self.alphabet_size = alphabet_size
+        self.num_states = num_states
+        self.num_lags = num_lags
+        self.embed = nn.Embedding(alphabet_size, hidden_size)
+        self.gru = nn.GRU(hidden_size, hidden_size, num_layers, batch_first=True)
+        self.h0 = nn.Parameter(torch.randn(num_layers, 1, hidden_size) * 0.02)
+        self.head = nn.Linear(hidden_size, num_states)
+        # Must not start tied. With every state's accept rate equal, p is constant in m, so
+        # the gradient reaching m's logits is the same for every state and the softmax
+        # Jacobian kills it exactly -- and while m stays near-uniform every state's rate
+        # gets the same gradient too, so the deadlock holds. Random init breaks it.
+        # The empty continuation keeps its own free scalar per state rather than being
+        # folded into the bilinear head. Routing it through a shared vector lets one
+        # parameter flatten every state's accept rate at once, which zeroes m's gradient
+        # far faster than flattening S independent scalars does -- measured as a total
+        # failure to learn even parity.
+        self.accept_logits = nn.Parameter(torch.randn(num_states))
+        self.state_vectors = nn.Parameter(torch.randn(num_states, suffix_dim))
+        self.suffix_embed = nn.Embedding(alphabet_size, suffix_dim)
+        self.suffix_gru = nn.GRU(suffix_dim, suffix_dim, batch_first=True)
+
+    def state_log_probs(self, x):
+        """``x``: ``(B, L)`` int64. Returns ``(B, L + 1, S)`` log-probabilities.
+
+        Index ``t`` is the prefix ``x[:t]``, so index 0 is the empty prefix and index
+        ``L`` is the whole string.
+        """
+        h0 = self.h0.expand(-1, x.shape[0], -1).contiguous()
+        out, _ = self.gru(self.embed(x), h0)
+        out = torch.cat([h0[-1].unsqueeze(1), out], dim=1)
+        return torch.log_softmax(self.head(out), dim=-1)
+
+    def forward(self, x):
+        return self.state_log_probs(x)
+
+    def empty_prefix_log_probs(self):
+        """``(S,)`` log-probabilities for the empty prefix, i.e. the initial state."""
+        return torch.log_softmax(self.head(self.h0[-1, 0]), dim=-1)
+
+    def accept_probs(self):
+        """``(S,)`` accept probability per state, i.e. the empty continuation.
+
+        This is what extraction reads; the longer continuations exist only to supervise the
+        partition.
+        """
+        return torch.sigmoid(self.accept_logits)
+
+    def continuation_encodings(self, x):
+        """``(B, L + 1, K, d)``: encoding of the continuation ``x[t:t + k]``, ``k >= 1``.
+
+        A recurrent encoder, not a bag of symbol embeddings. An additive encoding is
+        monotone in the symbol counts, so ``sigma(<u_s, phi(v)>)`` cannot represent
+        ``parity(v)`` -- which made every ``k >= 1`` column an unfittable target on the
+        parity oracle and drowned out ``k = 0``. A GRU represents modular counting fine.
+
+        Since ``x[t:t + k]`` for increasing ``k`` is a prefix of the window at ``t``, one
+        pass over the ``K``-wide sliding windows yields every length at once. Entries where
+        ``t + k`` runs past the end of the string are garbage and the loss masks them out.
+        """
+        batch, length = x.shape
+        tail = torch.zeros(batch, self.num_lags, dtype=x.dtype, device=x.device)
+        windows = torch.cat([x, tail], dim=1).unfold(1, self.num_lags, 1)
+        encoded, _ = self.suffix_gru(
+            self.suffix_embed(windows.reshape(-1, self.num_lags))
+        )
+        return encoded.reshape(batch, length + 1, self.num_lags, -1)
+
+    def continuation_accept_probs(self, x, log_m, *, suffix_grad_scale=1.0):
+        """``(B, L + 1, K + 1)``: ``P(accept | prefix x[:t], continuation x[t:t + k])``.
+
+        The state is latent, so this is a genuine mixture over states rather than a mixture
+        of logits: ``sum_s m(x[:t])[s] * sigma(<u_s, phi(v)>)``.
+        """
+        m = log_m.exp()
+        empty = (m * torch.sigmoid(self.accept_logits)).sum(-1, keepdim=True)
+        if self.num_lags == 0:
+            return empty
+        # Same value as m, but its gradient is scaled. When a continuation length switches
+        # on, u_s and the suffix GRU are still at random init, and their large initial
+        # errors flow straight back into m and destroy it -- measured on `.*1010101.*` as a
+        # collapse the round lag 2 activated, with J_internal still switched off entirely.
+        # Ramping this from 0 lets the head learn to *use* m before it can push back on it.
+        damped = suffix_grad_scale * m + (1 - suffix_grad_scale) * m.detach()
+        per_state = torch.sigmoid(
+            torch.einsum(
+                "btkd,sd->btks", self.continuation_encodings(x), self.state_vectors
+            )
+        )
+        return torch.cat(
+            [empty, torch.einsum("bts,btks->btk", damped, per_state)], dim=2
+        )

--- a/orthogonal_dfa/l_star/neural/objective.py
+++ b/orthogonal_dfa/l_star/neural/objective.py
@@ -1,0 +1,197 @@
+"""The two objectives, plus the statistics the internal one is read off of.
+
+``J_internal`` scores how close ``m`` is to being a deterministic automaton:
+
+    max_delta E_{x,c} sum_s m(x)[s] m(xc)[delta(s, c)]
+      = E_c sum_s max_{s'} E_x[ m(x)[s] m(xc)[s'] ]
+
+since ``delta(s, c)`` is chosen independently per ``(s, c)``. It is bounded by 1, with
+equality exactly when ``m`` is one-hot and consistent with some ``delta``, so hedging
+between two copies of a state costs quadratically. It prefers *coarse* partitions and is
+maximised by total collapse.
+
+``J_external`` is the log-likelihood of the noisy labels under a per-state accept rate.
+It prefers partitions that *refine* accept/reject.
+
+The coarsest partition that is both a transition congruence and refines acceptance is
+the Nerode congruence, so the minimal DFA sits at a joint optimum. Any deterministic
+refinement of it is also optimal, which is why extraction minifies.
+"""
+
+import torch
+
+
+class TransitionStatistics:
+    """EMA of ``T[c, s, s'] = E_x[m(x)[s] m(xc)[s']]`` and support ``N[c, s]``.
+
+    ``delta`` is read off the EMA rather than the current batch: in a cell holding
+    little probability mass, a per-batch ``argmax`` over ``s'`` is an argmax over noise,
+    and a confidently wrong ``delta`` produces a confidently wrong gradient.
+    """
+
+    def __init__(self, alphabet_size, num_states, decay=0.95, device="cpu"):
+        self.decay = decay
+        self.t = torch.zeros(alphabet_size, num_states, num_states, device=device)
+        self.n = torch.zeros(alphabet_size, num_states, device=device)
+        self.steps = 0
+
+    def update(self, t_batch, n_batch):
+        self.t.mul_(self.decay).add_(t_batch.detach(), alpha=1 - self.decay)
+        self.n.mul_(self.decay).add_(n_batch.detach(), alpha=1 - self.decay)
+        self.steps += 1
+
+    def support(self):
+        return self.n / (1 - self.decay**self.steps)
+
+    def conditional(self):
+        """``P(s' | c, s)``, left uniform where there is no support."""
+        n = self.support()
+        out = (self.t / (1 - self.decay**self.steps)) / n.unsqueeze(-1).clamp_min(1e-12)
+        out[n < 1e-12] = 1.0 / out.shape[-1]
+        return out
+
+    def transitions(self):
+        """``delta[s][c]``, as the transition dict shape ``automata-lib`` wants."""
+        delta = self.conditional().argmax(-1).cpu().numpy()
+        num_symbols, num_states = delta.shape
+        return {
+            s: {c: int(delta[c, s]) for c in range(num_symbols)}
+            for s in range(num_states)
+        }
+
+
+def batch_transition_statistics(log_m, x, alphabet_size):
+    """Per-batch ``T[c, s, s']`` and ``N[c, s]``, each normalised within a symbol.
+
+    The normalisation makes ``sum_{s, s'} T[c, s, s'] == 1``, so ``J_internal`` lands in
+    ``[0, 1]`` and a cell's contribution is automatically bounded by its support.
+    """
+    m = log_m.exp()
+    pair = m[:, :-1].unsqueeze(-1) * m[:, 1:].unsqueeze(-2)
+    symbols = torch.arange(alphabet_size, device=x.device)
+    onehot = (x.unsqueeze(-1) == symbols).to(m.dtype)
+    counts = onehot.sum((0, 1)).clamp_min(1e-12)
+    t = torch.einsum("blc,blij->cij", onehot, pair) / counts[:, None, None]
+    n = torch.einsum("blc,bls->cs", onehot, m[:, :-1]) / counts[:, None]
+    return t, n
+
+
+def internal_objective(t_batch, stats, *, temperature, min_support):
+    """``E_c sum_s max_{s'} T[c, s, s']``, maximiser taken from the EMA.
+
+    ``temperature`` softens the max: 0 is the exact argmax, 1 weights by
+    ``P(s' | c, s)``. Annealing it down avoids locking onto an early bad argmax. The
+    weights are detached, so the gradient hits only the batch's own ``T`` — this is the
+    M-step of hard EM.
+
+    Cells below ``min_support`` are dropped rather than contributing a noisy gradient;
+    their true contribution is at most their support, so the objective barely moves.
+    """
+    p = stats.conditional()
+    if temperature <= 0:
+        weights = torch.zeros_like(p).scatter_(-1, p.argmax(-1, keepdim=True), 1.0)
+    else:
+        weights = torch.softmax(p.clamp_min(1e-12).log() / temperature, dim=-1)
+    keep = (stats.support() >= min_support).to(t_batch.dtype)
+    return ((weights * t_batch).sum(-1) * keep).sum(-1).mean()
+
+
+def internal_information(t_batch):
+    """``I(m(xc) ; m(x), c)`` -- determinism that is also *informative*.
+
+    ``internal_objective`` (``E_c sum_s max_s' T``) is maximised by total collapse, which
+    is trivially deterministic. That makes merging two states a cheap descent direction:
+    it buys the same determinism as refining but in one step, and once ``m`` is one-hot on
+    a single state the softmax saturates and ``J_external`` can never undo it.
+
+    Worse, it gives refinement no *incremental* reward. On ``.*1010101.*`` the residual
+    nondeterminism is ``R --c--> {R, A}``; every partial split of ``R`` still leaves
+    nondeterminism, so the objective sits on a plateau (measured: 0.9853, flat over eight
+    rounds) until the whole 7-state chain appears at once.
+
+    Mutual information fixes both. It is 0 at collapse, so merging stops being a descent
+    direction at all; and a deterministic partition with ``k`` states scores ``log k``, so
+    every additional distinction that stays predictable is rewarded on its own. It prefers
+    *over*-refinement, which is harmless: any deterministic refinement of Nerode minifies
+    back to the minimal DFA.
+    """
+    num_symbols = t_batch.shape[0]
+    joint = t_batch / num_symbols  # P(c, s, s'), uniform over c
+    next_state = joint.sum((0, 1))
+    source = joint.sum(-1)
+    entropy_next = -(next_state * next_state.clamp_min(1e-12).log()).sum()
+    conditional = -(
+        joint * (joint.clamp_min(1e-12) / source.unsqueeze(-1).clamp_min(1e-12)).log()
+    ).sum()
+    return entropy_next - conditional
+
+
+def external_objective(probs, labels, mask, *, active_lags=None):
+    """Log-likelihood of ``label(x[:t + k])`` under ``probs[b, t, k]``, over all ``t, k``.
+
+    ``probs`` comes from :meth:`NeuralDFA.continuation_accept_probs`, i.e. it is conditioned
+    on the *observed* continuation ``x[t:t + k]`` rather than marginalised over
+    continuations. That is what gives this term any gradient toward refining the acceptance
+    partition at all -- see the docstring of :class:`NeuralDFA`.
+
+    None of this costs oracle queries: the target for ``(t, k)`` is the label at position
+    ``t + k`` of the same string, which was already bought when the prefix was labelled. The
+    observation table's suffix columns are, in effect, already paid for; the earlier version
+    of this term simply averaged them away.
+
+    ``active_lags`` restricts training to continuations up to that length. It has to grow:
+    the ``k = 0`` column is the only one whose target does not also require learning ``phi``,
+    and with all columns live from the start the head reaches "predict 0.5 everywhere" before
+    ``m`` learns anything -- which zeroes ``m``'s gradient (``dp/dm[s] = sigma(<u_s, phi>)``
+    becomes identical across ``s``) and deadlocks. Growing it mirrors L*, which finds short
+    distinguishers before long ones.
+    """
+    if active_lags is not None:
+        probs = probs[:, :, : active_lags + 1]
+    num_lags = probs.shape[2] - 1
+    # (B, L + 1, K + 1) windows: entry [b, t, k] is the label/weight at position t + k.
+    # Zero-padding gives weight 0 wherever t + k runs past the end of the string.
+    pad = torch.zeros(
+        labels.shape[0], num_lags, device=labels.device, dtype=labels.dtype
+    )
+    targets = torch.cat([labels, pad], dim=1).unfold(1, num_lags + 1, 1)
+    weights = torch.cat([mask, pad], dim=1).unfold(1, num_lags + 1, 1)
+
+    p = probs.clamp(1e-6, 1 - 1e-6)
+    log_lik = targets * p.log() + (1 - targets) * (-p).log1p()
+    return (log_lik * weights).sum() / weights.sum().clamp_min(1.0)
+
+
+def confidence_penalty(log_m):
+    """``E_x[H(m(x))] - H(E_x[m(x)])``, i.e. ``-I(prefix; state)``.
+
+    ``J_external`` is otherwise satisfied by a *soft mixture*: it reaches the noise floor
+    by interpolating accept rates across the simplex without ever committing to discrete
+    states, and when ``J_internal`` then demands determinism, collapsing to one state is a
+    cheaper way to get there than finding the congruence. So the assignment has to be hard
+    before ``J_internal`` turns on.
+
+    Minimising the conditional entropy alone does not achieve that -- one constant state is
+    the cheapest hard assignment, and it collapses in the first round. The marginal term is
+    the half that forbids it: together they ask for confident assignments that still spread
+    over several states.
+    """
+    flat = log_m.reshape(-1, log_m.shape[-1])
+    m = flat.exp()
+    conditional = -(m * flat).sum(-1).mean()
+    marginal = m.mean(0)
+    return conditional + (marginal * marginal.clamp_min(1e-12).log()).sum()
+
+
+def balance_penalty(log_m):
+    """``||E[m m^T] - I/S||_F^2``.
+
+    Zero only for a hard assignment that uses every state equally. Collapse makes the
+    Gram matrix rank one, and collapse is otherwise a strong early attractor because
+    ``J_internal = 1`` is reachable immediately while ``J_external`` has to be earned.
+    Annealed to zero — it is a scaffold, not part of the objective.
+    """
+    m = log_m.exp().reshape(-1, log_m.shape[-1])
+    gram = m.T @ m / m.shape[0]
+    target = torch.eye(gram.shape[0], device=gram.device) / gram.shape[0]
+    return ((gram - target) ** 2).sum()

--- a/orthogonal_dfa/l_star/neural/surrogate.py
+++ b/orthogonal_dfa/l_star/neural/surrogate.py
@@ -1,0 +1,702 @@
+"""Surrogate-guided DFA learning: fit the observation table, then read the DFA off it.
+
+The object L* spends its queries on is the table ``M[i][j] = oracle(p_i + v_j)`` -- 75% of
+them directly, and most of the rest classifying fresh prefixes against suffix families,
+which is the same thing for rows not yet in the table. The exploitable structure is that
+the noiseless table depends on ``p_i`` only through its Nerode state, so it has at most
+``n`` distinct rows out of however many prefixes there are.
+
+So: fit a model of the table from a subset of cells, and let it fill the rest.
+
+    M[p][v] = sum_s m(p)[s] * sigma(<u_s, phi(v)>)
+
+``m(p)`` is a distribution over ``S`` row-clusters, ``phi(v)`` embeds a suffix, and ``u_s``
+is a state's response profile. The softmax on ``m`` is the "at most n distinct rows"
+constraint and is what denoises: per-string noise is not expressible through an ``S``-cluster
+bottleneck, so a cell's prediction pools evidence from every prefix in its cluster. That
+matters because the noise here is fixed per string -- re-querying a cell can never denoise
+it, only populations can.
+
+Rows and columns are *encoders* over the strings rather than free per-row embeddings. That
+is the difference from ordinary matrix completion: the model generalises to prefixes and
+suffixes it never queried, which is what makes a fresh prefix classifiable for free.
+
+Empirically (``.*1010101.*``, 2000x64 table, symmetric noise 0.8): at 50% of cells the
+surrogate predicts held-out cells at 0.973 against the *noiseless* truth, versus 0.8 for
+reading each cell's own noisy label, and recovers 80% of the Nerode state information.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+import numpy as np
+import torch
+from automata.fa.dfa import DFA
+from torch import nn
+
+from orthogonal_dfa.l_star.neural.extract import accept_threshold
+from orthogonal_dfa.l_star.structures import Oracle
+
+
+@dataclass
+class SurrogateConfig:
+    num_states: int = 32  # over-provisioned on purpose; see module notes
+    suffix_dim: int = 16
+    hidden_size: int = 128
+    prefix_length: int = 40
+    num_prefixes: int = 1200
+    num_suffixes: int = 40
+    max_suffix_length: int = 10
+    initial_density: float = 0.3
+    cells_per_round: int = 6000
+    new_suffixes_per_round: int = 6
+    # Row growth, OFF by default. The idea is right -- random prefixes find a rare state only
+    # in proportion to its rarity -- but this implementation is not: it takes a row where the
+    # DFA disagrees with the surrogate, and the DFA is *extracted from* the surrogate, so a
+    # divergence measures extraction error rather than language error. Early on almost every
+    # probe "diverges", so the rows are near-arbitrary and each gets only cols_per_new_prefix
+    # columns, diluting the pool with under-observed rows. Measured over 14 targets it moved
+    # >=0.97 from 4/14 to 3/14 and median accuracy 0.855 -> 0.818 at more queries, with
+    # modulo9 falling 1.0 -> 0.773. A grounded version has to buy the candidate row's cells
+    # and keep it only if the OBSERVED row contradicts the hypothesis.
+    probe_strings: int = 3000
+    new_prefixes_per_round: int = 0
+    # Enrichment: add prefixes landing in under-populated clusters, and buy extra columns
+    # for prefixes the model cannot confidently place. Both are statements about our own
+    # sample rather than about the language, so neither can be self-referentially wrong the
+    # way a DFA-vs-surrogate divergence is.
+    enrich_per_round: int = 400
+    enrich_candidates: int = 20000
+    underconfident_rows_per_round: int = 300
+    # Mean absolute difference below which two prototype rows count as the same Nerode state.
+    # Rows converge to the noise rates, so the gap between "same" and "different" is
+    # |p_1 - p_0|; half of that is a natural cut.
+    merge_tolerance: float = 0.15
+    # Conformal calibration: fraction of observed cells held out of training and used to
+    # bound the surrogate's rate error, and the miscoverage level of that bound.
+    calibration_fraction: float = 0.15
+    conformal_alpha: float = 0.1
+    min_cells_per_estimate: int = 8
+    refine_iters: int = 12
+    max_blocks: int = 60
+    cols_per_new_prefix: int = 16
+    rounds: int = 5
+    steps_per_round: int = 250
+    prefix_batch: int = 256
+    lr: float = 3e-3
+    seed: int = 0
+
+
+class Encoder(nn.Module):
+    """Sequence -> vector, with a learned readout for the empty sequence.
+
+    The empty string has to be a first-class input: it is the initial state's row and the
+    plain-acceptance column.
+    """
+
+    def __init__(self, alphabet_size, out_dim, hidden_size):
+        super().__init__()
+        self.embed = nn.Embedding(alphabet_size, hidden_size)
+        self.gru = nn.GRU(hidden_size, hidden_size, batch_first=True)
+        self.h0 = nn.Parameter(torch.randn(1, 1, hidden_size) * 0.02)
+        self.head = nn.Linear(hidden_size, out_dim)
+
+    def forward(self, padded, lengths):
+        return self.all_positions(padded)[
+            torch.arange(len(lengths), device=padded.device), lengths
+        ]
+
+    def all_positions(self, padded):
+        """``(B, L + 1, out)`` -- every prefix of every row in one pass.
+
+        Counterexample search needs the verdict at all L+1 prefixes of a probe string; one
+        causal pass gives them instead of L+1 separate encodes.
+        """
+        h0 = self.h0.expand(-1, padded.shape[0], -1).contiguous()
+        out, _ = self.gru(self.embed(padded), h0)
+        return self.head(torch.cat([h0[-1].unsqueeze(1), out], dim=1))
+
+
+class TableSurrogate(nn.Module):
+    """``M[p][v] = sum_s m(p)[s] * sigma(<u_s, phi(v)>)``.
+
+    A mixture over states, not a mixture of logits: a prefix *has* a state and a state *has*
+    a behaviour. Mixing logits would let a prefix interpolate between states and mean nothing.
+    """
+
+    def __init__(self, alphabet_size, cfg: SurrogateConfig):
+        super().__init__()
+        self.rows = Encoder(alphabet_size, cfg.num_states, cfg.hidden_size)
+        self.cols = Encoder(alphabet_size, cfg.suffix_dim, cfg.hidden_size)
+        self.state_vectors = nn.Parameter(torch.randn(cfg.num_states, cfg.suffix_dim))
+
+    def row_log_probs(self, padded, lengths):
+        return torch.log_softmax(self.rows(padded, lengths), dim=-1)
+
+    def response(self, col_padded, col_lengths):
+        """``(V, S)``: probability that state ``s`` followed by suffix ``v`` is accepted."""
+        return torch.sigmoid(self.cols(col_padded, col_lengths) @ self.state_vectors.T)
+
+    def forward(self, row_log_m, response, rows_idx, cols_idx):
+        return (row_log_m[rows_idx].exp() * response[cols_idx]).sum(-1)
+
+
+def pad(sequences, width, device="cpu"):
+    out = np.zeros((len(sequences), width), dtype=np.int64)
+    for i, s in enumerate(sequences):
+        out[i, : len(s)] = s
+    lengths = np.array([len(s) for s in sequences], dtype=np.int64)
+    return torch.as_tensor(out, device=device), torch.as_tensor(lengths, device=device)
+
+
+@dataclass
+class CellPool:
+    """The prefix set, suffix set, and which cells have actually been paid for."""
+
+    oracle: Oracle
+    prefixes: List[List[int]]
+    suffixes: List[List[int]]
+    answers: dict = field(default_factory=dict)  # (i, j) -> bool
+    queried: set = field(default_factory=set)  # distinct strings, for the query count
+    holdout: set = field(
+        default_factory=set
+    )  # cells withheld from training, for conformal
+
+    def observe(self, cells):
+        wanted = [(i, j) for i, j in cells if (i, j) not in self.answers]
+        if not wanted:
+            return 0
+        strings = [self.prefixes[i] + self.suffixes[j] for i, j in wanted]
+        results = self.oracle.membership_queries(strings)
+        for (i, j), string, value in zip(wanted, strings, results):
+            self.answers[(i, j)] = bool(value)
+            self.queried.add(tuple(string))
+        return len(wanted)
+
+    def training_arrays(self):
+        """Observed cells minus the conformal holdout -- calibration must be on unseen data."""
+        usable = sorted(set(self.answers) - self.holdout)
+        cells = np.array(usable, dtype=np.int64)
+        labels = np.array([self.answers[tuple(c)] for c in cells], dtype=np.float32)
+        return cells, labels
+
+
+def _fit(model, opt, pool, *, cfg, rng, device, steps):
+    cells, labels = pool.training_arrays()
+    rows = torch.as_tensor(cells[:, 0], device=device)
+    cols = torch.as_tensor(cells[:, 1], device=device)
+    targets = torch.as_tensor(labels, device=device)
+    p_pad, p_len = pad(pool.prefixes, cfg.prefix_length, device)
+    v_pad, v_len = pad(pool.suffixes, cfg.max_suffix_length, device)
+
+    for _ in range(steps):
+        # Minibatch over PREFIXES, not cells: encoding the prefix set dominates the cost,
+        # and every cell in the batch reuses the same encodings.
+        chosen = torch.as_tensor(
+            rng.choice(
+                len(pool.prefixes),
+                size=min(cfg.prefix_batch, len(pool.prefixes)),
+                replace=False,
+            ),
+            device=device,
+        )
+        keep = torch.isin(rows, chosen)
+        if not bool(keep.any()):
+            continue
+        remap = torch.full((len(pool.prefixes),), -1, dtype=torch.long, device=device)
+        remap[chosen] = torch.arange(len(chosen), device=device)
+
+        row_log_m = model.row_log_probs(p_pad[chosen], p_len[chosen])
+        response = model.response(v_pad, v_len)
+        predicted = model(row_log_m, response, remap[rows[keep]], cols[keep]).clamp(
+            1e-6, 1 - 1e-6
+        )
+        y = targets[keep]
+        loss = -(y * predicted.log() + (1 - y) * (1 - predicted).log()).mean()
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+
+
+def _encode_all(model, pool, cfg, device, alphabet_size):
+    """Row distributions for every prefix and every one-symbol extension of it."""
+    with torch.no_grad():
+        p_pad, p_len = pad(pool.prefixes, cfg.prefix_length, device)
+        current = model.row_log_probs(p_pad, p_len).exp()
+        successors = []
+        for symbol in range(alphabet_size):
+            extended = [p + [symbol] for p in pool.prefixes]
+            e_pad, e_len = pad(extended, cfg.prefix_length + 1, device)
+            successors.append(model.row_log_probs(e_pad, e_len).exp())
+    return current, torch.stack(successors)
+
+
+def refine_partition(prefix_rows, successor_rows, empty_col, boundary, cfg):
+    """Moore/Hopcroft refinement over surrogate-predicted rows.
+
+    Start from the acceptance partition and split a block only when its transition is
+    ill-defined -- i.e. its members' ``c``-successors fall in different blocks. Every split is
+    then justified by an actual successor disagreement, so the result is a congruence *by
+    construction*.
+
+    That is the fix for letting the softmax choose the partition outright. The cell loss
+    cannot distinguish a Nerode class from that class split three ways -- all the sub-clusters
+    learn the same prototype row and predict identical cells -- so descent splits it at random,
+    and the successors then scatter across the sub-clusters (measured: 44/44 (state, symbol)
+    pairs diffuse, top-1 share 0.15-0.4). Refinement never creates a split it cannot justify.
+
+    The surrogate supplies the expensive ingredient: the predicted row of ``p . c`` for
+    prefixes that were never queried, so "see where (s, c) lands" costs nothing.
+    """
+    block = (prefix_rows[:, empty_col] > boundary).astype(np.int64)
+    successors = None
+    for _ in range(cfg.refine_iters):
+        num_blocks = int(block.max()) + 1
+        centroids = np.stack(
+            [
+                (
+                    prefix_rows[block == b].mean(0)
+                    if (block == b).any()
+                    else np.zeros(prefix_rows.shape[1])
+                )
+                for b in range(num_blocks)
+            ]
+        )
+        # Classify each p.c into a block by nearest centroid -- the surrogate standing in for
+        # sifting a fresh prefix through the discrimination tree.
+        successors = np.stack(
+            [
+                np.abs(rows[:, None, :] - centroids[None]).mean(-1).argmin(1)
+                for rows in successor_rows
+            ]
+        )
+        signature = list(zip(block, *successors))
+        codes = {sig: i for i, sig in enumerate(sorted(set(signature)))}
+        if len(codes) > cfg.max_blocks:
+            break
+        refined = np.array([codes[sig] for sig in signature], dtype=np.int64)
+        if len(codes) == num_blocks:
+            break
+        block = refined
+    return block, successors
+
+
+def conformal_rate_bound(response, clusters, pool, holdout, cfg):
+    """Distribution-free bound on how far the surrogate's predicted RATE can be off.
+
+    Conformal on the *label* is hopeless here: at 20% per-string noise a fifth of cells carry
+    a nonconformity score near 1, so any band with 90% label coverage is the whole interval
+    and every cell comes back undecided. The noise is irreducible per cell.
+
+    The rate is the right target -- it is what the cluster bottleneck estimates and what
+    pooling makes accurate. Held-out cells grouped by ``(cluster, suffix)`` give an empirical
+    rate to score against, and the ``1 - alpha`` quantile of ``|predicted - empirical|`` is a
+    calibrated bound. Unlike the two thresholds I picked by hand (a mean row distance, and
+    "any successor disagreement"), this one is measured.
+    """
+    buckets = {}
+    for i, j in holdout:
+        buckets.setdefault((int(clusters[i]), j), []).append(pool.answers[(i, j)])
+    # The empirical rate is itself a Bernoulli estimate, so |predicted - empirical| includes
+    # the calibration set's own sampling error -- at n=8 that alone is ~0.14 std, which would
+    # put q_hat near half the 0.6 gap between the noise rates and make everything undecided.
+    # Subtract that off so the score measures model error rather than our own noise.
+    scores = []
+    for (state, suffix), ys in buckets.items():
+        if len(ys) < cfg.min_cells_per_estimate:
+            continue
+        empirical = float(np.mean(ys))
+        standard_error = np.sqrt(max(empirical * (1 - empirical), 1e-6) / len(ys))
+        scores.append(
+            max(0.0, abs(response[state, suffix] - empirical) - 1.96 * standard_error)
+        )
+    if len(scores) < 20:
+        return 1.0  # not enough calibration data to claim anything
+    n = len(scores)
+    level = min(1.0, np.ceil((n + 1) * (1 - cfg.conformal_alpha)) / n)
+    return float(np.quantile(scores, level))
+
+
+def merge_by_conformal(response, counts, boundary, q_hat):
+    """Group clusters unless some suffix separates them *with calibrated confidence*.
+
+    ``label(s, v)`` is 1 when even the pessimistic rate ``R[s][v] - q_hat`` sits above the
+    boundary, 0 when the optimistic one sits below, and undecided in between -- the same
+    accept/reject/None trichotomy ``TriPredicate`` uses.
+
+    Two clusters merge unless some suffix gives them confident and *differing* labels. That
+    fixes the flaw in the mean-distance version: a single distinguishing column now blocks a
+    merge outright instead of being averaged away across 40 suffixes.
+    """
+    confident = np.where(
+        response - q_hat > boundary, 1, np.where(response + q_hat < boundary, 0, -1)
+    )
+    order = np.argsort(-counts)
+    labels = np.full(len(counts), -1)
+    representatives = []
+    for state in order:
+        if counts[state] == 0:
+            continue
+        for group, rep in enumerate(representatives):
+            both = (confident[state] >= 0) & (confident[rep] >= 0)
+            if not np.any(both & (confident[state] != confident[rep])):
+                labels[state] = group
+                break
+        else:
+            labels[state] = len(representatives)
+            representatives.append(state)
+    labels[labels < 0] = max(len(representatives), 1)
+    return labels, max(len(representatives), 1) + 1
+
+
+def merge_by_row(response, counts, tolerance):
+    """Group states whose prototype rows agree, returning a label per state.
+
+    The cell loss is *invariant* to arbitrary refinement: if a Nerode class is split across
+    three clusters, all three learn the same prototype row, predict the same cells and incur
+    the same loss, so gradient descent splits it arbitrarily. An arbitrary refinement is not
+    deterministic -- prefixes in one sub-cluster scatter across the sub-clusters of the next
+    class -- which is why the raw successor distribution is diffuse (measured: 44/44 pairs
+    non-concentrated, top-1 share 0.15-0.4).
+
+    ``minify`` cannot fix this because it needs correct transitions first. Rows can be
+    compared directly: two states with the same response over every suffix are the same
+    Nerode state, by definition.
+    """
+    order = np.argsort(-counts)
+    labels = np.full(len(counts), -1)
+    representatives = []
+    for state in order:
+        if counts[state] == 0:
+            continue
+        for group, rep in enumerate(representatives):
+            if np.abs(response[state] - response[rep]).mean() < tolerance:
+                labels[state] = group
+                break
+        else:
+            labels[state] = len(representatives)
+            representatives.append(state)
+    # Unused states get their own sink group so indexing stays total.
+    labels[labels < 0] = len(representatives)
+    return labels, len(representatives) + 1
+
+
+def extract_dfa(model, pool, cfg, device, alphabet_size):
+    """Soft-vote the transitions off the softmax clusters, then minify.
+
+    ``T[c, s, t] = sum_p m(p)[s] m(p.c)[t]``, and ``delta(s, c) = argmax_t``. This is a
+    population vote, so individual misclassification is tolerated -- but it also *discards*
+    the disagreement, which is the signal L*'s ``_resolve`` acts on: prefixes of ``s``
+    landing in different places means ``s`` needs splitting.
+
+    Two attempts to use that signal both did worse, in opposite directions, and both for the
+    same reason -- neither had a statistical decision rule:
+
+    * ``merge_by_row``: group states whose prototype rows are close. Over-merges, because a
+      mean over 40 suffixes dilutes a single distinguishing column. subseq and two_subseq
+      collapsed to one state; modulo9 fell to 0.227 on one seed. (It did get parity to
+      exactly 2 states, so row comparison does collapse duplicates -- the operator is wrong,
+      not the idea.)
+    * ``refine_partition``: Moore refinement, splitting a block when its members' successors
+      land in different blocks. Over-splits, because the successor assignment is a noisy
+      nearest-centroid classification, so any noise-driven disagreement causes a split and
+      blocks multiply each round. Parity shattered into 14-21 states at 0.49 accuracy.
+
+    What both are missing is ``transition_resolver._splits``: split only when the
+    disagreement is *significant* under a binomial test calibrated to the noise
+    (``split_pval``, ``decision_rule_fpr``, ``evidence_margin``). Under per-string noise a
+    bare threshold is not enough to decide whether two prefixes differ.
+    """
+    current, successors = _encode_all(model, pool, cfg, device, alphabet_size)
+    with torch.no_grad():
+        v_pad, v_len = pad(pool.suffixes, cfg.max_suffix_length, device)
+        response = model.response(v_pad, v_len).T.cpu().numpy()  # (S, V)
+        empty_col = [j for j, v in enumerate(pool.suffixes) if len(v) == 0][0]
+
+    clusters = current.argmax(-1).cpu().numpy()
+    counts = np.bincount(clusters, minlength=cfg.num_states)
+    # Hard counts, not soft mass: soft mass is never exactly zero, so unused clusters would
+    # enter the 2-means split carrying arbitrary accept probabilities.
+    boundary = accept_threshold(response[:, empty_col], counts.astype(float))
+
+    q_hat = conformal_rate_bound(response, clusters, pool, pool.holdout, cfg)
+    labels, num_groups = merge_by_conformal(response, counts, boundary, q_hat)
+    grouping = torch.zeros(cfg.num_states, num_groups, device=device)
+    grouping[torch.arange(cfg.num_states), torch.as_tensor(labels, device=device)] = 1.0
+
+    grouped = current @ grouping
+    transition = torch.einsum("ps,cpt->cst", grouped, successors @ grouping)
+    delta = transition.argmax(-1).cpu().numpy()
+    accept = np.array(
+        [
+            (
+                response[np.flatnonzero(labels == g), empty_col].mean()
+                if (labels == g).any()
+                else 0.5
+            )
+            for g in range(num_groups)
+        ]
+    )
+
+    empty_row = [i for i, p in enumerate(pool.prefixes) if len(p) == 0][0]
+    dfa = DFA(
+        states=set(range(num_groups)),
+        input_symbols=set(range(alphabet_size)),
+        transitions={
+            s: {c: int(delta[c, s]) for c in range(alphabet_size)}
+            for s in range(num_groups)
+        },
+        initial_state=int(grouped[empty_row].argmax()),
+        final_states={s for s in range(num_groups) if accept[s] > boundary},
+        allow_partial=False,
+    )
+    return (
+        dfa.minify(retain_names=False),
+        boundary,
+        {"q_hat": q_hat, "groups": num_groups},
+    )
+
+
+def counterexample_prefixes(
+    model, pool, dfa, boundary, *, cfg, rng, device, alphabet_size
+):
+    """Prefixes where the extracted DFA disagrees with the surrogate.
+
+    The surrogate is the denoised classifier here -- it plays the discrimination tree's role
+    in L*, and unlike a single oracle answer it is not 20% wrong. A divergence marks a prefix
+    the hypothesis routes to the wrong state, so adding it as a row targets exactly the
+    under-populated states that random prefix sampling misses. The new rows then get real
+    cells bought for them, which is what keeps this grounded rather than self-referential.
+    """
+    probes = rng.integers(
+        0, alphabet_size, size=(cfg.probe_strings, cfg.prefix_length), dtype=np.int64
+    )
+    with torch.no_grad():
+        v_pad, v_len = pad(pool.suffixes, cfg.max_suffix_length, device)
+        empty_col = [j for j, v in enumerate(pool.suffixes) if len(v) == 0][0]
+        accept = model.response(v_pad, v_len)[empty_col]
+        x = torch.as_tensor(probes, device=device)
+        rows = torch.log_softmax(model.rows.all_positions(x), dim=-1).exp()
+        surrogate_accepts = ((rows * accept).sum(-1) > boundary).cpu().numpy()
+
+    found = []
+    for row, verdict in zip(probes, surrogate_accepts):
+        state = dfa.initial_state
+        for t in range(len(row) + 1):
+            if (state in dfa.final_states) != bool(verdict[t]):
+                found.append(row[:t].tolist())
+                break
+            if t < len(row):
+                state = dfa.transitions[state][int(row[t])]
+    rng.shuffle(found)
+    return found[: cfg.new_prefixes_per_round]
+
+
+def enrich_underpopulated(model, pool, *, cfg, rng, device, alphabet_size):
+    """Prefixes that land in clusters with too few members.
+
+    This is ``enrich_underrepresented_leaves`` in the surrogate's terms, and it targets the
+    measured failure mode: a cluster with few members can fit its cells' noise instead of
+    pooling it away, because moving its prototype row costs nothing elsewhere.
+
+    Screening costs no oracle queries -- the encoder places a candidate prefix on its own --
+    so a large candidate pool can be filtered for free and only the keepers get cells bought.
+    """
+    with torch.no_grad():
+        p_pad, p_len = pad(pool.prefixes, cfg.prefix_length, device)
+        counts = np.bincount(
+            model.row_log_probs(p_pad, p_len).argmax(-1).cpu().numpy(),
+            minlength=cfg.num_states,
+        )
+    occupied = counts[counts > 0]
+    if occupied.size == 0:
+        return []
+    target = float(np.median(occupied))
+
+    candidates = [
+        rng.integers(
+            0, alphabet_size, size=rng.integers(0, cfg.prefix_length + 1)
+        ).tolist()
+        for _ in range(cfg.enrich_candidates)
+    ]
+    with torch.no_grad():
+        c_pad, c_len = pad(candidates, cfg.prefix_length, device)
+        placed = model.row_log_probs(c_pad, c_len).argmax(-1).cpu().numpy()
+
+    # Rarest-cluster-first, so the thinnest clusters get filled before the merely below-median.
+    wanted = [i for i, c in enumerate(placed) if counts[c] < target]
+    wanted.sort(key=lambda i: counts[placed[i]])
+    return [candidates[i] for i in wanted[: cfg.enrich_per_round]]
+
+
+def underconfident_rows(model, pool, *, cfg, device):
+    """Prefixes whose cluster assignment is least certain, by entropy of ``m(p)``.
+
+    A row the model cannot place is a row whose observed cells do not yet pin it to any
+    prototype -- so buying more of its columns is exactly the missing evidence.
+    """
+    with torch.no_grad():
+        p_pad, p_len = pad(pool.prefixes, cfg.prefix_length, device)
+        log_m = model.row_log_probs(p_pad, p_len)
+        entropy = -(log_m.exp() * log_m).sum(-1).cpu().numpy()
+    return np.argsort(-entropy)[: cfg.underconfident_rows_per_round]
+
+
+def propose_suffixes(model, pool, weights, *, cfg, rng, device, alphabet_size):
+    """Candidate suffixes scored by how much they split the current clusters.
+
+    This is the surrogate standing in for L*'s distinguisher search: instead of sampling
+    suffix families and evaluating each over every prefix, score candidates by prediction and
+    only pay for cells on the winners.
+    """
+    candidates = [
+        rng.integers(
+            0, alphabet_size, size=rng.integers(1, cfg.max_suffix_length + 1)
+        ).tolist()
+        for _ in range(64)
+    ]
+    known = {tuple(v) for v in pool.suffixes}
+    candidates = [v for v in candidates if tuple(v) not in known]
+    if not candidates:
+        return []
+    with torch.no_grad():
+        c_pad, c_len = pad(candidates, cfg.max_suffix_length, device)
+        response = model.response(c_pad, c_len).cpu().numpy()  # (C, S)
+    mass = weights / max(weights.sum(), 1e-9)
+    mean = (response * mass).sum(-1, keepdims=True)
+    spread = (((response - mean) ** 2) * mass).sum(-1)
+    order = np.argsort(-spread)[: cfg.new_suffixes_per_round]
+    return [candidates[i] for i in order]
+
+
+def learn_dfa(oracle: Oracle, cfg: SurrogateConfig, *, log=print) -> Tuple[DFA, dict]:
+    torch.manual_seed(cfg.seed)
+    rng = np.random.default_rng(cfg.seed)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    alphabet_size = oracle.alphabet_size
+
+    prefixes = [[]] + [
+        rng.integers(
+            0, alphabet_size, size=rng.integers(0, cfg.prefix_length + 1)
+        ).tolist()
+        for _ in range(cfg.num_prefixes - 1)
+    ]
+    suffixes = [[]] + [
+        rng.integers(
+            0, alphabet_size, size=rng.integers(1, cfg.max_suffix_length + 1)
+        ).tolist()
+        for _ in range(cfg.num_suffixes - 1)
+    ]
+    pool = CellPool(oracle, prefixes, suffixes)
+
+    all_cells = [(i, j) for i in range(len(prefixes)) for j in range(len(suffixes))]
+    initial = rng.permutation(len(all_cells))[
+        : int(cfg.initial_density * len(all_cells))
+    ]
+    pool.observe([all_cells[k] for k in initial])
+
+    observed = sorted(pool.answers)
+    pool.holdout.update(
+        tuple(observed[k])
+        for k in rng.permutation(len(observed))[
+            : int(cfg.calibration_fraction * len(observed))
+        ]
+    )
+
+    model = TableSurrogate(alphabet_size, cfg).to(device)
+    opt = torch.optim.Adam(model.parameters(), lr=cfg.lr)
+
+    dfa, boundary = None, 0.5
+    for round_idx in range(cfg.rounds):
+        _fit(
+            model,
+            opt,
+            pool,
+            cfg=cfg,
+            rng=rng,
+            device=device,
+            steps=cfg.steps_per_round,
+        )
+        dfa, boundary, diag = extract_dfa(model, pool, cfg, device, alphabet_size)
+        log(
+            f"round {round_idx}: cells={len(pool.answers):,} queries={len(pool.queried):,} "
+            f"prefixes={len(pool.prefixes)} suffixes={len(pool.suffixes)} "
+            f"q_hat={diag['q_hat']:.3f} groups={diag['groups']} states={len(dfa.states)}"
+        )
+        if round_idx == cfg.rounds - 1:
+            break
+
+        new_rows = counterexample_prefixes(
+            model,
+            pool,
+            dfa,
+            boundary,
+            cfg=cfg,
+            rng=rng,
+            device=device,
+            alphabet_size=alphabet_size,
+        )
+        new_rows = new_rows + enrich_underpopulated(
+            model, pool, cfg=cfg, rng=rng, device=device, alphabet_size=alphabet_size
+        )
+        fresh_cells = []
+        for index in underconfident_rows(model, pool, cfg=cfg, device=device):
+            for j in rng.choice(
+                len(pool.suffixes),
+                size=min(cfg.cols_per_new_prefix, len(pool.suffixes)),
+                replace=False,
+            ):
+                fresh_cells.append((int(index), int(j)))
+        for prefix in new_rows:
+            index = len(pool.prefixes)
+            pool.prefixes.append(prefix)
+            for j in rng.choice(
+                len(pool.suffixes),
+                size=min(cfg.cols_per_new_prefix, len(pool.suffixes)),
+                replace=False,
+            ):
+                fresh_cells.append((index, int(j)))
+        pool.observe(fresh_cells)
+
+        current, _ = _encode_all(model, pool, cfg, device, alphabet_size)
+        for suffix in propose_suffixes(
+            model,
+            pool,
+            current.sum(0).cpu().numpy(),
+            cfg=cfg,
+            rng=rng,
+            device=device,
+            alphabet_size=alphabet_size,
+        ):
+            pool.suffixes.append(suffix)
+
+        # Spend the round's budget where the surrogate is least sure, plus full coverage of
+        # any newly added column so it is anchored in real answers rather than prediction.
+        with torch.no_grad():
+            p_pad, p_len = pad(pool.prefixes, cfg.prefix_length, device)
+            v_pad, v_len = pad(pool.suffixes, cfg.max_suffix_length, device)
+            predicted = (
+                (
+                    model.row_log_probs(p_pad, p_len).exp()
+                    @ model.response(v_pad, v_len).T
+                )
+                .cpu()
+                .numpy()
+            )
+        uncertainty = -np.abs(predicted - 0.5)
+        for i, j in pool.answers:
+            uncertainty[i, j] = -np.inf
+        flat = np.argsort(uncertainty.ravel())[::-1][: cfg.cells_per_round]
+        pool.observe(
+            [(int(k // predicted.shape[1]), int(k % predicted.shape[1])) for k in flat]
+        )
+
+    return dfa, {
+        "distinct_queries": len(pool.queried),
+        "cells": len(pool.answers),
+        "prefixes": len(pool.prefixes),
+        "suffixes": len(pool.suffixes),
+        "states": len(dfa.states),
+        "boundary": round(float(boundary), 4),
+        "q_hat": round(float(diag["q_hat"]), 4),
+    }

--- a/orthogonal_dfa/l_star/neural/surrogate.py
+++ b/orthogonal_dfa/l_star/neural/surrogate.py
@@ -41,6 +41,7 @@ from orthogonal_dfa.l_star.structures import Oracle
 @dataclass
 class SurrogateConfig:
     num_states: int = 32  # over-provisioned on purpose; see module notes
+    signal_strength: float = 0.3  # same input SearchConfig takes
     suffix_dim: int = 16
     hidden_size: int = 128
     prefix_length: int = 40
@@ -129,13 +130,29 @@ class TableSurrogate(nn.Module):
         self.rows = Encoder(alphabet_size, cfg.num_states, cfg.hidden_size)
         self.cols = Encoder(alphabet_size, cfg.suffix_dim, cfg.hidden_size)
         self.state_vectors = nn.Parameter(torch.randn(cfg.num_states, cfg.suffix_dim))
+        # Response confined to [0.5 - s, 0.5 + s], the only rates a cell can legitimately
+        # have. Without this the model memorises: predicted rates pile up at 0.0 and 1.0
+        # instead of the noise rates, which only beats predicting the rate if the model is
+        # right about individual cells -- and it gets there by grouping prefixes whose
+        # observed cells happen to agree, which shreds the partition (each true residue
+        # smeared over 16-21 clusters, transition concentration 0.25).
+        #
+        # The bound must be FIXED, not learned. A learned range is vacuous: the model just
+        # widens it to 0/1 and memorises anyway, which is exactly what happened.
+        # min_signal_strength is an input to the existing pipeline too (SearchConfig), so
+        # this is the same information L* is given.
+        self.signal_strength = cfg.signal_strength
 
     def row_log_probs(self, padded, lengths):
         return torch.log_softmax(self.rows(padded, lengths), dim=-1)
 
     def response(self, col_padded, col_lengths):
-        """``(V, S)``: probability that state ``s`` followed by suffix ``v`` is accepted."""
-        return torch.sigmoid(self.cols(col_padded, col_lengths) @ self.state_vectors.T)
+        """``(V, S)``: probability that state ``s`` followed by suffix ``v`` is accepted.
+
+        Confined to the achievable rate range; see ``signal_strength`` above.
+        """
+        inner = torch.sigmoid(self.cols(col_padded, col_lengths) @ self.state_vectors.T)
+        return 0.5 - self.signal_strength + 2 * self.signal_strength * inner
 
     def forward(self, row_log_m, response, rows_idx, cols_idx):
         return (row_log_m[rows_idx].exp() * response[cols_idx]).sum(-1)

--- a/orthogonal_dfa/l_star/neural/surrogate.py
+++ b/orthogonal_dfa/l_star/neural/surrogate.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from typing import List, Tuple
 
 import numpy as np
+import scipy.stats
 import torch
 from automata.fa.dfa import DFA
 from torch import nn
@@ -77,6 +78,20 @@ class SurrogateConfig:
     # bound the surrogate's rate error, and the miscoverage level of that bound.
     calibration_fraction: float = 0.15
     conformal_alpha: float = 0.1
+    # SearchConfig uses 0.001, but it tests over far larger samples. Here a (cluster, suffix)
+    # cell holds ~15 observations, so a real 0.2-vs-0.8 gap gives z ~ 3.3 while Bonferroni
+    # over 40 columns at 0.001 demands 4.2 -- genuine differences get missed and clusters
+    # collapse. Measured over 3 seeds: subseq reaches exactly 8 states on 2/3 seeds at 0.01
+    # versus 1/3 at 0.001. Loosening further hurts (0/3 at 0.05), because extra groups make
+    # the transition argmax noisier and the DFA minifies back down.
+    split_pvalue: float = 0.01
+    # Statistical transition resolution, OFF by default: implemented but NOT validated.
+    # Enabling it regressed parity from 1.0 to 0.5003. The motivation stands -- delta(b, c)
+    # needs the group of p . c, which is not a row of the table, so the argmax infers it
+    # entirely from the model -- but buying successor cells per transition is not yet
+    # producing better transitions than the co-occurrence vote.
+    resolve_transitions_statistically: bool = False
+    successors_per_transition: int = 40
     min_cells_per_estimate: int = 8
     refine_iters: int = 12
     max_blocks: int = 60
@@ -334,6 +349,177 @@ def conformal_rate_bound(response, clusters, pool, holdout, cfg):
     return float(np.quantile(scores, level))
 
 
+def resolve_transitions(pool, block_of, num_groups, accepts, totals, *, cfg, rng):
+    """Determine delta(b, c) from cells bought for the successors themselves.
+
+    The argmax over the co-occurrence tensor cannot work: delta(b, c) needs the group of
+    ``p . c``, but ``p . c`` is generally not a row of the table, so its group comes entirely
+    from the model. L* sidesteps this by keeping the table prefix-closed, so the successor is
+    a real row. Bounded version of the same thing: there are only ``num_groups * |Sigma|``
+    transitions, so buy cells for a sample of successors per transition and assign the
+    destination by the same two-proportion test used to form the groups.
+
+    Falls back to the group's own index (a self-loop) when nothing clears the test, which
+    keeps the DFA total without inventing a destination.
+    """
+    members = {b: np.flatnonzero(block_of == b) for b in range(num_groups)}
+    delta = np.arange(num_groups)[None, :].repeat(pool.oracle.alphabet_size, axis=0)
+    for b, rows in members.items():
+        # Only prefixes with room to grow: p . c must still fit the padded width.
+        rows = np.array([i for i in rows if len(pool.prefixes[i]) < cfg.prefix_length])
+        if rows.size == 0:
+            continue
+        sample = rng.choice(
+            rows, size=min(cfg.successors_per_transition, len(rows)), replace=False
+        )
+        for c in range(pool.oracle.alphabet_size):
+            successors = [pool.prefixes[i] + [c] for i in sample]
+            start = len(pool.prefixes)
+            pool.prefixes.extend(successors)
+            columns = rng.choice(
+                len(pool.suffixes),
+                size=min(cfg.cols_per_new_prefix, len(pool.suffixes)),
+                replace=False,
+            )
+            pool.observe(
+                [(start + k, int(j)) for k in range(len(successors)) for j in columns]
+            )
+            # Pool the successors into one profile and ask which group it fails to differ from.
+            succ_accepts = np.zeros(len(pool.suffixes))
+            succ_totals = np.zeros(len(pool.suffixes))
+            for k in range(len(successors)):
+                for j in columns:
+                    value = pool.answers.get((start + k, int(j)))
+                    if value is not None:
+                        succ_accepts[j] += value
+                        succ_totals[j] += 1
+            stacked_a = np.vstack([accepts, succ_accepts])
+            stacked_t = np.vstack([totals, succ_totals])
+            candidates = [
+                b2
+                for b2 in range(num_groups)
+                if len(members[b2])
+                and not differ_significantly(
+                    stacked_a,
+                    stacked_t,
+                    num_groups,
+                    b2,
+                    pvalue=cfg.split_pvalue,
+                    min_cells=cfg.min_cells_per_estimate,
+                )
+            ]
+            if candidates:
+                delta[c, b] = min(candidates, key=lambda b2: -len(members[b2]))
+    return delta
+
+
+def trim_unreachable(dfa):
+    """Drop states unreachable from the initial state. Deliberately NOT ``minify``.
+
+    ``minify`` also merges behaviourally equivalent states, which assumes the transition
+    table is correct. Here it is estimated, so two states whose transitions are wrong in the
+    same way look equivalent and get merged -- turning a transition error into total
+    collapse, which is what the recurring "1 state" outcome was. It also explains why
+    loosening ``split_pvalue`` made things worse: more groups meant noisier transitions,
+    hence more spurious equivalences for minify to collapse.
+
+    ``transition_resolver._to_dfa_and_tree`` does not minify either. It does not need to: its
+    states are discrimination-tree leaves, each separated by an actual distinguishing suffix,
+    so no two are equivalent by construction. ``merge_by_counts`` gives the same guarantee.
+    """
+    reachable, frontier = {dfa.initial_state}, [dfa.initial_state]
+    while frontier:
+        state = frontier.pop()
+        for target in dfa.transitions[state].values():
+            if target not in reachable:
+                reachable.add(target)
+                frontier.append(target)
+    renamed = {state: i for i, state in enumerate(sorted(reachable))}
+    return DFA(
+        states=set(renamed.values()),
+        input_symbols=set(dfa.input_symbols),
+        transitions={
+            renamed[s]: {c: renamed[t] for c, t in dfa.transitions[s].items()}
+            for s in reachable
+        },
+        initial_state=renamed[dfa.initial_state],
+        final_states={renamed[s] for s in dfa.final_states if s in reachable},
+        allow_partial=False,
+    )
+
+
+def observed_counts(pool, clusters, num_states):
+    """``(accepts, totals)`` per ``(cluster, suffix)`` over the cells actually queried."""
+    accepts = np.zeros((num_states, len(pool.suffixes)))
+    totals = np.zeros((num_states, len(pool.suffixes)))
+    for (i, j), value in pool.answers.items():
+        # Rows appended after the assignment was computed (successor rows bought by
+        # resolve_transitions) have no cluster yet; they are counted next round.
+        if i >= len(clusters):
+            continue
+        accepts[clusters[i], j] += value
+        totals[clusters[i], j] += 1
+    return accepts, totals
+
+
+def differ_significantly(accepts, totals, s, t, *, pvalue, min_cells):
+    """Do clusters ``s`` and ``t`` differ on ANY suffix, by a two-proportion test?
+
+    Max over columns, not mean. That distinction is the whole point: separating two states
+    typically needs one specific suffix out of forty -- for ``.*1010101.*``, the one that
+    completes the pattern from one state and not the other. Averaging over columns buries it,
+    which is why a mean row distance over-merged and why the cross-entropy itself barely
+    notices the distinction (measured: each column separates ~12 of 28 state pairs, but the
+    other ~37 columns agree and dominate the loss).
+
+    Tested on the cells actually observed rather than on the model's predicted rows, so a
+    decision never rests on a value the surrogate interpolated. Bonferroni over the columns
+    compared.
+    """
+    usable = (totals[s] >= min_cells) & (totals[t] >= min_cells)
+    if not usable.any():
+        return False
+    rate_s = accepts[s][usable] / totals[s][usable]
+    rate_t = accepts[t][usable] / totals[t][usable]
+    pooled = (accepts[s][usable] + accepts[t][usable]) / (
+        totals[s][usable] + totals[t][usable]
+    )
+    standard_error = np.sqrt(
+        np.maximum(pooled * (1 - pooled), 1e-9)
+        * (1 / totals[s][usable] + 1 / totals[t][usable])
+    )
+    z = np.abs(rate_s - rate_t) / standard_error
+    critical = scipy.stats.norm.isf(pvalue / (2 * max(int(usable.sum()), 1)))
+    return bool((z > critical).any())
+
+
+def merge_by_counts(pool, clusters, counts, cfg):
+    """Group clusters unless some suffix separates them significantly on observed cells."""
+    accepts, totals = observed_counts(pool, clusters, len(counts))
+    order = np.argsort(-counts)
+    labels = np.full(len(counts), -1)
+    representatives = []
+    for state in order:
+        if counts[state] == 0:
+            continue
+        for group, rep in enumerate(representatives):
+            if not differ_significantly(
+                accepts,
+                totals,
+                state,
+                rep,
+                pvalue=cfg.split_pvalue,
+                min_cells=cfg.min_cells_per_estimate,
+            ):
+                labels[state] = group
+                break
+        else:
+            labels[state] = len(representatives)
+            representatives.append(state)
+    labels[labels < 0] = max(len(representatives), 1)
+    return labels, max(len(representatives), 1) + 1
+
+
 def merge_by_conformal(response, counts, boundary, q_hat):
     """Group clusters unless some suffix separates them *with calibrated confidence*.
 
@@ -398,7 +584,7 @@ def merge_by_row(response, counts, tolerance):
     return labels, len(representatives) + 1
 
 
-def extract_dfa(model, pool, cfg, device, alphabet_size):
+def extract_dfa(model, pool, cfg, device, alphabet_size, *, rng=None):
     """Soft-vote the transitions off the softmax clusters, then minify.
 
     ``T[c, s, t] = sum_p m(p)[s] m(p.c)[t]``, and ``delta(s, c) = argmax_t``. This is a
@@ -424,7 +610,8 @@ def extract_dfa(model, pool, cfg, device, alphabet_size):
     (``split_pval``, ``decision_rule_fpr``, ``evidence_margin``). Under per-string noise a
     bare threshold is not enough to decide whether two prefixes differ.
     """
-    current, successors = _encode_all(model, pool, cfg, device, alphabet_size)
+    rng = np.random.default_rng(0) if rng is None else rng
+    current, _ = _encode_all(model, pool, cfg, device, alphabet_size)
     with torch.no_grad():
         v_pad, v_len = pad(pool.suffixes, cfg.max_suffix_length, device)
         response = model.response(v_pad, v_len).T.cpu().numpy()  # (S, V)
@@ -437,13 +624,28 @@ def extract_dfa(model, pool, cfg, device, alphabet_size):
     boundary = accept_threshold(response[:, empty_col], counts.astype(float))
 
     q_hat = conformal_rate_bound(response, clusters, pool, pool.holdout, cfg)
-    labels, num_groups = merge_by_conformal(response, counts, boundary, q_hat)
+    labels, num_groups = merge_by_counts(pool, clusters, counts, cfg)
     grouping = torch.zeros(cfg.num_states, num_groups, device=device)
     grouping[torch.arange(cfg.num_states), torch.as_tensor(labels, device=device)] = 1.0
 
     grouped = current @ grouping
-    transition = torch.einsum("ps,cpt->cst", grouped, successors @ grouping)
-    delta = transition.argmax(-1).cpu().numpy()
+    block_of = labels[clusters]
+    group_accepts, group_totals = observed_counts(pool, block_of, num_groups)
+    # Transitions from cells bought for the successors, not from the co-occurrence argmax:
+    # delta(b, c) needs the group of p.c, and p.c is not a row of the table, so the argmax
+    # infers it entirely from the model. See resolve_transitions.
+    if cfg.resolve_transitions_statistically:
+        delta = resolve_transitions(
+            pool, block_of, num_groups, group_accepts, group_totals, cfg=cfg, rng=rng
+        )
+    else:
+        _, successors = _encode_all(model, pool, cfg, device, alphabet_size)
+        delta = (
+            torch.einsum("ps,cpt->cst", grouped, successors @ grouping)
+            .argmax(-1)
+            .cpu()
+            .numpy()
+        )
     accept = np.array(
         [
             (
@@ -467,11 +669,7 @@ def extract_dfa(model, pool, cfg, device, alphabet_size):
         final_states={s for s in range(num_groups) if accept[s] > boundary},
         allow_partial=False,
     )
-    return (
-        dfa.minify(retain_names=False),
-        boundary,
-        {"q_hat": q_hat, "groups": num_groups},
-    )
+    return trim_unreachable(dfa), boundary, {"q_hat": q_hat, "groups": num_groups}
 
 
 def counterexample_prefixes(
@@ -634,7 +832,9 @@ def learn_dfa(oracle: Oracle, cfg: SurrogateConfig, *, log=print) -> Tuple[DFA, 
             device=device,
             steps=cfg.steps_per_round,
         )
-        dfa, boundary, diag = extract_dfa(model, pool, cfg, device, alphabet_size)
+        dfa, boundary, diag = extract_dfa(
+            model, pool, cfg, device, alphabet_size, rng=rng
+        )
         log(
             f"round {round_idx}: cells={len(pool.answers):,} queries={len(pool.queried):,} "
             f"prefixes={len(pool.prefixes)} suffixes={len(pool.suffixes)} "

--- a/orthogonal_dfa/l_star/neural/train.py
+++ b/orthogonal_dfa/l_star/neural/train.py
@@ -1,0 +1,506 @@
+"""Counterexample-driven training of an amortised state predictor.
+
+The loop keeps the shape of :func:`orthogonal_dfa.l_star.lstar.counterexample_driven_synthesis`
+but two of its costs disappear. Sifting is a forward pass instead of one oracle batch per
+decision-tree level, and locating a divergence needs no binary search: ``m`` gives the
+state at every prefix at once, so a linear scan finds *every* divergence position. Mined
+strings feed ``J_internal``, which is unsupervised, so mining costs no oracle queries at
+all — the whole query budget goes to labelling prefixes for ``J_external``.
+
+Status. ``parity`` is recovered exactly (accuracy 1.0, 2 states, 88k distinct queries).
+``.*1010101.*`` and modulo-9 are not: ``m`` learns the acceptance partition and stops.
+
+Not for want of oracle information -- the same encoder without the state bottleneck reaches
+1.0 prefix accuracy on the same labels. The obstacle is that under the uniform length-40
+sampling distribution the Nerode refinement is worth almost nothing in likelihood. With a
+per-state scalar accept rate ``J_external`` is *exactly* invariant under every refinement of
+the acceptance partition, so it contributes zero gradient toward refining it. Conditioning
+on the observed continuation (see :class:`NeuralDFA`) removes that exact invariance, but
+only ~0.01 nats of it: the model already predicts within 0.01 of the noise floor without
+knowing the sub-states, because the continuations that separate them occur with probability
+~2^-k. Meanwhile collapsing buys ``J_internal`` 0.02-0.07. The refinement signal loses to
+the collapse signal by roughly an order of magnitude either way.
+
+That is the structural gap with L*, which does not optimise a distribution-matched average
+loss at all: it constructs *targeted* distinguishing experiments, so a state distinction is
+worth a whole counterexample rather than 2^-k of the likelihood.
+"""
+
+from collections import Counter, deque
+from dataclasses import dataclass, field
+from typing import List
+
+import numpy as np
+import torch
+
+from orthogonal_dfa.l_star.neural.extract import denoise_accept_labels, extract_dfa
+from orthogonal_dfa.l_star.neural.model import NeuralDFA
+from orthogonal_dfa.l_star.neural.objective import (
+    TransitionStatistics,
+    balance_penalty,
+    batch_transition_statistics,
+    confidence_penalty,
+    external_objective,
+    internal_information,
+    internal_objective,
+)
+from orthogonal_dfa.l_star.sampler import UniformSampler
+from orthogonal_dfa.l_star.structures import Oracle
+
+
+@dataclass
+class NeuralConfig:
+    num_states: int = 32
+    hidden_size: int = 128
+    num_layers: int = 1
+    length: int = 40
+    num_strings: int = 3000
+    mined_cap: int = 3000
+    batch_size: int = 64
+    lr: float = 3e-3
+    rounds: int = 10
+    epochs_per_round: int = 8
+    # Must dominate J_internal. J_internal only spans [0, 1] and collapse buys it very
+    # little, but its trivial basin is broad enough that at equal weight the optimizer
+    # slides into collapse anyway -- observed even where the value arithmetic says collapse
+    # is a net loss. J_internal is a tie-breaker toward determinism, not the main signal.
+    lambda_external: float = 5.0
+    # J_internal is satisfiable immediately -- by total collapse, but also by any trivial
+    # congruence ("length mod 2", "last symbol") that says nothing about acceptance. So
+    # it stays off while J_external establishes what the states have to explain, then
+    # ramps in to make that partition deterministic (which can only refine it).
+    internal_warmup_rounds: int = 3
+    internal_ramp_rounds: int = 3
+    # Continuation lengths the accept head conditions on. Needs to reach the length of the
+    # shortest distinguishing suffix -- 7 for `.*1010101.*`.
+    num_lags: int = 8
+    suffix_dim: int = 16
+    # False: the max form with num_lags=0 is the most stable configuration measured
+    # (J_external held at the noise floor for 12 rounds, no collapse). The information form
+    # does prevent collapse as designed, but it then settles on a *language-independent*
+    # deterministic congruence instead -- exactly log 2 on `.*1010101.*`, ~log 3 on modulo,
+    # with J_external back at base rate. Neither form recovers the Nerode partition; see
+    # the module docstring.
+    use_information_objective: bool = False
+    # Off by default: -I(prefix; state) makes m discrete but is unsupervised, so it wins
+    # over the label signal and encodes the wrong partition. The lagged targets are the
+    # supervised way to get the same discreteness. Kept as a knob.
+    gamma_confidence: float = 0.0
+    # Off by default. It was insurance against collapse, but the warmup already handles
+    # that, and with num_states over-provisioned "use every state equally" can only be
+    # satisfied by duplicating states -- which caps J_internal below 1 and makes the
+    # state-level agreement rate meaningless. Kept as a knob for diagnosing collapse.
+    beta_balance: float = 0.0
+    balance_rounds: int = 3  # rounds over which beta anneals to zero
+    temperature_start: float = 1.0
+    # Not annealed to 0. A hard argmax in J_internal drives collapse: on `.*1010101.*` a
+    # converged run survived tau=0.46 and 0.31 and collapsed the round tau hit 0.21. The
+    # softened max keeps J_internal an expectation over P(s'|c,s), which is gentler; the
+    # EMA argmax is what extraction reads anyway, so nothing needs tau=0.
+    temperature_end: float = 0.3
+    ema_decay: float = 0.95
+    min_support: float = 1e-3
+    sift_strings: int = 20000
+    agreement_target: float = 0.9995
+    denoise_samples: int = 200
+    # Mined counterexamples get labelled and fed to J_external, not just to J_internal.
+    # Feeding them only to J_internal (the original design here) aimed the targeting at the
+    # term that was never the binding constraint -- and is the one that prefers collapse.
+    # This is what makes a mined string a targeted experiment rather than another sample,
+    # and the query cost is exactly what buys that.
+    # 0 by default: measured, it does not fix the languages that fail (subseq still
+    # extracts one state) and it *breaks* the one that works (parity drops to chance,
+    # because 10x weight on a skewed mined sample distorts J_external). It also doubles the
+    # query count. Kept as a knob -- but see the module docstring: the mining criterion is
+    # self-referential, so a mined string is not yet an L*-style counterexample at all.
+    label_mined_per_round: int = 0
+    mined_boost: float = 10.0
+    # 0: measured, ANY positive value breaks parity (1.0 -> 0.5003 at 0.5, 1.0 and 4.0).
+    # The flag is only ~48% precise -- the DFA errs on 18.7% of prefixes and noise flips
+    # 20%, so P(flagged) = 0.187*0.8 + 0.813*0.2 = 0.313 of which 0.15 are genuine. Half
+    # noise would be survivable if it averaged out, but the noise is fixed per string, so
+    # upweighting a flagged prefix just re-amplifies the single coin flip that
+    # inverse-multiplicity weighting exists to suppress. Kept as a knob; the noise-robust
+    # version has to compare populations, not prefixes.
+    error_boost: float = 0.0
+    seed: int = 0
+
+
+@dataclass
+class Example:
+    string: np.ndarray
+    labels: np.ndarray
+    mask: np.ndarray
+    # Multiplier on this example's J_external weight. Mined counterexamples get more than
+    # 1: a counterexample is meant to force a split, and at distribution-matched weight it
+    # cannot, because the refinement it argues for is worth ~0.01 nats of average
+    # likelihood. 0 marks an example with no labels at all.
+    boost: float = 1.0
+    # 1 at prefixes the current hypothesis DFA gets wrong, 0 elsewhere. This is the
+    # oracle-grounded counterexample signal: unlike an m-vs-delta divergence it is evidence
+    # about the *language*, not about m's self-consistency.
+    error: np.ndarray = None
+
+
+@dataclass
+class LabelCache:
+    """Deduplicating label store; ``len`` is the distinct-query count.
+
+    Short prefixes are shared across most sampled strings, so deduplication is what
+    keeps the query count near-linear in the number of strings rather than in the number
+    of (string, position) pairs.
+    """
+
+    oracle: Oracle
+    values: dict = field(default_factory=dict)
+    total_queries: int = 0
+
+    def prefetch(self, strings):
+        missing = sorted({tuple(s) for s in strings} - self.values.keys())
+        if not missing:
+            return
+        answers = self.oracle.membership_queries([list(s) for s in missing])
+        self.total_queries += len(missing)
+        self.values.update(zip(missing, (bool(a) for a in answers)))
+
+    def __getitem__(self, string):
+        return self.values[tuple(string)]
+
+    def __len__(self):
+        return len(self.values)
+
+
+def labelled_examples(strings, labels: LabelCache, boost=1.0) -> List[Example]:
+    """Label every prefix, weighting each by inverse multiplicity in the pool.
+
+    The noise is fixed per string, so a prefix has exactly *one* label no matter how
+    often it is drawn. Short prefixes are shared by many strings, so unit weighting
+    repeats one coin flip hundreds of times and ``J_external`` learns it as ground truth
+    — the empty prefix is the extreme case, a population of size one. Weighting by
+    ``1 / multiplicity`` makes each distinct oracle answer count once, which is what its
+    information content actually is.
+    """
+    prefixes = [[tuple(s[:t]) for t in range(len(s) + 1)] for s in strings]
+    labels.prefetch([list(p) for row in prefixes for p in row])
+    out = []
+    for s, row in zip(strings, prefixes):
+        y = np.array([labels[p] for p in row], dtype=np.float32)
+        out.append(
+            Example(
+                np.asarray(s),
+                y,
+                np.ones(len(s) + 1, dtype=np.float32),
+                boost,
+                np.zeros(len(s) + 1, dtype=np.float32),
+            )
+        )
+    return out
+
+
+def mark_hypothesis_errors(dfa, pool):
+    """Flag every prefix where the extracted DFA disagrees with the label already held.
+
+    One simulation per string gives the DFA's verdict at all of its prefixes, so this costs
+    no oracle queries at all -- the labels were bought when the prefix was labelled.
+
+    The flag is contaminated: at 20% noise a DFA scoring 0.813 disagrees on ~31% of prefixes
+    where a perfect one would disagree on ~20%. But the spurious flags are spread uniformly
+    while the real errors are concentrated on exactly the prefixes the hypothesis cannot
+    represent, so upweighting them points the gradient at the distinctions a
+    distribution-matched loss undervalues.
+    """
+    for example in pool:
+        if not example.boost:
+            continue
+        state = dfa.initial_state
+        for t in range(len(example.string) + 1):
+            example.error[t] = float(
+                (state in dfa.final_states) != bool(example.labels[t])
+            )
+            if t < len(example.string):
+                state = dfa.transitions[state][int(example.string[t])]
+
+
+def refresh_weights(pool, error_boost=0.0):
+    """Set every labelled example's weight to ``boost / multiplicity`` across the pool.
+
+    Multiplicity has to be counted over the *whole* pool, not per batch: the noise is fixed
+    per string, so a prefix has one label however often it is drawn, and short prefixes are
+    shared by hundreds of strings. Counting them once each is what stops J_external from
+    learning a single coin flip as ground truth.
+    """
+    counter = Counter()
+    for e in pool:
+        if e.boost:
+            counter.update(tuple(e.string[:t]) for t in range(len(e.string) + 1))
+    for e in pool:
+        if not e.boost:
+            continue
+        for t in range(len(e.string) + 1):
+            scale = 1.0 + error_boost * float(e.error[t])
+            e.mask[t] = e.boost * scale / counter[tuple(e.string[:t])]
+
+
+def unlabelled_examples(strings) -> List[Example]:
+    """Mined strings kept unlabelled -- they drive ``J_internal`` only, and cost nothing."""
+    out = []
+    for s in strings:
+        blank = np.zeros(len(s) + 1, dtype=np.float32)
+        out.append(Example(np.asarray(s), blank, blank.copy(), 0.0, blank.copy()))
+    return out
+
+
+def _run_epoch(model, opt, pool, stats, cfg, *, schedule, rng, device):
+    order = rng.permutation(len(pool))
+    totals, batches = np.zeros(4), 0
+    for i in range(0, len(order), cfg.batch_size):
+        batch = [pool[j] for j in order[i : i + cfg.batch_size]]
+        x = torch.as_tensor(
+            np.stack([e.string for e in batch]), dtype=torch.long, device=device
+        )
+        y = torch.as_tensor(np.stack([e.labels for e in batch]), device=device)
+        mask = torch.as_tensor(np.stack([e.mask for e in batch]), device=device)
+
+        log_m = model.state_log_probs(x)
+        t_batch, n_batch = batch_transition_statistics(log_m, x, model.alphabet_size)
+        # Update before scoring so the first batch has a usable EMA to read delta from.
+        stats.update(t_batch, n_batch)
+
+        if cfg.use_information_objective:
+            j_internal = internal_information(t_batch)
+        else:
+            j_internal = internal_objective(
+                t_batch,
+                stats,
+                temperature=schedule["temperature"],
+                min_support=cfg.min_support,
+            )
+        j_external = external_objective(
+            model.continuation_accept_probs(
+                x, log_m, suffix_grad_scale=schedule["suffix_grad_scale"]
+            ),
+            y,
+            mask,
+            active_lags=schedule["active_lags"],
+        )
+        entropy = confidence_penalty(log_m)
+        balance = balance_penalty(log_m)
+        loss = (
+            -schedule["weight_internal"] * j_internal
+            - cfg.lambda_external * j_external
+            + schedule["gamma"] * entropy
+            + schedule["beta"] * balance
+        )
+
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        totals += [j_internal.item(), j_external.item(), entropy.item(), balance.item()]
+        batches += 1
+    return totals / max(batches, 1)
+
+
+def _simulate(delta, x, initial):
+    """State trajectory of the transition table over ``x``, starting at ``initial``."""
+    out = torch.empty(x.shape[0], x.shape[1] + 1, dtype=torch.long, device=x.device)
+    out[:, 0] = initial
+    for t in range(x.shape[1]):
+        out[:, t + 1] = delta[x[:, t], out[:, t]]
+    return out
+
+
+def choose_initial_state(model, delta, strings, device):
+    """Pick the initial state by self-consistency, not from ``argmax m(empty)``.
+
+    ``m(empty)`` is one decision backed by one oracle label that cannot be averaged, so
+    reading the initial state off it inverts the entire trajectory whenever that single
+    label was noise-flipped. Every other state is backed by many prefixes. Trying each
+    candidate and keeping the one whose simulation best reproduces ``m``'s own
+    trajectories decides it from the whole sample instead, and costs no oracle queries.
+    """
+    with torch.no_grad():
+        x = torch.as_tensor(strings, device=device)
+        predicted = model.state_log_probs(x).argmax(-1)
+        hits = [
+            int((predicted == _simulate(delta, x, s)).sum())
+            for s in range(model.num_states)
+        ]
+    return int(np.argmax(hits))
+
+
+def mine_divergences(
+    model, delta, initial, *, cfg, rng, device, alphabet_size, boundary
+):
+    """``(diverging strings, acceptance agreement, state agreement)``.
+
+    Compares ``m``'s own argmax trajectory against simulating the transition table read
+    off ``m``, on fresh uniform strings. Both sides are model objects, so this is free of
+    oracle queries — but for the same reason a divergence is evidence of *internal*
+    inconsistency only, which is what :func:`denoise_accept_labels` is there to cover.
+
+    Agreement is scored on *acceptance*, matching what
+    :func:`orthogonal_dfa.l_star.lstar.estimate_agreement_rate` measures. Raw state
+    indices are the wrong unit: a model holding two interchangeable copies of a state can
+    be a perfectly good automaton up to minification while its index sequence wanders.
+    Mining still uses the state-level divergence, which is the sharper training signal.
+
+    Simulation runs against the pre-minify table so both sides index the same states.
+    """
+    strings = rng.integers(
+        0, alphabet_size, size=(cfg.sift_strings, cfg.length), dtype=np.int64
+    )
+    diverged = []
+    accept_hits, state_hits, positions = 0, 0, 0
+    with torch.no_grad():
+        accepting = model.accept_probs() > boundary
+        for i in range(0, len(strings), 1024):
+            chunk = strings[i : i + 1024]
+            x = torch.as_tensor(chunk, device=device)
+            predicted = model.state_log_probs(x).argmax(-1)
+            simulated = _simulate(delta, x, initial)
+            same_state = predicted == simulated
+            accept_hits += int((accepting[predicted] == accepting[simulated]).sum())
+            state_hits += int(same_state.sum())
+            positions += same_state.numel()
+            diverged.extend(chunk[(~same_state).any(1).cpu().numpy()].tolist())
+    return diverged, accept_hits / positions, state_hits / positions
+
+
+def train_neural_dfa(oracle, cfg: NeuralConfig, *, log=print):
+    """Learn a DFA from a noisy membership oracle. Returns ``(dfa, info)``."""
+    torch.manual_seed(cfg.seed)
+    rng = np.random.default_rng(cfg.seed)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    model = NeuralDFA(
+        oracle.alphabet_size,
+        cfg.num_states,
+        cfg.hidden_size,
+        cfg.num_layers,
+        num_lags=cfg.num_lags,
+        suffix_dim=cfg.suffix_dim,
+    ).to(device)
+    opt = torch.optim.Adam(model.parameters(), lr=cfg.lr)
+    stats = TransitionStatistics(
+        oracle.alphabet_size, cfg.num_states, cfg.ema_decay, device
+    )
+    labels = LabelCache(oracle)
+
+    sampler = UniformSampler(cfg.length)
+    natural = labelled_examples(
+        [sampler.sample(rng, oracle.alphabet_size) for _ in range(cfg.num_strings)],
+        labels,
+    )
+    # Mined examples are extra and bounded: they skew hard toward the tail, and training
+    # on them alone round after round makes the state assignment non-stationary.
+    mined = deque(maxlen=cfg.mined_cap)
+    counterexamples: List[Example] = []
+    log(f"labelled {len(labels):,} distinct prefixes from {len(natural):,} strings")
+
+    dfa, boundary, agreement = None, 0.5, 0.0
+    for round_idx in range(cfg.rounds):
+        since_warmup = round_idx - cfg.internal_warmup_rounds
+        weight_internal = min(
+            1.0, max(0.0, (since_warmup + 1) / cfg.internal_ramp_rounds)
+        )
+        # Hold the max soft until J_internal is actually on, or the argmax freezes onto
+        # whatever partition the warmup happened to leave behind.
+        progress = min(
+            1.0,
+            max(
+                0.0, since_warmup / max(cfg.rounds - cfg.internal_warmup_rounds - 1, 1)
+            ),
+        )
+        temperature = (
+            cfg.temperature_start
+            * (cfg.temperature_end / cfg.temperature_start) ** progress
+        )
+        schedule = {
+            "weight_internal": weight_internal,
+            "temperature": temperature,
+            "beta": cfg.beta_balance * max(0.0, 1 - round_idx / cfg.balance_rounds),
+            # Full strength by the end of the warmup, then held: J_internal wants a hard
+            # assignment too, so there is no reason to relax it afterwards.
+            # One more continuation length per round: k=0 alone first, so the accept head
+            # cannot flatten before m has learned anything.
+            "active_lags": min(cfg.num_lags, round_idx),
+            # Held at 0 for the first round a continuation length is live, then ramped.
+            "suffix_grad_scale": min(1.0, max(0.0, (round_idx - 1) / 3)),
+            "gamma": cfg.gamma_confidence
+            * min(1.0, (round_idx + 1) / max(cfg.internal_warmup_rounds, 1)),
+        }
+
+        pool = natural + counterexamples + list(mined)
+        if dfa is not None and cfg.error_boost:
+            mark_hypothesis_errors(dfa, pool)
+        refresh_weights(pool, cfg.error_boost)
+        scores = np.zeros(4)
+        for _ in range(cfg.epochs_per_round):
+            scores = _run_epoch(
+                model,
+                opt,
+                pool,
+                stats,
+                cfg,
+                schedule=schedule,
+                rng=rng,
+                device=device,
+            )
+
+        delta = stats.conditional().argmax(-1)
+        probe = rng.integers(
+            0, oracle.alphabet_size, size=(1024, cfg.length), dtype=np.int64
+        )
+        initial = choose_initial_state(model, delta, probe, device)
+        dfa, boundary = extract_dfa(model, stats, initial=initial)
+        diverged, agreement, state_agreement = mine_divergences(
+            model,
+            delta,
+            initial,
+            cfg=cfg,
+            rng=rng,
+            device=device,
+            alphabet_size=oracle.alphabet_size,
+            boundary=boundary,
+        )
+        log(
+            f"round {round_idx}: J_int={scores[0]:.4f} J_ext={scores[1]:.4f} "
+            f"negMI={scores[2]:.4f} gram={scores[3]:.4f} "
+            f"w_int={weight_internal:.2f} lags={schedule['active_lags']} "
+            f"agree={agreement:.5f} state_agree={state_agreement:.5f} "
+            f"states={len(dfa.states)} mined={len(diverged)}"
+        )
+        # Agreement is only meaningful once J_internal is fully on; during warmup a
+        # degenerate m can agree with its own degenerate transition table.
+        if weight_internal >= 1.0 and agreement >= cfg.agreement_target:
+            break
+        # The labelled slice is the targeted experiment; the rest is free consistency data.
+        if cfg.label_mined_per_round:
+            counterexamples.extend(
+                labelled_examples(
+                    diverged[: cfg.label_mined_per_round], labels, cfg.mined_boost
+                )
+            )
+        mined.extend(
+            unlabelled_examples(diverged[cfg.label_mined_per_round :][: cfg.mined_cap])
+        )
+
+    before = len(dfa.states), len(dfa.final_states)
+    dfa = denoise_accept_labels(
+        dfa,
+        oracle,
+        rng,
+        cfg.length,
+        boundary=boundary,
+        max_samples=cfg.denoise_samples,
+    )
+    info = {
+        "distinct_queries": len(labels),
+        "total_queries": labels.total_queries,
+        "agreement": agreement,
+        "states": len(dfa.states),
+        "states_before_denoise": before[0],
+        "boundary": boundary,
+        "denoise_changed_labels": before != (len(dfa.states), len(dfa.final_states)),
+    }
+    return dfa, info

--- a/scripts/bench_surrogate.py
+++ b/scripts/bench_surrogate.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+"""Run the surrogate learner across a spread of target DFAs and report accuracy vs queries.
+
+    python scripts/bench_surrogate.py                 # hand-written + generated
+    python scripts/bench_surrogate.py --generated-only --seeds 8
+    python scripts/bench_surrogate.py --signal 0.2    # harder noise
+
+Accuracy is measured by the same harness the L* tests use: 10k uniform length-40 strings
+against a NOISELESS oracle.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from orthogonal_dfa.l_star.examples.benchmark_generator import (
+    DFAOracle,
+    sample_balanced_benchmark,
+)
+from orthogonal_dfa.l_star.examples.bernoulli_parity import (
+    BernoulliParityOracle,
+    BernoulliRegex,
+)
+from orthogonal_dfa.l_star.neural.surrogate import SurrogateConfig, learn_dfa
+from orthogonal_dfa.l_star.structures import Oracle, SymmetricBernoulli
+
+HAND_WRITTEN = {
+    "parity": (lambda nm, s: BernoulliParityOracle(nm, s), 2),
+    "modulo9": (
+        lambda nm, s: BernoulliParityOracle(nm, s, modulo=9, allowed_moduluses=(3, 6)),
+        9,
+    ),
+    "subseq": (lambda nm, s: BernoulliRegex(nm, s, regex=r".*1010101.*"), 8),
+    "two_subseq": (lambda nm, s: BernoulliRegex(nm, s, regex=r".*1111.*1111.*"), 9),
+    "alternating": (lambda nm, s: BernoulliRegex(nm, s, regex=r"(10)*1?"), 3),
+    "endswith": (lambda nm, s: BernoulliRegex(nm, s, regex=r".*110"), 4),
+}
+
+
+class CountingOracle(Oracle):
+    def __init__(self, inner):
+        self._inner = inner
+        self.count = 0
+        self.distinct = set()
+
+    @property
+    def alphabet_size(self):
+        return self._inner.alphabet_size
+
+    def membership_query(self, string):
+        self.count += 1
+        self.distinct.add(tuple(string))
+        return self._inner.membership_query(string)
+
+    def membership_queries(self, strings):
+        self.count += len(strings)
+        self.distinct.update(tuple(s) for s in strings)
+        return self._inner.membership_queries(strings)
+
+
+# (inner, outer) pairs the existing L* tests are known to be able to sample.
+GENERATED_SHAPES = ((12, 10), (20, 18))
+
+
+def generated(seed, num_inner_states, num_outer_states):
+    outer, _, _ = sample_balanced_benchmark(
+        seed,
+        alphabet_size=2,
+        num_inner_states=num_inner_states,
+        num_outer_states=num_outer_states,
+        probe_length=40,
+        min_accept_or_reject=0.15,
+        max_attempts=50000,
+    )
+    return (lambda nm, s: DFAOracle(nm, s, outer)), len(outer.states)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--signal", type=float, default=0.3)
+    parser.add_argument("--seeds", type=int, default=4)
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--states", type=int, default=32)
+    parser.add_argument("--prefixes", type=int, default=1200)
+    parser.add_argument("--generated-only", action="store_true")
+    parser.add_argument("--hand-only", action="store_true")
+    args = parser.parse_args()
+
+    from tests.test_lstar import evaluate_accuracy
+
+    noise = SymmetricBernoulli(p_correct=0.5 + args.signal)
+    tasks = []
+    if not args.generated_only:
+        tasks += [(name, creator, n) for name, (creator, n) in HAND_WRITTEN.items()]
+    if not args.hand_only:
+        for num_inner, num_outer in GENERATED_SHAPES:
+            for seed in range(args.seeds):
+                try:
+                    creator, n = generated(seed, num_inner, num_outer)
+                except RuntimeError as exc:  # infeasible shape/seed; skip, don't abort
+                    print(f"skip gen{num_outer}s{seed}: {exc}", flush=True)
+                    continue
+                tasks.append((f"gen{num_outer}s{seed}", creator, n))
+
+    results = []
+    for name, creator, true_states in tasks:
+        oracle = CountingOracle(creator(noise, 0))
+        cfg = SurrogateConfig(
+            num_states=args.states,
+            num_prefixes=args.prefixes,
+            rounds=args.rounds,
+        )
+        started = time.time()
+        try:
+            dfa, info = learn_dfa(oracle, cfg, log=lambda *_: None)
+            accuracy = evaluate_accuracy(dfa, creator, symbols=oracle.alphabet_size)
+        except Exception:  # keep the sweep going; report the failure
+            traceback.print_exc()
+            results.append({"task": name, "error": True})
+            continue
+        row = {
+            "task": name,
+            "true_states": true_states,
+            "learned_states": info["states"],
+            "accuracy": round(accuracy, 4),
+            "queries": len(oracle.distinct),
+            "seconds": round(time.time() - started, 1),
+        }
+        results.append(row)
+        print(json.dumps(row), flush=True)
+
+    ok = [r for r in results if not r.get("error")]
+    if ok:
+        good = [r for r in ok if r["accuracy"] >= 0.97]
+        print("\n===== SUMMARY =====")
+        print(f"tasks: {len(ok)}   >=0.97 accuracy: {len(good)}")
+        print(f"median accuracy: {sorted(r['accuracy'] for r in ok)[len(ok) // 2]}")
+        print(f"median queries:  {sorted(r['queries'] for r in ok)[len(ok) // 2]:,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/diagnose_surrogate.py
+++ b/scripts/diagnose_surrogate.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+"""Look at what the surrogate is actually doing on modulo9.
+
+    python scripts/diagnose_surrogate.py [output_dir]
+
+This found the memorisation bug that four rounds of reasoning missed: predicted rates were
+piling up at 0.0/1.0 instead of the noise rates, which only beats predicting the rate if the
+model is right about individual cells. Panels: true residue vs learned cluster, the response
+rows, transition concentration, and where the rates sit relative to the conformal band.
+
+modulo9 is the interpretable one: 9 states in a cycle, state = sum % 9, accepting {3, 6}.
+So the true partition is known exactly and every learned object can be compared against it.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import os
+import sys
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from orthogonal_dfa.l_star.examples.bernoulli_parity import BernoulliParityOracle
+from orthogonal_dfa.l_star.neural.extract import accept_threshold
+from orthogonal_dfa.l_star.neural.surrogate import (
+    CellPool,
+    SurrogateConfig,
+    TableSurrogate,
+    _encode_all,
+    _fit,
+    conformal_rate_bound,
+    pad,
+)
+from orthogonal_dfa.l_star.structures import SymmetricBernoulli
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+OUT = sys.argv[1] if len(sys.argv) > 1 else "figures"
+os.makedirs(OUT, exist_ok=True)
+cfg = SurrogateConfig(num_prefixes=1500, rounds=5, seed=0)
+oracle = BernoulliParityOracle(
+    SymmetricBernoulli(0.8), 0, modulo=9, allowed_moduluses=(3, 6)
+)
+rng = np.random.default_rng(cfg.seed)
+torch.manual_seed(cfg.seed)
+
+prefixes = [[]] + [
+    rng.integers(0, 2, size=rng.integers(0, 41)).tolist()
+    for _ in range(cfg.num_prefixes - 1)
+]
+suffixes = [[]] + [
+    rng.integers(0, 2, size=rng.integers(1, 11)).tolist()
+    for _ in range(cfg.num_suffixes - 1)
+]
+pool = CellPool(oracle, prefixes, suffixes)
+cells = [(i, j) for i in range(len(prefixes)) for j in range(len(suffixes))]
+pool.observe([cells[k] for k in rng.permutation(len(cells))[: int(0.3 * len(cells))]])
+observed = sorted(pool.answers)
+pool.holdout.update(
+    tuple(observed[k])
+    for k in rng.permutation(len(observed))[: int(0.15 * len(observed))]
+)
+
+model = TableSurrogate(2, cfg)
+opt = torch.optim.Adam(model.parameters(), lr=cfg.lr)
+_fit(model, opt, pool, cfg=cfg, rng=rng, device="cpu", steps=1250)
+
+residue = np.array([sum(p) % 9 for p in prefixes])
+with torch.no_grad():
+    v_pad, v_len = pad(suffixes, cfg.max_suffix_length)
+    response = model.response(v_pad, v_len).T.numpy()  # (S, V)
+current, successors = _encode_all(model, pool, cfg, "cpu", 2)
+clusters = current.argmax(-1).numpy()
+counts = np.bincount(clusters, minlength=cfg.num_states)
+empty_col = [j for j, v in enumerate(suffixes) if len(v) == 0][0]
+boundary = accept_threshold(response[:, empty_col], counts.astype(float))
+q_hat = conformal_rate_bound(response, clusters, pool, pool.holdout, cfg)
+print(
+    f"q_hat={q_hat:.4f} boundary={boundary:.4f} clusters used={np.count_nonzero(counts)}"
+)
+
+fig, axes = plt.subplots(2, 2, figsize=(15, 12))
+
+# 1. true residue x learned cluster
+used = np.flatnonzero(counts)
+confusion = np.zeros((9, len(used)), dtype=int)
+for r, c in zip(residue, clusters):
+    confusion[r, np.searchsorted(used, c)] += 1
+# plot_clustering_results assumes a square matrix; this one is 9 x (clusters used).
+plt.sca(axes[0, 0])
+plt.imshow(confusion / confusion.sum(1, keepdims=True), aspect="auto", cmap="viridis")
+plt.colorbar(label="fraction of the residue's prefixes")
+plt.xlabel("learned cluster (by index among used)")
+plt.ylabel("true residue (sum % 9)")
+plt.title("true residue vs learned cluster")
+
+# 2. response matrix: does each cluster have a distinct row?
+plt.sca(axes[0, 1])
+order = used[np.argsort(-counts[used])]
+plt.imshow(response[order], aspect="auto", vmin=0, vmax=1, cmap="RdBu_r")
+plt.colorbar(label="predicted accept rate")
+plt.xlabel("suffix")
+plt.ylabel("cluster (by size)")
+plt.title("response rows R[s][v] -- distinct rows = distinct states")
+
+# 3. how concentrated is each (cluster, symbol) successor distribution?
+transition = torch.einsum("ps,cpt->cst", current, successors).numpy()
+shares = []
+for s in used:
+    for c in (0, 1):
+        row = transition[c, s]
+        if row.sum() > 0:
+            shares.append(np.sort(row / row.sum())[::-1][0])
+plt.sca(axes[1, 0])
+plt.hist(shares, bins=20, range=(0, 1), edgecolor="black")
+plt.axvline(0.8, color="red", ls="--", label="concentrated (argmax safe)")
+plt.xlabel("top-1 share of successor distribution")
+plt.ylabel("(cluster, symbol) pairs")
+plt.title(f"transition concentration -- median {np.median(shares):.2f}")
+plt.legend()
+
+# 4. where do the predicted rates sit relative to the conformal band?
+plt.sca(axes[1, 1])
+flat = response[used].ravel()
+plt.hist(flat, bins=50, range=(0, 1), edgecolor="black")
+for edge, label in (
+    (boundary - q_hat, "boundary - q̂"),
+    (boundary + q_hat, "boundary + q̂"),
+):
+    plt.axvline(edge, color="red", ls="--", label=label)
+plt.axvline(boundary, color="black", label="boundary")
+undecided = np.mean(np.abs(flat - boundary) < q_hat)
+plt.xlabel("predicted accept rate")
+plt.title(f"conformal band: {undecided:.1%} of cells undecided (q̂={q_hat:.3f})")
+plt.legend()
+
+plt.tight_layout()
+plt.savefig(f"{OUT}/modulo9_diagnosis.png", dpi=110)
+print(f"saved {OUT}/modulo9_diagnosis.png")
+
+# Text summary of what the confusion says.
+print("\nresidue -> cluster concentration:")
+for r in range(9):
+    row = confusion[r]
+    if row.sum():
+        print(
+            f"  residue {r}: {row.max() / row.sum():.2f} in its modal cluster, spread over {np.count_nonzero(row)} clusters"
+        )

--- a/scripts/train_neural_dfa.py
+++ b/scripts/train_neural_dfa.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+"""Run the amortised-state-predictor learner on the L* benchmarks.
+
+    python scripts/train_neural_dfa.py parity
+    python scripts/train_neural_dfa.py subseq modulo --signal 0.3 --states 48
+
+Reports noiseless accuracy against the same harness the L* tests use, plus the distinct
+oracle query count so the result is comparable to `scripts/count_queries.py`.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+# Running this as a script only puts scripts/ on the path; the eval harness lives in
+# tests/. Same approach as scripts/count_queries.py.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from orthogonal_dfa.l_star.examples.benchmark_generator import (
+    DFAOracle,
+    sample_balanced_benchmark,
+)
+from orthogonal_dfa.l_star.examples.bernoulli_parity import (
+    BernoulliParityOracle,
+    BernoulliRegex,
+)
+from orthogonal_dfa.l_star.neural.train import NeuralConfig, train_neural_dfa
+from orthogonal_dfa.l_star.structures import (
+    AsymmetricBernoulli,
+    Oracle,
+    SymmetricBernoulli,
+)
+
+BENCHMARKS = {
+    "parity": lambda nm, s: BernoulliParityOracle(nm, s),
+    "modulo": lambda nm, s: BernoulliParityOracle(
+        nm, s, modulo=9, allowed_moduluses=(3, 6)
+    ),
+    "subseq": lambda nm, s: BernoulliRegex(nm, s, regex=r".*1010101.*"),
+    "two_subseq": lambda nm, s: BernoulliRegex(nm, s, regex=r".*1111.*1111.*"),
+}
+
+
+class CountingOracle(Oracle):
+    def __init__(self, inner):
+        self._inner = inner
+        self.count = 0
+        self.distinct = set()
+
+    @property
+    def alphabet_size(self):
+        return self._inner.alphabet_size
+
+    def membership_query(self, string):
+        self.count += 1
+        self.distinct.add(tuple(string))
+        return self._inner.membership_query(string)
+
+    def membership_queries(self, strings):
+        self.count += len(strings)
+        self.distinct.update(tuple(s) for s in strings)
+        return self._inner.membership_queries(strings)
+
+
+def generated_benchmark(seed, num_outer_states):
+    outer, _, _ = sample_balanced_benchmark(
+        seed,
+        alphabet_size=2,
+        num_inner_states=4,
+        num_outer_states=num_outer_states,
+        probe_length=40,
+        min_accept_or_reject=0.2,
+    )
+    return lambda nm, s: DFAOracle(nm, s, outer)
+
+
+def main():
+    # Imported here so the sys.path fix above is in effect and isort stays happy.
+    from tests.test_lstar import evaluate_accuracy
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("tasks", nargs="*", default=["parity"])
+    parser.add_argument("--signal", type=float, default=0.3)
+    parser.add_argument("--asymmetric", nargs=2, type=float, metavar=("P0", "P1"))
+    parser.add_argument("--states", type=int, default=32)
+    parser.add_argument("--strings", type=int, default=3000)
+    parser.add_argument("--rounds", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--lags", type=int, default=NeuralConfig.num_lags)
+    parser.add_argument(
+        "--lambda-ext", type=float, default=NeuralConfig.lambda_external
+    )
+    parser.add_argument(
+        "--warmup", type=int, default=NeuralConfig.internal_warmup_rounds
+    )
+    parser.add_argument("--beta", type=float, default=NeuralConfig.beta_balance)
+    parser.add_argument("--error-boost", type=float, default=NeuralConfig.error_boost)
+    parser.add_argument("--generated", type=int, metavar="N_STATES")
+    args = parser.parse_args()
+
+    noise = (
+        AsymmetricBernoulli(*args.asymmetric)
+        if args.asymmetric
+        else SymmetricBernoulli(p_correct=0.5 + args.signal)
+    )
+
+    tasks = args.tasks
+    if args.generated is not None:
+        tasks = [f"generated{args.generated}"]
+
+    for name in tasks:
+        if name.startswith("generated"):
+            creator = generated_benchmark(args.seed, int(name[len("generated") :]))
+        else:
+            creator = BENCHMARKS[name]
+        oracle = CountingOracle(creator(noise, args.seed))
+        cfg = NeuralConfig(
+            num_states=args.states,
+            num_strings=args.strings,
+            rounds=args.rounds,
+            seed=args.seed,
+            num_lags=args.lags,
+            lambda_external=args.lambda_ext,
+            internal_warmup_rounds=args.warmup,
+            beta_balance=args.beta,
+            error_boost=args.error_boost,
+        )
+        started = time.time()
+        dfa, info = train_neural_dfa(oracle, cfg)
+        info.update(
+            task=name,
+            accuracy=evaluate_accuracy(dfa, creator, symbols=oracle.alphabet_size),
+            oracle_queries=oracle.count,
+            oracle_distinct=len(oracle.distinct),
+            seconds=round(time.time() - started, 1),
+        )
+        print(json.dumps(info, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_neural_dfa.py
+++ b/tests/test_neural_dfa.py
@@ -1,0 +1,217 @@
+import unittest
+
+import numpy as np
+import torch
+
+from orthogonal_dfa.l_star.examples.bernoulli_parity import BernoulliParityOracle
+from orthogonal_dfa.l_star.neural.extract import accept_threshold
+from orthogonal_dfa.l_star.neural.model import NeuralDFA
+from orthogonal_dfa.l_star.neural.objective import (
+    TransitionStatistics,
+    batch_transition_statistics,
+    external_objective,
+    internal_information,
+    internal_objective,
+)
+from orthogonal_dfa.l_star.neural.train import NeuralConfig, train_neural_dfa
+from orthogonal_dfa.l_star.structures import SymmetricBernoulli
+from tests.test_lstar import assertion_allowed_error, evaluate_accuracy
+
+
+def one_hot(idx, num_classes):
+    return (idx.unsqueeze(-1) == torch.arange(num_classes)).float()
+
+
+def prefix_parity(x):
+    """``(B, L + 1)`` parity of each prefix of ``x`` -- a genuine 2-state congruence."""
+    out = torch.zeros(x.shape[0], x.shape[1] + 1, dtype=torch.long)
+    out[:, 1:] = torch.cumsum(x, dim=1) % 2
+    return out
+
+
+class TestInternalObjective(unittest.TestCase):
+    """J_internal must be 1 exactly for a hard deterministic assignment and strictly
+    less for anything that hedges, since that is what makes it a tight relaxation."""
+
+    def _score(self, log_m, x, alphabet_size):
+        stats = TransitionStatistics(alphabet_size, log_m.shape[-1])
+        t_batch, n_batch = batch_transition_statistics(log_m, x, alphabet_size)
+        stats.update(t_batch, n_batch)
+        return float(
+            internal_objective(t_batch, stats, temperature=0.0, min_support=0.0)
+        )
+
+    def test_deterministic_assignment_scores_one(self):
+        x = torch.tensor([[0, 1, 1, 0, 1], [1, 1, 0, 1, 0]])
+        log_m = one_hot(prefix_parity(x), 2).clamp_min(1e-9).log()
+        self.assertAlmostEqual(self._score(log_m, x, 2), 1.0, places=5)
+
+    def test_hedging_between_duplicate_states_is_penalised(self):
+        # Same partition, but mass split 50/50 over two copies of each state.
+        x = torch.tensor([[0, 1, 1, 0, 1], [1, 1, 0, 1, 0]])
+        parity = prefix_parity(x)
+        m = torch.zeros(*parity.shape, 4)
+        m.scatter_(2, (2 * parity).unsqueeze(-1), 0.5)
+        m.scatter_(2, (2 * parity + 1).unsqueeze(-1), 0.5)
+        self.assertAlmostEqual(
+            self._score(m.clamp_min(1e-9).log(), x, 2), 0.5, places=5
+        )
+
+    def test_total_collapse_also_scores_one(self):
+        # The reason J_external is required: collapse is a global maximum of J_internal.
+        x = torch.tensor([[0, 1, 1, 0, 1]])
+        log_m = torch.log(torch.tensor([[[1.0, 1e-9]] * 6]))
+        self.assertAlmostEqual(self._score(log_m, x, 2), 1.0, places=5)
+
+
+class TestInternalInformation(unittest.TestCase):
+    """The point of the information form: collapse scores 0 rather than 1, so merging is
+    not a descent direction, and a k-state deterministic partition scores log k, so each
+    extra distinction is rewarded on its own."""
+
+    def _score(self, log_m, x, alphabet_size):
+        t_batch, _ = batch_transition_statistics(log_m, x, alphabet_size)
+        return float(internal_information(t_batch))
+
+    def test_collapse_scores_zero(self):
+        x = torch.tensor([[0, 1, 1, 0, 1]])
+        log_m = torch.log(torch.tensor([[[1.0, 1e-9]] * 6]))
+        self.assertAlmostEqual(self._score(log_m, x, 2), 0.0, places=4)
+
+    def test_balanced_two_state_congruence_scores_log_two(self):
+        x = torch.tensor([[0, 1, 1, 0, 1], [1, 1, 0, 1, 0], [1, 0, 1, 0, 1]])
+        log_m = one_hot(prefix_parity(x), 2).clamp_min(1e-9).log()
+        self.assertAlmostEqual(
+            self._score(log_m, x, 2), float(torch.tensor(2.0).log()), places=2
+        )
+
+    def test_refinement_scores_higher_than_collapse(self):
+        # The gradient signal the max form lacks: a finer deterministic partition wins.
+        x = torch.tensor([[0, 1, 1, 0, 1], [1, 1, 0, 1, 0], [1, 0, 1, 0, 1]])
+        coarse = one_hot(prefix_parity(x), 4).clamp_min(1e-9).log()
+        positions = torch.arange(x.shape[1] + 1).expand(x.shape[0], -1)
+        # parity refined by length mod 2 -> still deterministic, but 4 states.
+        fine = one_hot(2 * prefix_parity(x) + positions % 2, 4).clamp_min(1e-9).log()
+        self.assertGreater(self._score(fine, x, 2), self._score(coarse, x, 2))
+
+
+class TestExternalObjective(unittest.TestCase):
+    def test_matches_plain_weighted_bce(self):
+        torch.manual_seed(0)
+        probs = torch.rand(3, 6, 1) * 0.8 + 0.1
+        labels = (torch.rand(3, 6) > 0.5).float()
+        mask = torch.rand(3, 6)
+        p = probs[:, :, 0]
+        expected = (
+            (labels * p.log() + (1 - labels) * (1 - p).log()) * mask
+        ).sum() / mask.sum()
+        self.assertAlmostEqual(
+            float(external_objective(probs, labels, mask)), float(expected), places=5
+        )
+
+    def test_lag_k_reads_position_t_plus_k(self):
+        # Constant probs, so only target alignment can matter. Lag 1 must see label[t + 1],
+        # and positions running past the end must carry no weight: 4 lag-0 targets plus 3
+        # in-range lag-1 targets = 7 terms, each log(0.5).
+        probs = torch.full((1, 4, 2), 0.5)
+        labels = torch.tensor([[1.0, 1.0, 0.0, 0.0]])
+        mask = torch.ones(1, 4)
+        self.assertAlmostEqual(
+            float(external_objective(probs, labels, mask)),
+            float(torch.tensor(0.5).log()),
+            places=5,
+        )
+        weights_used = torch.cat([mask, torch.zeros(1, 1)], 1).unfold(1, 2, 1).sum()
+        self.assertEqual(int(weights_used), 7)
+
+    def test_splitting_a_state_can_change_the_objective(self):
+        """The whole point: a per-state scalar accept rate is invariant under refinement,
+        so it gives no gradient toward it. Conditioning on the continuation must not be.
+        """
+        torch.manual_seed(0)
+        model = NeuralDFA(2, 4, hidden_size=16, num_lags=3, suffix_dim=8)
+        x = torch.tensor([[0, 1, 1, 0, 1], [1, 0, 1, 0, 0]])
+        merged = one_hot(torch.zeros(2, 6, dtype=torch.long), 4).clamp_min(1e-9).log()
+        positions = torch.arange(6).expand(2, -1)
+        split = one_hot((positions % 2), 4).clamp_min(1e-9).log()
+        labels = torch.tensor([[1.0, 0, 1, 0, 1, 0], [0.0, 1, 0, 1, 0, 1]])
+        mask = torch.ones(2, 6)
+        a = external_objective(model.continuation_accept_probs(x, merged), labels, mask)
+        b = external_objective(model.continuation_accept_probs(x, split), labels, mask)
+        self.assertNotAlmostEqual(float(a), float(b), places=4)
+
+
+class TestAcceptThreshold(unittest.TestCase):
+    def test_finds_asymmetric_boundary(self):
+        # Accept rates cluster at the noise rates, not at 0/1, and need not straddle 0.5.
+        probs = np.array([0.10, 0.11, 0.40, 0.39, 0.41])
+        weights = np.ones(5)
+        self.assertAlmostEqual(accept_threshold(probs, weights), 0.2525, places=3)
+
+    def test_single_cluster_falls_back(self):
+        probs = np.array([0.4, 0.4, 0.4])
+        self.assertEqual(accept_threshold(probs, np.ones(3)), 0.5)
+
+    def test_zero_weight_states_ignored(self):
+        # Unused states carry junk accept probabilities; they must not move the split.
+        probs = np.array([0.10, 0.40, 0.99])
+        self.assertAlmostEqual(
+            accept_threshold(probs, np.array([1.0, 1.0, 0.0])), 0.25, places=3
+        )
+
+
+class TestModel(unittest.TestCase):
+    def test_empty_prefix_matches_position_zero(self):
+        torch.manual_seed(0)
+        model = NeuralDFA(2, 6, hidden_size=16)
+        x = torch.tensor([[0, 1, 1], [1, 0, 1]])
+        self.assertTrue(
+            torch.allclose(
+                model.state_log_probs(x)[:, 0],
+                model.empty_prefix_log_probs().expand(2, -1),
+                atol=1e-6,
+            )
+        )
+
+    def test_accept_rates_not_initialised_tied(self):
+        # Tied accept rates make p constant in m and zero out m's gradient entirely.
+        torch.manual_seed(0)
+        model = NeuralDFA(2, 8, hidden_size=16)
+        self.assertGreater(float(model.accept_probs().std()), 0.02)
+
+    def test_continuation_encoding_distinguishes_suffixes(self):
+        # phi must separate specific continuations, or conditioning on them buys nothing.
+        torch.manual_seed(0)
+        model = NeuralDFA(2, 4, hidden_size=16, num_lags=3, suffix_dim=8)
+        x = torch.tensor([[1, 0, 1, 0], [1, 1, 1, 0]])
+        enc = model.continuation_encodings(x)
+        # K columns, one per continuation length 1..K; the empty one is not in here.
+        self.assertEqual(enc.shape, (2, 5, 3, 8))
+        # Length-2 continuations "10" vs "11" from position 0 must encode differently.
+        self.assertGreater(float((enc[0, 0, 1] - enc[1, 0, 1]).abs().max()), 1e-3)
+
+
+class TestNeuralLStar(unittest.TestCase):
+    def test_parity(self):
+        oracle_creator = BernoulliParityOracle
+        oracle = oracle_creator(SymmetricBernoulli(p_correct=0.8), 0)
+        dfa, info = train_neural_dfa(
+            oracle,
+            NeuralConfig(
+                num_states=8,
+                num_strings=3000,
+                rounds=8,
+                lambda_external=1.0,
+                sift_strings=2048,
+            ),
+            log=lambda *_: None,
+        )
+        accuracy = evaluate_accuracy(dfa, oracle_creator)
+        self.assertGreaterEqual(accuracy, 1 - assertion_allowed_error)
+        # Mining is unsupervised, so the only queries are labelled prefixes plus the
+        # accept-label denoising pass.
+        self.assertLess(info["distinct_queries"], 100_000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two approaches to replacing the DT + suffix-family machinery with a learned model. **Neither beats L\* yet.** This PR commits the working code plus the measurements that explain why, so the negative results are not re-derived later.

## Approach 1: amortised state predictor (`model.py`, `objective.py`, `train.py`)

`m(x)` predicts a distribution over latent states for *every* prefix in one pass, trained on `J_internal` (determinism) + `J_external` (labels). Unlike the unrolled relaxations in `utils/pdfa.py` and `deep_dfa`, nothing backpropagates through 40 soft transition matrices.

Recovers **parity exactly** — 1.0 accuracy, 2 states, 25k distinct queries against L\*'s 869k–1.23M scale. Fails on every language whose Nerode partition is finer than its acceptance partition.

**Why, measured:** `J_external` sees `m` only through a per-state accept scalar, so it is *exactly invariant* under any refinement of the acceptance partition and contributes **zero** gradient toward refining it. That leaves `J_internal` to choose among all refinements — where the Nerode partition beats the bare acceptance partition by 0.015 (0.9853 vs 1.0, the residual nondeterminism carries little mass) while language-independent congruences like length-mod-k win by ~`log 2`. The larger signal wins every time.

Not a shortage of oracle information: the same encoder **without** the state bottleneck reaches 1.0 prefix accuracy on the same 88k labels.

## Approach 2: table surrogate (`surrogate.py`)

Models the observation table directly, which is where the queries actually go — profiling `.*1010101.*` (1,277,963 queries): **75% is filling cells of `M[i][j] = oracle(p_i + v_j)`**, and 50.2% is a single pattern, one new suffix evaluated across 14,584 prefixes. The other 25% is DT classification, which is the same cells for rows not yet in the table.

```
M[p][v] = sum_s m(p)[s] * sigma(<u_s, phi(v)>)
```

The row softmax is an "at most n distinct rows" constraint — the noiseless table depends on a prefix only through its Nerode state. That constraint is what denoises: per-string noise is not expressible through an S-cluster bottleneck, so each cell pools evidence from every prefix sharing its prototype row. Rows and columns are **encoders over strings** rather than free per-row embeddings, which is the difference from ordinary matrix completion — the model generalises to prefixes and suffixes never queried.

### What holds up

Measured on held-out data rather than single end-to-end runs:

| claim | measurement |
|---|---|
| it denoises | held-out cells **0.973** vs **0.8** for reading each cell's own noisy label, at 50% density |
| recovers state structure | MI **1.95 / 2.45** bits, purity **0.866** on subseq's 8 states |
| over-provision `num_states` | `S=32` purity 0.861 vs `S=8` 0.663 — matching the true count is *worse* |
| conformal calibration | `q_hat ≈ 0.1` after subtracting the calibration set's own binomial error, which alone put it at 0.30 |

### What does not

End-to-end accuracy, across 3 seeds each:

| task | accuracy | true states |
|---|---|---|
| parity | 1.0, 1.0, 1.0 | 2 |
| modulo9 | 0.888, 0.832, 0.888 | 9 |
| subseq | 0.920, 0.813, 0.813 | 8 |
| two_subseq | 0.631, 0.649, 0.676 | 9 |

L\* gets 1.0 on all of these. Run-to-run variance is large enough that single-seed results are not meaningful — an earlier "modulo9 solved at 1.0" did not replicate.

## Failed variants, kept as defaulted-off knobs

Each records the measurement that rejected it rather than being deleted:

- **counterexample rows** (`new_prefixes_per_round=0`) — compared the DFA against the surrogate it was *extracted from*, so divergence measured extraction error, not language error. 4/14 → 3/14 targets at ≥0.97.
- **per-prefix error boosting** (`error_boost=0.0`) — the flag is only ~48% precise (DFA errs 18.7%, noise flips 20%), and per-string noise cannot be averaged, so boosting re-amplifies single fixed labels. Broke parity at every level tested.
- **`merge_by_row`** — mean distance over 40 suffixes dilutes a single distinguishing column; over-merges, subseq collapsed to 1 state.
- **`refine_partition`** — Moore refinement splitting on any successor disagreement; the assignment is a noisy nearest-centroid classification, so blocks shatter. Parity → 14–21 states at 0.49.
- **MI-form `J_internal`** (`use_information_objective=False`) — refuses collapse as designed, then selects language-independent congruences (exactly `log 2`, `~log 3`).

The common thread: both extraction attempts used a threshold I picked by hand and failed in opposite directions. What they lacked is `transition_resolver._splits` — a decision calibrated to the noise. `merge_by_conformal` is the first version with a *measured* error rate, and it produces the correct state count on the cases it gets closest to.

## Testing

`tests/test_neural_dfa.py` — 16 tests. Pins the objective maths (`J_internal` exactly 1.0 for a deterministic assignment, 0.5 for duplicate-hedging, 1.0 for collapse), the accept-threshold 2-means under asymmetric noise, the lag/target alignment, and an end-to-end parity run. pylint 10.00/10.

Scripts: `train_neural_dfa.py` (approach 1), `bench_surrogate.py` (approach 2 across hand-written + generated DFAs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
