### PR TITLE
Lower the class-preserving precondition from 0.05 to 0.02

### DIFF
--- a/orthogonal_dfa/l_star/learn.py
+++ b/orthogonal_dfa/l_star/learn.py
@@ -38,7 +38,7 @@ def build_pst(
     min_signal_strength: float,
     seed: int,
     noise_model: Optional[Any] = None,
-    min_suffix_frequency: float = 0.05,
+    min_suffix_frequency: float = 0.02,
     sample_length: int = DEFAULT_SAMPLE_LENGTH,
 ) -> PrefixSuffixTracker:
     """A PrefixSuffixTracker sized for an oracle carrying `min_signal_strength`.
@@ -81,7 +81,7 @@ def learn_dfa(
     min_signal_strength: float,
     seed: int,
     noise_model: Optional[Any] = None,
-    min_suffix_frequency: float = 0.05,
+    min_suffix_frequency: float = 0.02,
     sample_length: int = DEFAULT_SAMPLE_LENGTH,
     acc_threshold: float = DEFAULT_ACC_THRESHOLD,
 ):

--- a/orthogonal_dfa/l_star/preconditions.py
+++ b/orthogonal_dfa/l_star/preconditions.py
@@ -148,7 +148,7 @@ def satisfies_preconditions(
     dfa: DFA,
     *,
     length: int,
-    min_class_preserving_frac: float = 0.05,
+    min_class_preserving_frac: float = 0.02,
     min_covered_accuracy: float = 0.99,
     num_samples: int = DEFAULT_NUM_SAMPLES,
     short_circuit: bool = True,

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -53,7 +53,7 @@ class SearchConfig:
     num_addtl_prefixes: Optional[int] = None
     fnr_limit: float = 0.02
     split_pval: float = 0.001
-    min_suffix_frequency: float = 0.05
+    min_suffix_frequency: float = 0.02
     min_acc_rej: float = 0.1
 
 

--- a/tests/test_preconditions.py
+++ b/tests/test_preconditions.py
@@ -66,6 +66,41 @@ MOD9_SKEWED = DFA(
 )
 
 
+# cp = 0.028: admitted at the 0.02 bar, rejected at the old 0.05 one.
+MARGINAL_CLASS_PRESERVING = DFA(
+    states=set(range(7)),
+    input_symbols={0, 1},
+    transitions={
+        0: {0: 5, 1: 0},
+        1: {0: 6, 1: 6},
+        2: {0: 3, 1: 6},
+        3: {0: 2, 1: 1},
+        4: {0: 4, 1: 5},
+        5: {0: 1, 1: 5},
+        6: {0: 0, 1: 1},
+    },
+    initial_state=0,
+    final_states={4, 6},
+    allow_partial=False,
+)
+
+# cp = 0.011: below the bar, and E-L* does not learn it within a 420s budget.
+TOO_FEW_CLASS_PRESERVING = DFA(
+    states=set(range(5)),
+    input_symbols={0, 1},
+    transitions={
+        0: {0: 3, 1: 1},
+        1: {0: 1, 1: 2},
+        2: {0: 3, 1: 2},
+        3: {0: 0, 1: 3},
+        4: {0: 4, 1: 2},
+    },
+    initial_state=0,
+    final_states={1, 4},
+    allow_partial=False,
+)
+
+
 def _constant_dfa(final_states):
     return DFA(
         states={0},
@@ -131,6 +166,17 @@ class TestSatisfiesPreconditions(unittest.TestCase):
         # balance: E-L* learns this one to accuracy 1.0.
         self.assertLess(P.acceptance_rate(MOD9_SKEWED, length=40), 0.15)
         self.assertTrue(P.satisfies_preconditions(MOD9_SKEWED, length=40))
+
+    def test_marginal_class_preserving_target_passes(self):
+        # Between the old 0.05 bar and the current 0.02 one: E-L* learns these.
+        cp = P.class_preserving_fraction(MARGINAL_CLASS_PRESERVING, length=40)
+        self.assertTrue(0.02 <= cp < 0.05)
+        self.assertTrue(P.satisfies_preconditions(MARGINAL_CLASS_PRESERVING, length=40))
+
+    def test_too_few_class_preserving_suffixes_fails(self):
+        report = P.satisfies_preconditions(TOO_FEW_CLASS_PRESERVING, length=40)
+        self.assertFalse(report)
+        self.assertIn("class-preserving", report.reasons[0])
 
     def test_ceiling_catches_transient_states(self):
         # Difficult09 is non-degenerate and class-preserving, so only the

--- a/tests/test_random_dfa_validation.py
+++ b/tests/test_random_dfa_validation.py
@@ -19,7 +19,9 @@ NUM_DFAS = 600
 ETA = 0.05
 LENGTH = 40
 LEARNED = 0.95  # E-L* accuracy bar for "learned it"
-PER_DFA_TIMEOUT = 60  # a passer that hangs this long is itself a failure
+#: Only admitted DFAs are run, and the slowest measured is ~113s, so this is
+#: a backstop against a hang rather than a learnability standard.
+PER_DFA_TIMEOUT = 600
 
 
 def _elstar_accuracy(aut) -> float:


### PR DESCRIPTION
`satisfies_preconditions` required a class-preserving fraction of at least 0.05. Nothing measured supports that value: everything tried between 0.02 and 0.05 learns to **accuracy 1.0**.

| target | cp | result |
| --- | ---: | --- |
| `Simple05` (CAPAL) | 0.0200 | 5/5 states, acc 1.0 |
| random idx=567 | 0.0270 | acc 1.0 (113s) |
| `Difficult02` (CAPAL) | 0.0290 | 5/5 states, acc 1.0 |
| random idx=66 | 0.0405 | acc 1.0 (91s) |
| `regex_alt_111_or_000_3sym` | 0.0410 | 6/6 states, acc 1.0 |

These are slower than targets above 0.05 — 74–400s against 6–20s — but they are learnable, and this function is documented as a learnability check.

## Provenance

Both 0.05s trace to #105, *"reject benchmarks that don't have class preserving suffixes"*, where the value was a bare default on a benchmark **generator** filter. #135 lifted the generator's filters into `preconditions.py`, promoting a sampling filter into an admission gate. Same path the acceptance-rate band took in #143.

`sample_balanced_benchmark` keeps its own 0.05 — being picky there costs a resample, not a rejected target.

## The learner knob moves with it

`min_class_preserving_frac` (precondition) and `min_suffix_frequency` (learner) measure the *same quantity*: the fraction of length-L suffixes that preserve every state's accept/reject class. `min_suffix_frequency` feeds `give_up_check`, which sets `k = binom.ppf(p, T, r)` — a lower bound on how many sampled suffixes are class-preserving.

Admitting a cp=0.02 target while the give-up check still assumes 0.05 admits targets the learner then refuses. `Simple05` is exactly that: at r=0.05 it raises `GaveUpOnSuffixSearch` (`Top-4 mean agreement 0.924 <= 0.926`); at r=0.02 it recovers all 5 states at accuracy 1.0.

Lowering r is safe because it only ever decides *when to abort* — it never feeds back into clustering, the decision boundary, or sampling. Benchmark query counts are bit-identical at 0.05 and 0.02:

| target | states | acc | MQ @ r=0.05 | MQ @ r=0.02 |
| --- | --- | --- | ---: | ---: |
| `parity_mod9_allowed_3_6` | 9 | 1.0 | 320,886 | 320,886 |
| `regex_subseq_1010101` | 8 | 1.0 | 299,040 | 299,040 |
| `regex_two_1111` | 9 | 1.0 | 508,281 | 508,281 |
| `regex_alt_1111_or_0000_11` | 10 | 0.990 | 328,929 | 328,929 |
| `regex_alt_111_or_000_3sym` | 6 | 1.0 | 1,107,150 | 1,107,150 |
| `Simple05` | — | — | GaveUp @ 517,592 | **5 states, acc 1.0** @ 7,894,390 |

## The validation test's cap

`test_random_dfa_validation` capped each DFA at 60s and scores a timeout as accuracy 0.0. The two DFAs the new bar admits reach accuracy 1.0 in **113s** and **91s**, so under the old cap both registered as false positives — an artifact of the cap, not a learnability failure. Raised to 600s.

Its comment claimed *"a passer that hangs this long is itself a failure"*, i.e. that 60 encoded a deliberate standard. It didn't; the comment now says what the number is actually for.

Only admitted DFAs are run (35 of 600 today, 37 now), so the cost is ~35 runs at 6–20s plus those two.

## What is *not* being claimed

0.02 is the conservative end of a plausible range, not a measured cliff.

- Below the bar, failure is structural. At cp≈0 the DFA mixes: by length 40 the start state is erased (mean TV distance between endpoint distributions 0.0079), every state has the same P(accept) to three decimals, and no suffix family ever completes — FNR pins at 1.0, synthesis never runs, and no guard fires, so it grinds unbounded.
- Between 0.011 and 0.020 the picture is a **cost gradient, not a cliff**: query counts rise from 1.9M at cp=0.018 to 12.1M at cp=0.0115. Successes and failures interleaved there under a 420s cap, but the one success landed at 403s — so those "failures" were very likely cap artifacts too, and the real floor may be below 0.02.

Two new precondition tests use real DFAs from that sweep: cp=0.028 admitted (rejected under the old bar), cp=0.011 still rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)