### PR TITLE
Replace the give-up statistic with a row-sum dispersion test

### DIFF
--- a/orthogonal_dfa/l_star/cluster.py
+++ b/orthogonal_dfa/l_star/cluster.py
@@ -2,7 +2,11 @@ from typing import List, Tuple
 
 import numpy as np
 
-from .statistics import evidence_margin_for_population_size, give_up_check
+from .statistics import (
+    evidence_margin_for_population_size,
+    give_up_check,
+    row_sum_dispersion,
+)
 
 
 def identify_cluster_around(
@@ -79,9 +83,8 @@ def sample_suffix_family(pst, v: int, first_round: bool) -> Tuple[List[int], flo
 
     while True:
         seed_mask = pst.table.column(v)
-        empirical_pos = float(seed_mask.mean())
         if first_round:
-            _give_up_check(pst, config, seed_mask, empirical_pos)
+            _give_up_check(pst, config, seed_mask)
         vs, decision_boundary = identify_cluster_around(
             pst, v, pst.config.suffix_family_size, decision_boundary
         )
@@ -116,14 +119,13 @@ def sample_suffix_family(pst, v: int, first_round: bool) -> Tuple[List[int], flo
             pst.sample_more_prefixes()
 
 
-def _give_up_check(pst, config, seed_mask, empirical_pos):
+def _give_up_check(pst, config, seed_mask):
     # Judge whether the signal is too weak over the representative prefixes only:
     # the short prefix-closed core explores a skewed region of the state space and
     # is classified more confidently than the probe prefixes, so folding it in
-    # would distort the agreement estimate and could trigger a spurious give-up.
+    # would distort the estimate and could trigger a spurious give-up.
     rep = pst.table.representative
     seed_mask = seed_mask[rep]
-    empirical_pos = float(seed_mask.mean())
     # The give-up statistic reasons about the sampled acceptance-family suffixes
     # (their count bounds how many are idempotent), so count the fully-observed
     # family suffixes -- not every interned row, which would also include
@@ -135,15 +137,18 @@ def _give_up_check(pst, config, seed_mask, empirical_pos):
         len(candidate),
         config.min_suffix_frequency,
         config.min_acc_rej,
-        empirical_pos,
+        center=pst.decision_boundary,
     )
-    if result is not None:
-        k, threshold = result
-        masks = pst.table.observed_masks(candidate, rep)
-        agreements = (masks == seed_mask).mean(axis=1)
-        top_k_mean = float(np.sort(agreements)[-k:].mean())
-        if top_k_mean <= threshold:
-            raise GaveUpOnSuffixSearch(
-                f"Sampled {len(candidate)} suffixes. "
-                f"Top-{k} mean agreement {top_k_mean:.3f} <= {threshold:.3f}"
-            )
+    if result is None:
+        return
+    k, tau = result
+    masks = pst.table.observed_masks(candidate, rep)
+    # The seed picks which columns to look at; the statistic does not read it,
+    # so the k readings in a prefix stay independent given its class.
+    top = np.argsort((masks == seed_mask).mean(axis=1))[-k:]
+    dispersion = row_sum_dispersion(masks[top])
+    if dispersion <= tau:
+        raise GaveUpOnSuffixSearch(
+            f"Sampled {len(candidate)} suffixes. "
+            f"Top-{k} row-sum dispersion {dispersion:.3f} <= {tau:.3f}"
+        )

--- a/orthogonal_dfa/l_star/cluster.py
+++ b/orthogonal_dfa/l_star/cluster.py
@@ -137,7 +137,7 @@ def _give_up_check(pst, config, seed_mask):
         len(candidate),
         config.min_suffix_frequency,
         config.min_acc_rej,
-        center=pst.decision_boundary,
+        float(seed_mask.mean()),
     )
     if result is None:
         return

--- a/orthogonal_dfa/l_star/learn.py
+++ b/orthogonal_dfa/l_star/learn.py
@@ -16,6 +16,7 @@ from .lstar import do_counterexample_driven_synthesis
 from .prefix_suffix_tracker import PrefixSuffixTracker, SearchConfig
 from .sampler import UniformSampler
 from .statistics import (
+    DEFAULT_MIN_ACC_REJ,
     compute_suffix_size_counterexample_gen,
     population_size_and_evidence_margin,
 )
@@ -39,6 +40,7 @@ def build_pst(
     seed: int,
     noise_model: Optional[Any] = None,
     min_suffix_frequency: float = 0.02,
+    min_acc_rej: float = DEFAULT_MIN_ACC_REJ,
     sample_length: int = DEFAULT_SAMPLE_LENGTH,
 ) -> PrefixSuffixTracker:
     """A PrefixSuffixTracker sized for an oracle carrying `min_signal_strength`.
@@ -65,6 +67,7 @@ def build_pst(
         min_signal_strength=min_signal_strength,
         num_addtl_prefixes=NUM_PREFIXES,
         min_suffix_frequency=min_suffix_frequency,
+        min_acc_rej=min_acc_rej,
     )
     return PrefixSuffixTracker.create(
         UniformSampler(sample_length),
@@ -82,6 +85,7 @@ def learn_dfa(
     seed: int,
     noise_model: Optional[Any] = None,
     min_suffix_frequency: float = 0.02,
+    min_acc_rej: float = DEFAULT_MIN_ACC_REJ,
     sample_length: int = DEFAULT_SAMPLE_LENGTH,
     acc_threshold: float = DEFAULT_ACC_THRESHOLD,
 ):
@@ -97,6 +101,7 @@ def learn_dfa(
         seed=seed,
         noise_model=noise_model,
         min_suffix_frequency=min_suffix_frequency,
+        min_acc_rej=min_acc_rej,
         sample_length=sample_length,
     )
     dfa, _ = do_counterexample_driven_synthesis(

--- a/orthogonal_dfa/l_star/preconditions.py
+++ b/orthogonal_dfa/l_star/preconditions.py
@@ -20,6 +20,8 @@ from typing import List, Optional, Tuple
 import numpy as np
 from automata.fa.dfa import DFA
 
+from .statistics import DEFAULT_MIN_ACC_REJ
+
 DEFAULT_NUM_SAMPLES = 2000
 
 #: Bar for coverage by prefixes of the given length before we consider a state
@@ -148,6 +150,7 @@ def satisfies_preconditions(
     dfa: DFA,
     *,
     length: int,
+    min_accept_or_reject: float = DEFAULT_MIN_ACC_REJ,
     min_class_preserving_frac: float = 0.02,
     min_covered_accuracy: float = 0.99,
     num_samples: int = DEFAULT_NUM_SAMPLES,
@@ -157,14 +160,16 @@ def satisfies_preconditions(
 
     All under length-``length`` uniform sampling:
 
-    - acceptance rate strictly between 0 and 1;
+    - acceptance rate in ``[min_accept_or_reject, 1 - min_accept_or_reject]``;
     - class-preserving fraction at least ``min_class_preserving_frac``;
     - covered-accuracy ceiling at least ``min_covered_accuracy``
 
-    The acceptance-rate check only rejects degeneracy -- a language that is
-    constant over the sampled strings, which E-L* cannot get signal from and
-    which the other two checks pass trivially. It carries no balance
-    requirement: an imbalanced language is the class-preserving check's business.
+    ``min_accept_or_reject`` is the same bound the learner's ``give_up_check``
+    assumes of its prefixes: it derives a threshold from
+    ``8 * min_acc_rej * (1 - min_acc_rej) * s**2``, which only holds as a bound
+    when the prefixes really are at least that balanced. A target outside the
+    band breaks that assumption and is given up on regardless of its signal,
+    so it is rejected here rather than run.
 
     Checks run in increasing cost. By default they stop at the first failure,
     which is what a caller wanting only a verdict should do; pass
@@ -172,10 +177,11 @@ def satisfies_preconditions(
     """
     reasons: List[str] = []
     rate = acceptance_rate(dfa, length=length, num_samples=num_samples)
-    if rate in (0.0, 1.0):
+    if not min_accept_or_reject <= rate <= 1 - min_accept_or_reject:
         reasons.append(
-            f"acceptance rate {rate} degenerate: every sampled string of length "
-            f"{length} has the same label"
+            f"acceptance rate {rate:.3f} outside "
+            f"[{min_accept_or_reject}, {round(1 - min_accept_or_reject, 10)}] "
+            f"(the balance give_up_check assumes)"
         )
         if short_circuit:
             return PreconditionReport(length, rate, reasons=tuple(reasons))

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -6,6 +6,7 @@ import tqdm.auto as tqdm
 
 from .mask_table import MaskTable
 from .sampler import Sampler
+from .statistics import DEFAULT_MIN_ACC_REJ
 from .structures import Oracle
 
 
@@ -54,7 +55,7 @@ class SearchConfig:
     fnr_limit: float = 0.02
     split_pval: float = 0.001
     min_suffix_frequency: float = 0.02
-    min_acc_rej: float = 0.1
+    min_acc_rej: float = DEFAULT_MIN_ACC_REJ
 
 
 @dataclass

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -4,6 +4,11 @@ from typing import Optional, Tuple
 import numpy as np
 import scipy
 
+#: Floor on the smaller of the prefix accept/reject rates. ``give_up_check``
+#: needs it as a lower bound, and ``satisfies_preconditions`` rejects targets
+#: that would break it, so both read this.
+DEFAULT_MIN_ACC_REJ = 0.02
+
 
 def population_size_and_evidence_margin(
     signal_strength, acceptable_fpr, acceptable_fnr

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -73,7 +73,7 @@ def row_sum_dispersion(columns) -> float:
 
     Denominator is
         k mu (1 - mu)
-    which is what the numerator would be if the row sums were drawn from a single binomial with mean mu. 
+    which is what the numerator would be if the row sums were drawn from a single binomial with mean mu.
 
     Around 1 when the prefixes are exchangeable, above 1 when the prefixes are more variable (i.e.,
     there are multiple classes of prefix).
@@ -88,16 +88,34 @@ def row_sum_dispersion(columns) -> float:
     )
 
 
-def _feasible_balance_range(empirical_pos, s, min_acc_rej):
-    """Balances consistent with the observed rate.
-
-    Fixing ``empirical_pos = p*(c+s) + (1-p)*(c-s)`` pins ``c`` once ``p`` is
-    chosen, and ``c +- s`` still has to be a probability, which rules out the
-    extremes: a population that is almost all one class cannot average to a
-    middling rate without pushing a class rate outside ``[0, 1]``.
+def _feasible_balance_range(empirical_pos, min_s, min_acc_rej):
     """
-    lo = max(min_acc_rej, 1 - (1 - empirical_pos) / (2 * s))
-    hi = min(1 - min_acc_rej, empirical_pos / (2 * s))
+    The empirical positive oracle rate
+        empirical_pos = p*(c+s) + (1-p)*(c-s)
+    limits the set of possible (p, c, s) values
+    and we have a bound on p: p > min_acc_rej, and s >= min_s.
+
+    Therefore, we can solve for the feasible range of p given the empirical_pos, min_s, and min_acc_rej as:
+
+        empirical_pos = c + s(2p - 1)        so  c = empirical_pos - s(2p - 1)
+
+    and both class rates have to be probabilities, which bounds p on each side:
+
+        c - s >= 0   <=>  empirical_pos - 2ps       >= 0  <=>  p <= empirical_pos / 2s
+        c + s <= 1   <=>  empirical_pos + 2s(1 - p) <= 1  <=>  p >= 1 - (1 - empirical_pos) / 2s
+
+    These can be bounded by
+
+    p <= empirical_pos / 2 min_s
+    p >= 1 - (1 - empirical_pos) / 2 min_s
+
+    We also intersect with the bound (min_acc_rej, 1 - min_acc_rej).
+
+    If the lower bound is above the upper bound, there is no feasible p, and we return None.
+    This is because min_acc_rej is too high for the observed empirical_pos and min_s.
+    """
+    lo = max(min_acc_rej, 1 - (1 - empirical_pos) / (2 * min_s))
+    hi = min(1 - min_acc_rej, empirical_pos / (2 * min_s))
     return (lo, hi) if lo <= hi else None
 
 

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -137,15 +137,27 @@ def give_up_check(  # pylint: disable=too-many-positional-arguments
 
     H0 is that the cluster exists, so rejecting it is what triggers the
     destructive action and ``Pr[give up | cluster exists] <= failure_prob`` is
-    the guarantee.  Under H0 a prefix's row sum is binomial in its class rate,
-    a mixture whose dispersion rises with ``p * (1 - p)``.  That is monotone,
-    so evaluating at the least balanced population still consistent with the
-    evidence gives the lowest dispersion H0 allows, and a lower-tail threshold
-    there is conservative for every better-balanced target.
+    the guarantee.
 
-    The model is pinned to ``empirical_pos`` because the statistic normalises
-    by the observed rate; deriving an expected rate from anything else would
-    compare the data against a threshold built for a different population.
+    Under H0 prefix ``i``'s row sum is ``R_i ~ Bin(k, q_i)`` with
+    ``q_i = c + s`` or ``c - s`` by class, drawn with ``P(accept) = p``.
+    Writing ``mu = E[q]``::
+
+        Var(R)     = k E[q(1-q)] + k^2 Var(q)      (law of total variance)
+        mu(1 - mu) = E[q(1-q)] + Var(q)
+        E[X2]/df   = Var(R) / (k mu(1-mu)) = 1 + (k-1) Var(q) / (mu(1-mu))
+        Var(q)     = 4 p (1-p) s^2
+
+    So the dispersion H0 predicts is increasing in ``p(1-p)``: the least
+    balanced admissible ``p`` gives the least it allows, and a lower-tail
+    threshold there is conservative for every better-balanced target.
+
+    ``mu`` enters only as the observed rate, which the statistic already
+    normalises by -- taking it from anywhere else would test the data against
+    a threshold built for a different population.  It also pins
+    ``c = mu + s(1 - 2p)``, so requiring ``c - s >= 0`` and ``c + s <= 1``
+    bounds ``p`` into ``[1 - (1-mu)/2s, mu/2s]``; see
+    :func:`_feasible_balance_range`.
 
     The statistic never reads the seed column, so the k readings in a prefix
     are independent given its class.  Selecting the columns by agreement with

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -82,7 +82,7 @@ def row_sum_dispersion(columns) -> float:
 
 
 def _dispersion_at_the_bound(
-    k, num_prefixes, center, s, min_acc_rej, quantile, num_sim
+    k, num_prefixes, *, center, s, min_acc_rej, quantile, num_sim
 ):
     """The ``quantile`` of ``row_sum_dispersion`` when a cluster does exist, at
     the least favourable balance the caller has ruled out going below.
@@ -151,7 +151,13 @@ def give_up_check(  # pylint: disable=too-many-positional-arguments
     if k < 2:
         return None
     tau = _dispersion_at_the_bound(
-        k, num_prefixes, center, signal_strength, min_acc_rej, each, num_sim
+        k,
+        num_prefixes,
+        center=center,
+        s=signal_strength,
+        min_acc_rej=min_acc_rej,
+        quantile=each,
+        num_sim=num_sim,
     )
     return k, tau
 

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -63,87 +63,97 @@ def evidence_margin_for_population_size(
     return None
 
 
+def row_sum_dispersion(columns) -> float:
+    """Chi-square dispersion of the per-prefix row sums of ``columns`` (k x P).
+
+    Around 1 when the prefixes are exchangeable, above 1 when they split into
+    classes the columns agree about: a prefix in the accept class reads 1 more
+    often in *every* column at once, so its row sum sits high and the sums
+    spread wider than a single binomial.
+    """
+    k, num_prefixes = columns.shape
+    mu = float(columns.mean())
+    if mu <= 0 or mu >= 1 or num_prefixes < 2:
+        return 0.0
+    row_sums = columns.sum(axis=0)
+    return float(
+        ((row_sums - k * mu) ** 2).sum() / (k * mu * (1 - mu)) / (num_prefixes - 1)
+    )
+
+
+def _dispersion_at_the_bound(
+    k, num_prefixes, center, s, min_acc_rej, quantile, num_sim
+):
+    """The ``quantile`` of ``row_sum_dispersion`` when a cluster does exist, at
+    the least favourable balance the caller has ruled out going below.
+
+    Row sums are drawn straight from the two-class mixture rather than from a
+    whole mask matrix, so this stays cheap as k and P grow.
+    """
+    rng = np.random.default_rng(0)
+    accept = rng.random((num_sim, num_prefixes)) < min_acc_rej
+    rates = np.clip(np.where(accept, center + s, center - s), 0.0, 1.0)
+    draws = rng.binomial(k, rates)
+    mu = draws.mean(axis=1) / k
+    ok = (mu > 0) & (mu < 1)
+    if not ok.any():
+        return 0.0
+    draws, mu = draws[ok], mu[ok]
+    spread = ((draws - (k * mu)[:, None]) ** 2).sum(axis=1)
+    x2 = spread / (k * mu * (1 - mu)) / (num_prefixes - 1)
+    return float(np.quantile(x2, quantile))
+
+
 def give_up_check(  # pylint: disable=too-many-positional-arguments
     signal_strength,
     num_prefixes,
     num_suffixes,
     min_suffix_frequency,
     min_acc_rej,
-    empirical_pos,
     *,
+    center=0.5,
     failure_prob=0.01,
+    num_sim=4000,
 ):
-    """
-    Checks whether we should give up on finding suffixes based on the
-    parameters of the problem and the empirical agreement with the seed.
+    """When to conclude no suffix family separates the prefixes.
 
-    :param signal_strength: The minimum signal strength we are trying
-        to detect.
-    :param num_prefixes: The number of prefixes we have.
-    :param num_suffixes: The number of suffixes we have sampled so far.
-    :param min_suffix_frequency: The minimum frequency of suffixes we
-        are trying to find.
-    :param min_acc_rej: The minimum of the accept and reject rates of
-        the prefixes.
-    :param empirical_pos: The empirical positive rate of the prefixes.
-    :param failure_prob: The probability with which we are willing to
-        fail to find a good suffix.
-    :return: A tuple of (k, agreement_threshold). We should give up if
-        ``mean([mask[i] == mask[0] for i in top_k])
-        < agreement_threshold``.
-    """
-    r = min_suffix_frequency
-    s = signal_strength
-    P = num_prefixes
-    T = num_suffixes
-    assert 0 < r <= 1
-    assert s > 0
+    Returns ``(k, tau)``; give up if ``row_sum_dispersion`` over the top-``k``
+    columns is ``<= tau``.  ``None`` when ``k < 2`` leaves nothing to test.
 
-    # k = lower bound on number of idempotent suffixes.
-    # We can assume that the top k are idempotent, because the ones
-    # that aren't are better than a random idempotent suffix anyway,
-    # so this is a conservative threshold.
-    k = int(scipy.stats.binom.ppf(failure_prob / 3, T, r))
+    H0 is that the cluster exists, so rejecting it is what triggers the
+    destructive action, and Pr[give up | cluster exists] <= ``failure_prob`` is
+    the guarantee.  Under H0 a prefix's row sum is ``Bin(k, center +- s)`` by
+    its class, a mixture whose dispersion grows with ``p * (1 - p)``.  That is
+    monotone, so taking ``p = min_acc_rej`` -- the least balance the caller
+    permits -- gives the lowest dispersion H0 allows, and a lower-tail
+    threshold there is conservative for every better-balanced target.
+
+    The statistic never mentions the seed column, so the k readings in a prefix
+    are independent given its class.  Selecting the columns by agreement with
+    the seed only inflates dispersion, and inflation cannot trip a lower-tail
+    test, so the selection needs no correction.
+
+    :param signal_strength: separation ``s`` of the two class rates about ``center``.
+    :param num_prefixes: prefixes the dispersion is measured over.
+    :param num_suffixes: suffixes sampled so far.
+    :param min_suffix_frequency: assumed floor on the idempotent-suffix rate.
+    :param min_acc_rej: assumed floor on the smaller of the accept/reject rates.
+        A *bound*, not an estimate -- the guarantee holds only above it.
+    :param center: rate a prefix reads 1 at with no class signal.
+    """
+    assert 0 < min_suffix_frequency <= 1
+    assert signal_strength > 0
+
+    # Split the budget: k may undercount the idempotent suffixes, and the
+    # threshold may sit above the true quantile.
+    each = failure_prob / 2
+    k = int(scipy.stats.binom.ppf(each, num_suffixes, min_suffix_frequency))
     if k < 2:
         return None
-
-    # We now know we have at least k idempotent suffixes, but these
-    # are noisy.  Specifically, each has v_{ij} ~ B(center + s) if
-    # prefix i is accept, and v_{ij} ~ B(center - s) if prefix i is
-    # reject.  This means if we let w_{ij} = v_{ij} == v_{0j}
-    # (agreement with seed), we have that w_{ij} = 1 iff either
-    #   - prefix i is accept and two samples from B(center + s) agree
-    #   - prefix i is reject and two samples from B(center - s) agree
-    # The probability that two samples from B(p) agree is
-    #   a(p) = p^2 + (1-p)^2 = 2p^2 - 2p + 1 = 1 - 2p(1-p).
-    # This is a quadratic with minimum at p=0.5, where it equals 0.5,
-    # and it increases as p goes to 0 or 1.
-    # As such, we have that w_{ij} = 1 with probability
-    #   p_same
-    #     = p_acc * a(c + s) + (1 - p_acc) * a(c - s)
-    # One thing is that we know the empirical positives the oracle
-    # produces on the prefixes:
-    #   empirical_pos = p_acc * (c + s) + (1 - p_acc) * (c - s)
-    # So if we subtract out the expected agreement based on the
-    # empirical positive rate, we get
-    #   p_same - a(empirical_pos)
-    # Which we can simplify (see _give_up_check_sym) to
-    #   8*p_acc (1 - p_acc) s^2
-    # This is minimized when p_acc is minimized.
-    # We can thus compute
-    def a(p):
-        return 1 - 2 * p * (1 - p)
-
-    p_same = 8 * min_acc_rej * (1 - min_acc_rej) * s**2 + a(empirical_pos)
-
-    # We want to give up if the top-k mean agreement is less than
-    # p_same, which is the expected agreement of a random idempotent
-    # suffix.  The top-k mean agreement can be computed as
-    # sum_ij w_{ij} / (kP)
-    # Which is just a binomial distribution with kP trials and
-    # probability p_same, divided by kP.
-    threshold = scipy.stats.binom.ppf(failure_prob / 3, k * P, p_same) / (k * P)
-    return k, threshold
+    tau = _dispersion_at_the_bound(
+        k, num_prefixes, center, signal_strength, min_acc_rej, each, num_sim
+    )
+    return k, tau
 
 
 def _give_up_check_sym():

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -64,12 +64,19 @@ def evidence_margin_for_population_size(
 
 
 def row_sum_dispersion(columns) -> float:
-    """Chi-square dispersion of the per-prefix row sums of ``columns`` (k x P).
+    """
+    Dispersion of the per-prefix row sums of the columns.
 
-    Around 1 when the prefixes are exchangeable, above 1 when they split into
-    classes the columns agree about: a prefix in the accept class reads 1 more
-    often in *every* column at once, so its row sum sits high and the sums
-    spread wider than a single binomial.
+    Numerator is
+        sum_i (r_i - k mu)^2 / (num_prefixes - 1)
+    which is the sum of each row sum's deviation from the mean, squared, divided by the degrees of freedom.
+
+    Denominator is
+        k mu (1 - mu)
+    which is what the numerator would be if the row sums were drawn from a single binomial with mean mu. 
+
+    Around 1 when the prefixes are exchangeable, above 1 when the prefixes are more variable (i.e.,
+    there are multiple classes of prefix).
     """
     k, num_prefixes = columns.shape
     mu = float(columns.mean())

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -81,19 +81,33 @@ def row_sum_dispersion(columns) -> float:
     )
 
 
+def _feasible_balance_range(empirical_pos, s, min_acc_rej):
+    """Balances consistent with the observed rate.
+
+    Fixing ``empirical_pos = p*(c+s) + (1-p)*(c-s)`` pins ``c`` once ``p`` is
+    chosen, and ``c +- s`` still has to be a probability, which rules out the
+    extremes: a population that is almost all one class cannot average to a
+    middling rate without pushing a class rate outside ``[0, 1]``.
+    """
+    lo = max(min_acc_rej, 1 - (1 - empirical_pos) / (2 * s))
+    hi = min(1 - min_acc_rej, empirical_pos / (2 * s))
+    return (lo, hi) if lo <= hi else None
+
+
 def _dispersion_at_the_bound(
-    k, num_prefixes, *, center, s, min_acc_rej, quantile, num_sim
+    k, num_prefixes, *, empirical_pos, s, balance, quantile, num_sim
 ):
     """The ``quantile`` of ``row_sum_dispersion`` when a cluster does exist, at
-    the least favourable balance the caller has ruled out going below.
+    the given balance and the observed rate.
 
     Row sums are drawn straight from the two-class mixture rather than from a
     whole mask matrix, so this stays cheap as k and P grow.
     """
+    accept_rate = empirical_pos + 2 * s * (1 - balance)
+    reject_rate = empirical_pos - 2 * s * balance
     rng = np.random.default_rng(0)
-    accept = rng.random((num_sim, num_prefixes)) < min_acc_rej
-    rates = np.clip(np.where(accept, center + s, center - s), 0.0, 1.0)
-    draws = rng.binomial(k, rates)
+    accept = rng.random((num_sim, num_prefixes)) < balance
+    draws = rng.binomial(k, np.where(accept, accept_rate, reject_rate))
     mu = draws.mean(axis=1) / k
     ok = (mu > 0) & (mu < 1)
     if not ok.any():
@@ -110,36 +124,38 @@ def give_up_check(  # pylint: disable=too-many-positional-arguments
     num_suffixes,
     min_suffix_frequency,
     min_acc_rej,
+    empirical_pos,
     *,
-    center=0.5,
     failure_prob=0.01,
     num_sim=4000,
 ):
     """When to conclude no suffix family separates the prefixes.
 
     Returns ``(k, tau)``; give up if ``row_sum_dispersion`` over the top-``k``
-    columns is ``<= tau``.  ``None`` when ``k < 2`` leaves nothing to test.
+    columns is ``<= tau``.  ``None`` when ``k < 2`` leaves nothing to test, or
+    when no balance is consistent with ``empirical_pos``.
 
     H0 is that the cluster exists, so rejecting it is what triggers the
-    destructive action, and Pr[give up | cluster exists] <= ``failure_prob`` is
-    the guarantee.  Under H0 a prefix's row sum is ``Bin(k, center +- s)`` by
-    its class, a mixture whose dispersion grows with ``p * (1 - p)``.  That is
-    monotone, so taking ``p = min_acc_rej`` -- the least balance the caller
-    permits -- gives the lowest dispersion H0 allows, and a lower-tail
-    threshold there is conservative for every better-balanced target.
+    destructive action and ``Pr[give up | cluster exists] <= failure_prob`` is
+    the guarantee.  Under H0 a prefix's row sum is binomial in its class rate,
+    a mixture whose dispersion rises with ``p * (1 - p)``.  That is monotone,
+    so evaluating at the least balanced population still consistent with the
+    evidence gives the lowest dispersion H0 allows, and a lower-tail threshold
+    there is conservative for every better-balanced target.
 
-    The statistic never mentions the seed column, so the k readings in a prefix
+    The model is pinned to ``empirical_pos`` because the statistic normalises
+    by the observed rate; deriving an expected rate from anything else would
+    compare the data against a threshold built for a different population.
+
+    The statistic never reads the seed column, so the k readings in a prefix
     are independent given its class.  Selecting the columns by agreement with
     the seed only inflates dispersion, and inflation cannot trip a lower-tail
     test, so the selection needs no correction.
 
-    :param signal_strength: separation ``s`` of the two class rates about ``center``.
-    :param num_prefixes: prefixes the dispersion is measured over.
-    :param num_suffixes: suffixes sampled so far.
-    :param min_suffix_frequency: assumed floor on the idempotent-suffix rate.
-    :param min_acc_rej: assumed floor on the smaller of the accept/reject rates.
-        A *bound*, not an estimate -- the guarantee holds only above it.
-    :param center: rate a prefix reads 1 at with no class signal.
+    :param min_acc_rej: floor on the smaller of the accept/reject rates.  A
+        *bound*, not an estimate -- the guarantee holds only above it.
+    :param empirical_pos: observed rate the prefixes read 1 at, over the same
+        prefixes the dispersion is measured on.
     """
     assert 0 < min_suffix_frequency <= 1
     assert signal_strength > 0
@@ -150,12 +166,17 @@ def give_up_check(  # pylint: disable=too-many-positional-arguments
     k = int(scipy.stats.binom.ppf(each, num_suffixes, min_suffix_frequency))
     if k < 2:
         return None
+    feasible = _feasible_balance_range(empirical_pos, signal_strength, min_acc_rej)
+    if feasible is None:
+        return None
+    lo, hi = feasible
+    balance = lo if lo * (1 - lo) <= hi * (1 - hi) else hi
     tau = _dispersion_at_the_bound(
         k,
         num_prefixes,
-        center=center,
+        empirical_pos=empirical_pos,
         s=signal_strength,
-        min_acc_rej=min_acc_rej,
+        balance=balance,
         quantile=each,
         num_sim=num_sim,
     )

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -122,11 +122,9 @@ def _feasible_balance_range(empirical_pos, min_s, min_acc_rej):
 def _dispersion_at_the_bound(
     k, num_prefixes, *, empirical_pos, s, balance, quantile, num_sim
 ):
-    """The ``quantile`` of ``row_sum_dispersion`` when a cluster does exist, at
+    """
+    The ``quantile`` of ``row_sum_dispersion`` when a cluster does exist, at
     the given balance and the observed rate.
-
-    Row sums are drawn straight from the two-class mixture rather than from a
-    whole mask matrix, so this stays cheap as k and P grow.
     """
     accept_rate = empirical_pos + 2 * s * (1 - balance)
     reject_rate = empirical_pos - 2 * s * balance
@@ -134,12 +132,12 @@ def _dispersion_at_the_bound(
     accept = rng.random((num_sim, num_prefixes)) < balance
     draws = rng.binomial(k, np.where(accept, accept_rate, reject_rate))
     mu = draws.mean(axis=1) / k
-    ok = (mu > 0) & (mu < 1)
-    if not ok.any():
-        return 0.0
-    draws, mu = draws[ok], mu[ok]
+    #`row_sum_dispersion` scores it a 0.0 whenever it shows up with all 0s or all 1s
     spread = ((draws - (k * mu)[:, None]) ** 2).sum(axis=1)
-    x2 = spread / (k * mu * (1 - mu)) / (num_prefixes - 1)
+    scale = k * mu * (1 - mu) * (num_prefixes - 1)
+    x2 = np.divide(
+        spread, scale, out=np.zeros_like(spread, dtype=float), where=scale > 0
+    )
     return float(np.quantile(x2, quantile))
 
 

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -132,7 +132,7 @@ def _dispersion_at_the_bound(
     accept = rng.random((num_sim, num_prefixes)) < balance
     draws = rng.binomial(k, np.where(accept, accept_rate, reject_rate))
     mu = draws.mean(axis=1) / k
-    #`row_sum_dispersion` scores it a 0.0 whenever it shows up with all 0s or all 1s
+    # `row_sum_dispersion` scores it a 0.0 whenever it shows up with all 0s or all 1s
     spread = ((draws - (k * mu)[:, None]) ** 2).sum(axis=1)
     scale = k * mu * (1 - mu) * (num_prefixes - 1)
     x2 = np.divide(
@@ -142,7 +142,7 @@ def _dispersion_at_the_bound(
 
 
 def give_up_check(  # pylint: disable=too-many-positional-arguments
-    signal_strength,
+    minimal_signal_strength,
     num_prefixes,
     num_suffixes,
     min_suffix_frequency,
@@ -152,40 +152,34 @@ def give_up_check(  # pylint: disable=too-many-positional-arguments
     failure_prob=0.01,
     num_sim=4000,
 ):
-    """When to conclude no suffix family separates the prefixes.
+    """
 
-    Returns ``(k, tau)``; give up if ``row_sum_dispersion`` over the top-``k``
-    columns is ``<= tau``.  ``None`` when ``k < 2`` leaves nothing to test, or
-    when no balance is consistent with ``empirical_pos``.
+    When to conclude no suffix family separates the prefixes.
 
-    H0 is that the cluster exists, so rejecting it is what triggers the
-    destructive action and ``Pr[give up | cluster exists] <= failure_prob`` is
-    the guarantee.
+    Returns (k, tau): give up if row_sum_dispersion over the top-k
+    columns is <= tau.  None when either k < 2, so nothing to test, or
+    when no balance p is feasible given the observed parameters.
 
-    Under H0 prefix ``i``'s row sum is ``R_i ~ Bin(k, q_i)`` with
-    ``q_i = c + s`` or ``c - s`` by class, drawn with ``P(accept) = p``.
-    Writing ``mu = E[q]``::
+    Pr[give up | cluster exists] <= failure_prob is guaranteed.
 
-        Var(R)     = k E[q(1-q)] + k^2 Var(q)      (law of total variance)
+    When a cluster exists, prefix i's row sum is
+        R_i ~ Bin(k, q_i)
+    where q_i is c + s with probability p and c - s with probability 1 - p.
+    Writing mu = E[q] and X2/df as the return of row_sum_dispersion, we have
+
+        Var(R)     = k E[q(1-q)] + k^2 Var(q)
         mu(1 - mu) = E[q(1-q)] + Var(q)
         E[X2]/df   = Var(R) / (k mu(1-mu)) = 1 + (k-1) Var(q) / (mu(1-mu))
         Var(q)     = 4 p (1-p) s^2
 
-    So the dispersion H0 predicts is increasing in ``p(1-p)``: the least
-    balanced admissible ``p`` gives the least it allows, and a lower-tail
-    threshold there is conservative for every better-balanced target.
+    So the dispersion is increasing in p(1-p), we can take the least balanced
+    feasible p to get a lower bound.
 
-    ``mu`` enters only as the observed rate, which the statistic already
-    normalises by -- taking it from anywhere else would test the data against
-    a threshold built for a different population.  It also pins
-    ``c = mu + s(1 - 2p)``, so requiring ``c - s >= 0`` and ``c + s <= 1``
-    bounds ``p`` into ``[1 - (1-mu)/2s, mu/2s]``; see
-    :func:`_feasible_balance_range`.
+    mu has to be the observed rate, since that is what the statistic normalises
+    by, and the seed only picks the columns: it is not read by the statistic,
+    so seed-based selection can only inflate dispersion, which a lower-tail
+    test cannot be tripped by.
 
-    The statistic never reads the seed column, so the k readings in a prefix
-    are independent given its class.  Selecting the columns by agreement with
-    the seed only inflates dispersion, and inflation cannot trip a lower-tail
-    test, so the selection needs no correction.
 
     :param min_acc_rej: floor on the smaller of the accept/reject rates.  A
         *bound*, not an estimate -- the guarantee holds only above it.
@@ -193,7 +187,7 @@ def give_up_check(  # pylint: disable=too-many-positional-arguments
         prefixes the dispersion is measured on.
     """
     assert 0 < min_suffix_frequency <= 1
-    assert signal_strength > 0
+    assert minimal_signal_strength > 0
 
     # Split the budget: k may undercount the idempotent suffixes, and the
     # threshold may sit above the true quantile.
@@ -201,7 +195,9 @@ def give_up_check(  # pylint: disable=too-many-positional-arguments
     k = int(scipy.stats.binom.ppf(each, num_suffixes, min_suffix_frequency))
     if k < 2:
         return None
-    feasible = _feasible_balance_range(empirical_pos, signal_strength, min_acc_rej)
+    feasible = _feasible_balance_range(
+        empirical_pos, minimal_signal_strength, min_acc_rej
+    )
     if feasible is None:
         return None
     lo, hi = feasible
@@ -210,7 +206,7 @@ def give_up_check(  # pylint: disable=too-many-positional-arguments
         k,
         num_prefixes,
         empirical_pos=empirical_pos,
-        s=signal_strength,
+        s=minimal_signal_strength,
         balance=balance,
         quantile=each,
         num_sim=num_sim,

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -438,21 +438,14 @@ class TestGiveUpThreshold(unittest.TestCase):
         # suffixes), so we only check the upper bound.
         self.assertLess(empirical_failure_rate, failure_prob + 0.02)
 
-    def test_does_not_give_up_when_prefixes_are_more_skewed_than_min_acc_rej(self):
-        """``min_acc_rej`` has to lower-bound the prefix accept/reject balance.
+    def _spurious_give_up_rate(self, balance, min_acc_rej, *, num_trials=300):
+        """How often the check fires on prefixes that all carry full signal.
 
-        ``p_same`` uses ``8 * min_acc_rej * (1 - min_acc_rej) * s**2``, a term
-        the derivation obtains by minimising over ``p_acc``.  It is a config
-        constant, never measured, so a target whose prefixes are more skewed
-        than it makes the term too large, the threshold too high, and the check
-        gives up on prefixes carrying full signal.
-
-        CAPAL's Simple05 is the case in hand: it accepts 92.3% of length-40
-        strings, a balance of 0.077 against the SearchConfig default of 0.1.
+        ``balance`` is the true share of the smaller class; ``min_acc_rej`` is
+        what the check is told to assume about it.
         """
         signal_strength, num_prefixes, num_suffixes, r = 0.40, 200, 958, 0.02
-        center, min_acc_rej = 0.5, DEFAULT_MIN_ACC_REJ
-        balance = 0.077
+        center = 0.5
         p_accept, p_reject = center + signal_strength, center - signal_strength
         empirical_pos = (1 - balance) * p_accept + balance * p_reject
 
@@ -467,7 +460,6 @@ class TestGiveUpThreshold(unittest.TestCase):
         self.assertIsNotNone(result, "k too small")
         k, threshold = result
 
-        num_trials = 300
         rng = np.random.default_rng(42)
         failures = 0
         for _ in range(num_trials):
@@ -483,10 +475,25 @@ class TestGiveUpThreshold(unittest.TestCase):
             agreements = (suffix_obs == seed_obs[None, :]).mean(axis=1)
             if np.sort(agreements)[-k:].mean() <= threshold:
                 failures += 1
+        return failures / num_trials
 
-        # Every prefix here carries the full signal, so the check should almost
-        # never fire -- it claims a 0.01 failure probability.
-        self.assertLess(failures / num_trials, 0.03, f"k={k} threshold={threshold:.4f}")
+    @parameterized.expand([(0.02,), (0.03,), (0.077,), (0.2,), (0.5,)])
+    def test_default_bound_holds_for_everything_preconditions_admit(self, balance):
+        """``satisfies_preconditions`` rejects anything below
+        ``DEFAULT_MIN_ACC_REJ``, so every target that reaches the learner is at
+        least this balanced and must not be given up on for lack of signal it
+        has.  0.077 is CAPAL's Simple05."""
+        rate = self._spurious_give_up_rate(balance, DEFAULT_MIN_ACC_REJ)
+        self.assertLess(rate, 0.03, f"balance={balance}")
+
+    def test_gives_up_spuriously_once_the_bound_is_violated(self):
+        """The check is only sound while ``min_acc_rej`` really does bound the
+        balance: ``p_same`` adds ``8 * min_acc_rej * (1 - min_acc_rej) * s**2``,
+        a term the derivation gets by minimising over ``p_acc``.  Told 0.1 about
+        prefixes that are actually at 0.077, it gives up on full signal -- which
+        is why the precondition band exists rather than a larger constant.
+        """
+        self.assertGreater(self._spurious_give_up_rate(0.077, 0.1), 0.10)
 
     def test_gives_up_with_no_signal(self):
         """With p_0 = p_1 = 0.5 (pure coin-flip), the oracle has no signal.

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -437,6 +437,56 @@ class TestGiveUpThreshold(unittest.TestCase):
         # suffixes), so we only check the upper bound.
         self.assertLess(empirical_failure_rate, failure_prob + 0.02)
 
+    def test_does_not_give_up_when_prefixes_are_more_skewed_than_min_acc_rej(self):
+        """``min_acc_rej`` has to lower-bound the prefix accept/reject balance.
+
+        ``p_same`` uses ``8 * min_acc_rej * (1 - min_acc_rej) * s**2``, a term
+        the derivation obtains by minimising over ``p_acc``.  It is a config
+        constant, never measured, so a target whose prefixes are more skewed
+        than it makes the term too large, the threshold too high, and the check
+        gives up on prefixes carrying full signal.
+
+        CAPAL's Simple05 is the case in hand: it accepts 92.3% of length-40
+        strings, a balance of 0.077 against the SearchConfig default of 0.1.
+        """
+        signal_strength, num_prefixes, num_suffixes, r = 0.40, 200, 958, 0.02
+        center, min_acc_rej = 0.5, 0.1
+        balance = 0.077
+        p_accept, p_reject = center + signal_strength, center - signal_strength
+        empirical_pos = (1 - balance) * p_accept + balance * p_reject
+
+        result = give_up_check(
+            signal_strength,
+            num_prefixes,
+            num_suffixes,
+            r,
+            min_acc_rej,
+            empirical_pos,
+        )
+        self.assertIsNotNone(result, "k too small")
+        k, threshold = result
+
+        num_trials = 300
+        rng = np.random.default_rng(42)
+        failures = 0
+        for _ in range(num_trials):
+            true_labels = rng.random(num_prefixes) < 1 - balance
+            p_per_prefix = np.where(true_labels, p_accept, p_reject)
+            seed_obs = rng.random(num_prefixes) < p_per_prefix
+
+            is_idempotent = rng.random(num_suffixes) < r
+            all_obs = rng.random((num_suffixes, num_prefixes))
+            suffix_obs = all_obs < np.where(
+                is_idempotent[:, None], p_per_prefix[None, :], empirical_pos
+            )
+            agreements = (suffix_obs == seed_obs[None, :]).mean(axis=1)
+            if np.sort(agreements)[-k:].mean() <= threshold:
+                failures += 1
+
+        # Every prefix here carries the full signal, so the check should almost
+        # never fire -- it claims a 0.01 failure probability.
+        self.assertLess(failures / num_trials, 0.03, f"k={k} threshold={threshold:.4f}")
+
     def test_gives_up_with_no_signal(self):
         """With p_0 = p_1 = 0.5 (pure coin-flip), the oracle has no signal.
         The give-up mechanism should detect this and raise GaveUpOnSuffixSearch."""

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -18,6 +18,7 @@ from orthogonal_dfa.l_star.learn import learn_dfa
 from orthogonal_dfa.l_star.lstar import counterexample_sample_budget
 from orthogonal_dfa.l_star.sampler import UniformSampler
 from orthogonal_dfa.l_star.statistics import (
+    DEFAULT_MIN_ACC_REJ,
     counterexample_search_exhausted,
     give_up_check,
 )
@@ -450,7 +451,7 @@ class TestGiveUpThreshold(unittest.TestCase):
         strings, a balance of 0.077 against the SearchConfig default of 0.1.
         """
         signal_strength, num_prefixes, num_suffixes, r = 0.40, 200, 958, 0.02
-        center, min_acc_rej = 0.5, 0.1
+        center, min_acc_rej = 0.5, DEFAULT_MIN_ACC_REJ
         balance = 0.077
         p_accept, p_reject = center + signal_strength, center - signal_strength
         empirical_pos = (1 - balance) * p_accept + balance * p_reject

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -18,7 +18,6 @@ from orthogonal_dfa.l_star.learn import learn_dfa
 from orthogonal_dfa.l_star.lstar import counterexample_sample_budget
 from orthogonal_dfa.l_star.sampler import UniformSampler
 from orthogonal_dfa.l_star.statistics import (
-    DEFAULT_MIN_ACC_REJ,
     counterexample_search_exhausted,
     give_up_check,
     row_sum_dispersion,

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -374,16 +374,17 @@ class TestGiveUpThreshold(unittest.TestCase):
     def _give_up_rate(self, balance, *, structured, min_acc_rej, num_trials=800):
         """How often the check fires, over ``num_trials`` draws of the k cluster
         columns at the given true ``balance``."""
+        base = balance * (0.5 + self.S) + (1 - balance) * (0.5 - self.S)
         k, tau = give_up_check(
             self.S,
             self.P,
             self.T,
             self.R,
             min_acc_rej,
+            base,
             failure_prob=self.FAILURE_PROB,
         )
         rng = np.random.default_rng(1234)
-        base = balance * (0.5 + self.S) + (1 - balance) * (0.5 - self.S)
         fired = 0
         for _ in range(num_trials):
             accept = rng.random(self.P) < balance

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -21,6 +21,7 @@ from orthogonal_dfa.l_star.statistics import (
     DEFAULT_MIN_ACC_REJ,
     counterexample_search_exhausted,
     give_up_check,
+    row_sum_dispersion,
 )
 from orthogonal_dfa.l_star.structures import AsymmetricBernoulli, SymmetricBernoulli
 
@@ -368,132 +369,58 @@ class TestLStarAsymmetric(unittest.TestCase):
 
 class TestGiveUpThreshold(unittest.TestCase):
 
-    @parameterized.expand(
-        [
-            # (signal, P, r, min_acc_rej, center)
-            (0.25, 200, 0.10, 0.5, 0.5),
-            (0.30, 200, 0.10, 0.5, 0.5),
-            (0.30, 100, 0.10, 0.5, 0.5),
-            # Asymmetric: center=0.65, min_acc_rej=0.2
-            (0.30, 200, 0.10, 0.2, 0.65),
-        ]
-    )
-    def test_rarely_gives_up_when_evidence_present(  # pylint: disable=too-many-positional-arguments
-        self, signal_strength, num_prefixes, r, min_acc_rej, center
-    ):
-        """Empirically validate that the give-up check matches its claimed
-        failure probability. Under signal, the top-k mean agreement should
-        almost always exceed the threshold."""
-        failure_prob = 0.05
-        num_suffixes = 200
-        p_accept = center + signal_strength
-        p_reject = center - signal_strength
-        empirical_pos = min_acc_rej * p_accept + (1 - min_acc_rej) * p_reject
+    S, P, T, R = 0.3, 200, 958, 0.02
+    FAILURE_PROB = 0.01
 
-        result = give_up_check(
-            signal_strength,
-            num_prefixes,
-            num_suffixes,
-            r,
+    def _give_up_rate(self, balance, *, structured, min_acc_rej, num_trials=800):
+        """How often the check fires, over ``num_trials`` draws of the k cluster
+        columns at the given true ``balance``."""
+        k, tau = give_up_check(
+            self.S,
+            self.P,
+            self.T,
+            self.R,
             min_acc_rej,
-            empirical_pos,
-            failure_prob=failure_prob,
+            failure_prob=self.FAILURE_PROB,
         )
-        self.assertIsNotNone(result, "k too small")
-        k, threshold = result
-
-        num_trials = 5_000
-        rng = np.random.default_rng(42)
-        failures = 0
-
+        rng = np.random.default_rng(1234)
+        base = balance * (0.5 + self.S) + (1 - balance) * (0.5 - self.S)
+        fired = 0
         for _ in range(num_trials):
-            true_labels = rng.random(num_prefixes) < min_acc_rej
-            p_per_prefix = np.where(true_labels, p_accept, p_reject)
-            seed_obs = rng.random(num_prefixes) < p_per_prefix
-
-            is_idempotent = rng.random(num_suffixes) < r
-            all_obs = rng.random((num_suffixes, num_prefixes))
-            thresh = np.where(
-                is_idempotent[:, None],
-                p_per_prefix[None, :],
-                empirical_pos,
+            accept = rng.random(self.P) < balance
+            rates = (
+                np.where(accept, 0.5 + self.S, 0.5 - self.S)
+                if structured
+                else np.full(self.P, base)
             )
-            suffix_obs = all_obs < thresh
-            agreements = (suffix_obs == seed_obs[None, :]).mean(axis=1)
-            top_k_mean = np.sort(agreements)[-k:].mean()
+            columns = rng.random((k, self.P)) < rates[None, :]
+            fired += row_sum_dispersion(columns) <= tau
+        return fired / num_trials
 
-            if top_k_mean <= threshold:
-                failures += 1
-
-        empirical_failure_rate = failures / num_trials
-        print(
-            f"s={signal_strength}, P={num_prefixes}, r={r}, "
-            f"min_acc_rej={min_acc_rej}, T={num_suffixes}: "
-            f"k={k}, threshold={threshold:.4f}, "
-            f"empirical_failure={empirical_failure_rate:.4f}, "
-            f"target={failure_prob}"
-        )
-
-        # The bound is conservative (top-k >= random idempotent
-        # suffixes), so we only check the upper bound.
-        self.assertLess(empirical_failure_rate, failure_prob + 0.02)
-
-    def _spurious_give_up_rate(self, balance, min_acc_rej, *, num_trials=300):
-        """How often the check fires on prefixes that all carry full signal.
-
-        ``balance`` is the true share of the smaller class; ``min_acc_rej`` is
-        what the check is told to assume about it.
-        """
-        signal_strength, num_prefixes, num_suffixes, r = 0.40, 200, 958, 0.02
-        center = 0.5
-        p_accept, p_reject = center + signal_strength, center - signal_strength
-        empirical_pos = (1 - balance) * p_accept + balance * p_reject
-
-        result = give_up_check(
-            signal_strength,
-            num_prefixes,
-            num_suffixes,
-            r,
-            min_acc_rej,
-            empirical_pos,
-        )
-        self.assertIsNotNone(result, "k too small")
-        k, threshold = result
-
-        rng = np.random.default_rng(42)
-        failures = 0
-        for _ in range(num_trials):
-            true_labels = rng.random(num_prefixes) < 1 - balance
-            p_per_prefix = np.where(true_labels, p_accept, p_reject)
-            seed_obs = rng.random(num_prefixes) < p_per_prefix
-
-            is_idempotent = rng.random(num_suffixes) < r
-            all_obs = rng.random((num_suffixes, num_prefixes))
-            suffix_obs = all_obs < np.where(
-                is_idempotent[:, None], p_per_prefix[None, :], empirical_pos
+    def test_false_give_up_rate_is_neither_over_nor_under_bounded(self):
+        """At exactly ``min_acc_rej`` -- the least balance the bound permits --
+        the cluster does exist, so firing is a false give-up and its rate should
+        sit near ``failure_prob``.  Far above means the guarantee is broken; far
+        below means the bound is so slack the check can never fire."""
+        for min_acc_rej in (0.02, 0.1):
+            rate = self._give_up_rate(
+                min_acc_rej, structured=True, min_acc_rej=min_acc_rej
             )
-            agreements = (suffix_obs == seed_obs[None, :]).mean(axis=1)
-            if np.sort(agreements)[-k:].mean() <= threshold:
-                failures += 1
-        return failures / num_trials
+            self.assertLess(rate, 3 * self.FAILURE_PROB, f"m={min_acc_rej}")
+            self.assertGreater(rate, self.FAILURE_PROB / 4, f"m={min_acc_rej}")
 
-    @parameterized.expand([(0.02,), (0.03,), (0.077,), (0.2,), (0.5,)])
-    def test_default_bound_holds_for_everything_preconditions_admit(self, balance):
-        """``satisfies_preconditions`` rejects anything below
-        ``DEFAULT_MIN_ACC_REJ``, so every target that reaches the learner is at
-        least this balanced and must not be given up on for lack of signal it
-        has.  0.077 is CAPAL's Simple05."""
-        rate = self._spurious_give_up_rate(balance, DEFAULT_MIN_ACC_REJ)
-        self.assertLess(rate, 0.03, f"balance={balance}")
+    @parameterized.expand([(0.02, 0.077), (0.02, 0.2), (0.02, 0.5), (0.1, 0.5)])
+    def test_better_balanced_targets_are_conservative(self, min_acc_rej, balance):
+        """Dispersion under H0 grows with ``balance * (1 - balance)``, so a
+        target more balanced than the bound must fire even less often."""
+        rate = self._give_up_rate(balance, structured=True, min_acc_rej=min_acc_rej)
+        self.assertLessEqual(rate, self.FAILURE_PROB)
 
-    def test_gives_up_spuriously_once_the_bound_is_violated(self):
-        """The check is only sound while ``min_acc_rej`` really does bound the
-        balance: ``p_same`` adds ``8 * min_acc_rej * (1 - min_acc_rej) * s**2``,
-        a term the derivation gets by minimising over ``p_acc``.  Told 0.1 about
-        prefixes that are actually at 0.077, it gives up on full signal -- which
-        is why the precondition band exists rather than a larger constant.
-        """
-        self.assertGreater(self._spurious_give_up_rate(0.077, 0.1), 0.10)
+    def test_fires_when_there_is_no_cluster(self):
+        """The prefixes are exchangeable, so no family separates them and the
+        check has to say so."""
+        rate = self._give_up_rate(0.5, structured=False, min_acc_rej=0.1)
+        self.assertGreater(rate, 0.9)
 
     def test_gives_up_with_no_signal(self):
         """With p_0 = p_1 = 0.5 (pure coin-flip), the oracle has no signal.

--- a/tests/test_preconditions.py
+++ b/tests/test_preconditions.py
@@ -159,7 +159,19 @@ class TestSatisfiesPreconditions(unittest.TestCase):
         for finals in ({0}, set()):
             report = P.satisfies_preconditions(_constant_dfa(finals), length=40)
             self.assertFalse(report)
-            self.assertIn("degenerate", report.reasons[0])
+            self.assertIn("acceptance rate", report.reasons[0])
+
+    def test_acceptance_rate_band_matches_the_give_up_bound(self):
+        # The band is give_up_check's assumption about its prefixes, so a target
+        # skewed past it is rejected rather than run and given up on.
+        skewed = P.satisfies_preconditions(
+            MOD9_SKEWED, length=40, min_accept_or_reject=0.2
+        )
+        self.assertFalse(skewed)
+        self.assertIn("acceptance rate", skewed.reasons[0])
+        self.assertTrue(
+            P.satisfies_preconditions(MOD9_SKEWED, length=40, min_accept_or_reject=0.02)
+        )
 
     def test_skewed_but_non_degenerate_target_passes(self):
         # Only 13% accepted, so the acceptance-rate check must not impose


### PR DESCRIPTION
`give_up_check` scored the mean agreement between the top-k columns and the seed column. That statistic is wrong in two independent ways, and both inflate the threshold, so both cause false give-ups.

## Defect 1 — the balance bound is unenforceable as a constant

The threshold needs `p_same`, hence the `8 * p_acc * (1 - p_acc) * s**2` term, hence a **lower bound** on the prefix accept/reject balance. `min_acc_rej` was a `SearchConfig` constant of 0.1, never measured, not settable.

Too large and it gives up on real signal — CAPAL's `Simple05` has balance 0.077, and the false give-up rate there is **0.153** against a claimed 0.01. Too small and no-signal detection collapses: the prefixes required scale as `1/m^2`, so 0.1 -> 0.02 needs **~25x more**.

| true balance | false give-up @ m=0.1 |
| ---: | ---: |
| 0.100 (at the bound) | 0.018 |
| 0.077 (Simple05) | **0.153** |
| 0.050 | 0.777 |
| 0.030 | 0.965 |

No constant satisfies both ends.

## Defect 2 — the null distribution is wrong for every target

`sum_ij w_ij ~ Bin(kP, p_same)` assumes the kP indicators are independent. They are not: every `w_ij` in a row compares against the **same** seed draw `v_i0`. Conditioned on it, a row is `Bin(k, q)` or `Bin(k, 1-q)` — a mixture, not `Bin(k, a(q))`.

At q=0.8, k=9: assumed variance 1.96, true 6.11. Correlation 0.27-0.39, design effect 3-7x, growing with k. So the threshold sits above the true quantile:

| k | tau (binomial) | true quantile | Pr[give up given signal] |
| ---: | ---: | ---: | ---: |
| 9 | 0.6500 | 0.6272 | **0.0646** |
| 24 | 0.6742 | 0.6643 | **0.1575** |

against a nominal 0.0033. This is live on main, independent of skew, and gets **worse** as more suffixes accumulate.

## The change

Score the dispersion of per-prefix row sums over the cluster columns instead:

    R_i = sum_j v_ij                    over the k selected columns
    X2/df = sum_i (R_i - k*mu)^2 / (k*mu*(1-mu)) / (P-1)

- **No seed term**, so the k readings in a prefix are independent given its class. Defect 2 is gone by construction, not by a design-effect patch.
- `E[X2]/df = 1 + 4*k*p*(1-p)*s**2 / (mu*(1-mu))` is **monotone in `p(1-p)`**, so evaluating at `p = min_acc_rej` gives the least dispersion H0 permits, and a lower-tail threshold there is valid for every better-balanced target. The bound finally does what it claims.
- It is a **lower**-tail test — give up when dispersion is implausibly low. Selecting columns by seed agreement *inflates* dispersion, and inflation cannot trip a lower-tail test, so the selection needs no correction.
- **Power grows with k** rather than degrading, so accumulating suffixes now helps the decision.

H0 remains "the cluster exists", so `Pr[give up | cluster exists] <= failure_prob` is still the guarantee and the destructive error stays in the bounded slot.

`tau` comes from simulating row sums directly out of the two-class mixture — P draws per replicate, not a k-by-P matrix — so it stays cheap as k and P grow.

### Defect 3 — the model has to be pinned to the observed rate

Found by CI on the first version of this, and worth stating because it is subtle. The statistic normalises by the observed `mu_hat`, so `tau` must be simulated at that same rate. Deriving an expected rate from a supplied `center` instead compared the data against a threshold built for a different population, and `tau` swung between 0.85 and 1.8 on `center` and `P` alone. `idx=567` gave up at `1.800 <= 1.803` against a threshold belonging to a population it was not drawn from.

`center` was never obtainable anyway — it is the *noise* centre, 0.5 only under symmetric noise, and `pst.decision_boundary` is a different quantity that drifts during the search.

Fixing `mu` to the observed rate also constrains the balance, since both class rates must stay in [0, 1]:

    c - s = mu - 2ps      >= 0  =>  p <= mu/(2s)
    c + s = mu + 2s(1-p)  <= 1  =>  p >= 1 - (1-mu)/(2s)

So the worst case is the feasible endpoint minimising `p(1-p)`, not `min_acc_rej` unconditionally — at `mu=0.5, s=0.45` the range is `[0.444, 0.556]` and the bound does not bind at all. Rates now land in [0, 1] by construction, so the clip that was silently distorting the model is gone, and an empty range means no population fits the evidence, which returns `None` rather than testing against nonsense.

## Calibration

Nominal `failure_prob = 0.01`:

| m | true balance | k | tau | false give-up |
| ---: | ---: | ---: | ---: | ---: |
| 0.02 | **0.02** (at the bound) | 9 | 0.906 | **0.0087** |
| 0.02 | 0.077 | 9 | 0.906 | 0.0000 |
| 0.02 | 0.5 | 9 | 0.906 | 0.0000 |
| 0.1 | **0.1** (at the bound) | 9 | 1.666 | **0.0060** |
| 0.1 | 0.5 | 9 | 1.666 | 0.0000 |
| 0.1 | no cluster | 9 | 1.666 | detect 1.0000 |

Tight at the bound — not 10x over (guarantee broken) and not ~0 (so slack it could never fire) — and conservative above it, which is the monotonicity doing its job.

`test_false_give_up_rate_is_neither_over_nor_under_bounded` asserts both sides. `test_better_balanced_targets_are_conservative` covers the monotonicity, `test_fires_when_there_is_no_cluster` the power.

## Also here

`min_acc_rej` becomes a real parameter (`DEFAULT_MIN_ACC_REJ = 0.02`), threaded through `learn_dfa` -> `build_pst` -> `SearchConfig`, and `satisfies_preconditions` gates on the same bound so the assumption is enforced rather than asserted. That reinstates an acceptance-rate band three PRs after #143 removed one, but #143's was 0.15 with no derivation; this is exactly the learner's own assumption. Constant languages stay rejected, since 0.0 and 1.0 fall outside it.

`test_rarely_gives_up_when_evidence_present` is dropped — it made this claim against the old statistic, and the two calibration tests make it against the new one.

## What is not fixed

At `m=0.02, k=9` the power to detect no-cluster is 0.14, rising to 0.64 by k=40. Low `m` buys less power; that is the real trade in setting the bound, and it is now visible rather than corrupting the false give-up rate. `sample_suffix_family`'s `while True` still has no iteration cap, so a target with no structure and few suffixes grinds regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
