### PR TITLE
Add SpliceModelOracle: a batching adapter for splice-model E-L* oracles

### DIFF
--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -1,23 +1,3 @@
-r"""An E-L\* membership oracle backed by a splice model (e.g. SpliceAI).
-
-:class:`SpliceModelOracle` is only a **batching / format adapter**: it takes E-L\*'s
-ragged ``List[List[int]]`` queries (variable-length middles over {A,C,G,T}), wraps
-each with the exon's fixed flanks, right-pads the batch to a rectangle, chunks it,
-and returns a numpy bool array. It does no model evaluation and no calibration of
-its own -- those live in the ``scorer`` you pass in.
-
-A ``scorer`` is any callable ``(wrapped, lengths) -> np.ndarray[bool]`` where
-``wrapped`` is the padded ``(n, width)`` int array of flank+middle+flank sequences
-and ``lengths`` is the ``(n,)`` array of middle lengths. Build a calibrated SpliceAI
-scorer with :func:`calibrated_spliceai_scorer` (the calibration -- i.e. the accept
-threshold -- is computed outside the oracle, e.g. via :func:`median_threshold`)::
-
-    model = load_spliceai(400, 0)
-    threshold = median_threshold(model, exon, length=95)   # calibrate OUTSIDE
-    scorer = calibrated_spliceai_scorer(model, threshold)  # model + calibration
-    oracle = SpliceModelOracle(exon, scorer)               # just batching
-"""
-
 from typing import Callable, List
 
 import numpy as np
@@ -25,19 +5,12 @@ import numpy as np
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.l_star.structures import Oracle
 
-# A scorer maps a padded batch of wrapped sequences + their middle lengths to a
-# per-sequence hard accept/reject call.
+# (wrapped [n, width] int, middle lengths [n]) -> accept mask [n] bool
 Scorer = Callable[[np.ndarray, np.ndarray], np.ndarray]
 
 
 def wrap_with_flanks(flank_l, flank_r, strings):
-    """Right-pad a ragged batch of middles wrapped in the flanks to a rectangle.
-
-    Returns ``(wrapped, lengths)`` where ``wrapped`` is ``(n, width)`` int64 with
-    each row ``flank_l + middle + flank_r`` followed by ``0`` padding, and
-    ``lengths`` is the ``(n,)`` array of middle lengths. Padding sits after
-    ``flank_r`` so a convolutional splice model's boundary outputs are unaffected.
-    """
+    """Wrap each middle as flank_l+middle+flank_r, right-pad to a rectangle, and return (wrapped, middle_lengths)."""
     lengths = np.array([len(s) for s in strings], dtype=np.int64)
     flank = len(flank_l) + len(flank_r)
     width = int(flank + (lengths.max() if len(strings) else 0))
@@ -49,12 +22,7 @@ def wrap_with_flanks(flank_l, flank_r, strings):
 
 
 class SpliceModelOracle(Oracle):
-    r"""Batching/format adapter turning a calibrated ``scorer`` into an E-L\* oracle.
-
-    Wraps each queried middle with the exon flanks, right-pads ragged batches,
-    chunks, and converts to/from numpy -- nothing else. All model evaluation and
-    calibration lives in ``scorer`` (see the module docstring).
-    """
+    r"""E-L\* oracle that only batches: it wraps/pads/chunks queries and defers scoring to ``scorer``."""
 
     def __init__(self, exon: RawExon, scorer: Scorer, *, chunk: int = 8192):
         trim = exon.cl // 2 + 2
@@ -86,16 +54,8 @@ class SpliceModelOracle(Oracle):
         return bool(self.membership_queries([string])[0])
 
 
-# -- SpliceAI scorer + calibration (external to the oracle) --------------------
-
-
 def spliceai_exon_scores(model, wrapped: np.ndarray, lengths: np.ndarray) -> np.ndarray:
-    """Continuous exon score for each wrapped sequence: the mean of the acceptor
-    logit at the 5' boundary (output position 0) and the donor logit at the 3'
-    boundary (output position ``len(middle)+3``). Mirrors
-    :func:`orthogonal_dfa.oracle.run_model.compute_exon_scores`, but gathers the
-    donor position per row (it shifts with the middle length in a ragged batch).
-    """
+    """Exon score per wrapped sequence: mean of the acceptor logit at output position 0 and the donor logit at len(middle)+3."""
     import torch
 
     from orthogonal_dfa.oracle.run_model import batched_run
@@ -110,7 +70,7 @@ def spliceai_exon_scores(model, wrapped: np.ndarray, lengths: np.ndarray) -> np.
 
 
 def calibrated_spliceai_scorer(model, threshold: float) -> Scorer:
-    """A scorer with calibration built in: SpliceAI exon score > ``threshold``."""
+    """Scorer that accepts when the SpliceAI exon score exceeds ``threshold``."""
 
     def scorer(wrapped, lengths):
         return spliceai_exon_scores(model, wrapped, lengths) > threshold
@@ -119,10 +79,7 @@ def calibrated_spliceai_scorer(model, threshold: float) -> Scorer:
 
 
 def median_threshold(model, exon: RawExon, length: int, *, count=20000, seed=0xCA11B):
-    """Calibration (done outside the oracle): the median exon score over ``count``
-    random length-``length`` middles, so a scorer thresholding above it accepts
-    ~50%. The exon score drifts with middle length, hence calibrating per length.
-    """
+    """Median exon score over ``count`` random length-``length`` middles (per-length since the score drifts with length)."""
     rng = np.random.default_rng(seed)
     mids = rng.integers(0, 4, size=(count, length)).tolist()
     trim = exon.cl // 2 + 2

--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -1,0 +1,134 @@
+r"""An E-L\* membership oracle backed by a splice model (e.g. SpliceAI).
+
+:class:`SpliceModelOracle` is only a **batching / format adapter**: it takes E-L\*'s
+ragged ``List[List[int]]`` queries (variable-length middles over {A,C,G,T}), wraps
+each with the exon's fixed flanks, right-pads the batch to a rectangle, chunks it,
+and returns a numpy bool array. It does no model evaluation and no calibration of
+its own -- those live in the ``scorer`` you pass in.
+
+A ``scorer`` is any callable ``(wrapped, lengths) -> np.ndarray[bool]`` where
+``wrapped`` is the padded ``(n, width)`` int array of flank+middle+flank sequences
+and ``lengths`` is the ``(n,)`` array of middle lengths. Build a calibrated SpliceAI
+scorer with :func:`calibrated_spliceai_scorer` (the calibration -- i.e. the accept
+threshold -- is computed outside the oracle, e.g. via :func:`median_threshold`)::
+
+    model = load_spliceai(400, 0)
+    threshold = median_threshold(model, exon, length=95)   # calibrate OUTSIDE
+    scorer = calibrated_spliceai_scorer(model, threshold)  # model + calibration
+    oracle = SpliceModelOracle(exon, scorer)               # just batching
+"""
+
+from typing import Callable, List
+
+import numpy as np
+
+from orthogonal_dfa.data.exon import RawExon
+from orthogonal_dfa.l_star.structures import Oracle
+
+# A scorer maps a padded batch of wrapped sequences + their middle lengths to a
+# per-sequence hard accept/reject call.
+Scorer = Callable[[np.ndarray, np.ndarray], np.ndarray]
+
+
+def wrap_with_flanks(flank_l, flank_r, strings):
+    """Right-pad a ragged batch of middles wrapped in the flanks to a rectangle.
+
+    Returns ``(wrapped, lengths)`` where ``wrapped`` is ``(n, width)`` int64 with
+    each row ``flank_l + middle + flank_r`` followed by ``0`` padding, and
+    ``lengths`` is the ``(n,)`` array of middle lengths. Padding sits after
+    ``flank_r`` so a convolutional splice model's boundary outputs are unaffected.
+    """
+    lengths = np.array([len(s) for s in strings], dtype=np.int64)
+    flank = len(flank_l) + len(flank_r)
+    width = int(flank + (lengths.max() if len(strings) else 0))
+    wrapped = np.zeros((len(strings), width), dtype=np.int64)
+    for i, s in enumerate(strings):
+        row = np.concatenate([flank_l, np.asarray(s, dtype=np.int64), flank_r])
+        wrapped[i, : len(row)] = row
+    return wrapped, lengths
+
+
+class SpliceModelOracle(Oracle):
+    r"""Batching/format adapter turning a calibrated ``scorer`` into an E-L\* oracle.
+
+    Wraps each queried middle with the exon flanks, right-pads ragged batches,
+    chunks, and converts to/from numpy -- nothing else. All model evaluation and
+    calibration lives in ``scorer`` (see the module docstring).
+    """
+
+    def __init__(self, exon: RawExon, scorer: Scorer, *, chunk: int = 8192):
+        trim = exon.cl // 2 + 2
+        self._flank_l = np.array(exon.text[:trim], dtype=np.int64)
+        self._flank_r = np.array(exon.text[-trim:], dtype=np.int64)
+        self._length = exon.random_text_length
+        self._scorer = scorer
+        self._chunk = chunk
+
+    @property
+    def alphabet_size(self) -> int:
+        return 4
+
+    @property
+    def string_length(self) -> int:
+        return self._length
+
+    def membership_queries(self, strings: List[List[int]]) -> np.ndarray:
+        out = np.empty(len(strings), dtype=bool)
+        for i in range(0, len(strings), self._chunk):
+            batch = strings[i : i + self._chunk]
+            wrapped, lengths = wrap_with_flanks(self._flank_l, self._flank_r, batch)
+            out[i : i + self._chunk] = np.asarray(
+                self._scorer(wrapped, lengths), dtype=bool
+            )
+        return out
+
+    def membership_query(self, string: List[int]) -> bool:
+        return bool(self.membership_queries([string])[0])
+
+
+# -- SpliceAI scorer + calibration (external to the oracle) --------------------
+
+
+def spliceai_exon_scores(model, wrapped: np.ndarray, lengths: np.ndarray) -> np.ndarray:
+    """Continuous exon score for each wrapped sequence: the mean of the acceptor
+    logit at the 5' boundary (output position 0) and the donor logit at the 3'
+    boundary (output position ``len(middle)+3``). Mirrors
+    :func:`orthogonal_dfa.oracle.run_model.compute_exon_scores`, but gathers the
+    donor position per row (it shifts with the middle length in a ragged batch).
+    """
+    import torch
+
+    from orthogonal_dfa.oracle.run_model import batched_run
+
+    with torch.no_grad():
+        lyp = batched_run(model, wrapped).log_softmax(-1)
+        rows = torch.arange(len(wrapped), device=lyp.device)
+        don_pos = torch.tensor(lengths + 3, device=lyp.device)
+        acc = lyp[rows, 0, 1]
+        don = lyp[rows, don_pos, 2]
+        return torch.stack([acc, don], -1).mean(-1).cpu().numpy()
+
+
+def calibrated_spliceai_scorer(model, threshold: float) -> Scorer:
+    """A scorer with calibration built in: SpliceAI exon score > ``threshold``."""
+
+    def scorer(wrapped, lengths):
+        return spliceai_exon_scores(model, wrapped, lengths) > threshold
+
+    return scorer
+
+
+def median_threshold(model, exon: RawExon, length: int, *, count=20000, seed=0xCA11B):
+    """Calibration (done outside the oracle): the median exon score over ``count``
+    random length-``length`` middles, so a scorer thresholding above it accepts
+    ~50%. The exon score drifts with middle length, hence calibrating per length.
+    """
+    rng = np.random.default_rng(seed)
+    mids = rng.integers(0, 4, size=(count, length)).tolist()
+    trim = exon.cl // 2 + 2
+    wrapped, lengths = wrap_with_flanks(
+        np.array(exon.text[:trim], dtype=np.int64),
+        np.array(exon.text[-trim:], dtype=np.int64),
+        mids,
+    )
+    return float(np.median(spliceai_exon_scores(model, wrapped, lengths)))

--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -2,19 +2,19 @@ from typing import Callable, List
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 from permacache import permacache, stable_hash
 
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.l_star.structures import Oracle
+from orthogonal_dfa.spliceai.exon_score import (
+    FLANK_MARGIN,
+    device_of,
+    forward_batch,
+    spliceai_exon_scores,
+)
 
 # (model output tensor, middle lengths tensor) -> per-sequence value tensor
 Readout = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
-
-# Each flank keeps this many bases beyond the model's cl/2 half-context (matching
-# data.sample_text's trim_zone = cl//2 + 2), so the output spans len(middle) +
-# 2*FLANK_MARGIN positions: the acceptor is the first, the donor the last.
-FLANK_MARGIN = 2
 
 CALIBRATION_SEED = int(stable_hash("calibration"), 16)
 
@@ -29,7 +29,14 @@ def flanks(exon: RawExon):
 
 
 def wrap_with_flanks(flank_l, flank_r, strings):
-    """Wrap each middle as flank_l+middle+flank_r, right-pad to a rectangle, and return (wrapped, middle_lengths)."""
+    """Wrap each middle as flank_l+middle+flank_r, right-pad to a rectangle, and
+    return (wrapped, middle_lengths).
+
+    The pad value is arbitrary: a row's acceptor and donor readout positions sit
+    cl/2 inside the row's own last real base, so neither one's receptive field
+    ever reaches the padding, whatever the rest of the batch is.  That holds only
+    with the model in eval mode -- BatchNorm over batch statistics would let the
+    padded rows leak into every other row."""
     lengths = np.array([len(s) for s in strings], dtype=np.int64)
     flank = len(flank_l) + len(flank_r)
     width = int(flank + (lengths.max() if len(strings) else 0))
@@ -41,28 +48,23 @@ def wrap_with_flanks(flank_l, flank_r, strings):
 
 
 def run_over_middles(model, flank_l, flank_r, strings, readout, *, device, chunk):
-    """Flank-wrap, one-hot, and run ``model`` (no_grad) over ``strings`` in chunks,
-    returning np.concatenate of ``readout(logits, lengths)``."""
+    """Flank-wrap and run ``model`` over ``strings`` in chunks, returning
+    np.concatenate of ``readout(logits, lengths)``."""
     parts = []
     for i in range(0, len(strings), chunk):
         wrapped, lengths = wrap_with_flanks(flank_l, flank_r, strings[i : i + chunk])
-        # pylint: disable=not-callable
-        x = F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
+        logits = forward_batch(model, wrapped, device=device)
         lens = torch.as_tensor(lengths, device=device)
-        with torch.no_grad():
-            parts.append(readout(model(x), lens).cpu().numpy())
-    return np.concatenate(parts) if parts else np.empty(0)
-
-
-def _device_of(model, device):
-    return (
-        torch.device(device) if device is not None else next(model.parameters()).device
-    )
+        parts.append(readout(logits, lens).cpu().numpy())
+    return np.concatenate(parts) if parts else np.empty(0, dtype=bool)
 
 
 class SpliceModelOracle(Oracle):
     r"""E-L\* oracle that wraps/one-hots/batches queries and runs ``model`` (eval,
-    no_grad, on ``device``), deferring the accept decision to ``readout``."""
+    no_grad, on ``device``), deferring the accept decision to ``readout``.
+
+    ``model`` is left on its own device unless ``device`` is passed, which only
+    picks where the inputs go -- it does not move the model."""
 
     def __init__(
         self, exon: RawExon, model, readout: Readout, *, device=None, chunk: int = 1024
@@ -70,7 +72,7 @@ class SpliceModelOracle(Oracle):
         model.eval()
         self._model = model
         self._readout = readout
-        self._device = _device_of(model, device)
+        self._device = device_of(model, device)
         self._flank_l, self._flank_r = flanks(exon)
         self._length = exon.random_text_length
         self._chunk = chunk
@@ -99,16 +101,6 @@ class SpliceModelOracle(Oracle):
         return bool(self.membership_queries([string])[0])
 
 
-def spliceai_exon_scores(logits: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
-    """Exon score per sequence: mean of the acceptor logit at the first output
-    position and the donor logit at the last."""
-    lyp = logits.log_softmax(-1)
-    rows = torch.arange(len(lyp), device=lyp.device)
-    acc = lyp[rows, 0, 1]
-    don = lyp[rows, lengths + 2 * FLANK_MARGIN - 1, 2]
-    return torch.stack([acc, don], -1).mean(-1)
-
-
 def calibrated_spliceai_readout(threshold: float) -> Readout:
     """Readout that accepts when the SpliceAI exon score exceeds ``threshold``."""
     return lambda logits, lengths: spliceai_exon_scores(logits, lengths) > threshold
@@ -131,10 +123,17 @@ def median_threshold(
     count=20000,
     seed=CALIBRATION_SEED,
     device=None,
-    chunk=1024
+    chunk=1024,
 ):
     """Median exon score over ``count`` random length-``length`` middles (per-length
-    since the score drifts with length)."""
+    since the score drifts with length).
+
+    oracle.run_model calibrates its dataset with a z-score thresholded at 0, i.e.
+    at the *mean*; the median here instead puts the accept rate at exactly 0.5
+    whatever the score distribution's skew, which is what E-L*'s degeneracy
+    precondition wants.  The two conventions will disagree on borderline
+    sequences, so do not mix a dataset built by one with an oracle built by the
+    other."""
     model.eval()
     flank_l, flank_r = flanks(exon)
     mids = np.random.default_rng(seed).integers(0, 4, size=(count, length)).tolist()
@@ -144,7 +143,7 @@ def median_threshold(
         flank_r,
         mids,
         spliceai_exon_scores,
-        device=_device_of(model, device),
+        device=device_of(model, device),
         chunk=chunk,
     )
     return float(np.median(scores))

--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -41,10 +41,12 @@ def wrap_with_flanks(flank_l, flank_r, strings):
 
 
 def run_over_middles(model, flank_l, flank_r, strings, readout, *, device, chunk):
-    """Flank-wrap, one-hot, and run ``model`` (no_grad) over ``strings`` in chunks, returning np.concatenate of ``readout(logits, lengths)``."""
+    """Flank-wrap, one-hot, and run ``model`` (no_grad) over ``strings`` in chunks,
+    returning np.concatenate of ``readout(logits, lengths)``."""
     parts = []
     for i in range(0, len(strings), chunk):
         wrapped, lengths = wrap_with_flanks(flank_l, flank_r, strings[i : i + chunk])
+        # pylint: disable=not-callable
         x = F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
         lens = torch.as_tensor(lengths, device=device)
         with torch.no_grad():
@@ -59,7 +61,8 @@ def _device_of(model, device):
 
 
 class SpliceModelOracle(Oracle):
-    r"""E-L\* oracle that wraps/one-hots/batches queries and runs ``model`` (eval, no_grad, on ``device``), leaving the accept decision to ``readout``."""
+    r"""E-L\* oracle that wraps/one-hots/batches queries and runs ``model`` (eval,
+    no_grad, on ``device``), deferring the accept decision to ``readout``."""
 
     def __init__(
         self, exon: RawExon, model, readout: Readout, *, device=None, chunk: int = 1024
@@ -97,7 +100,8 @@ class SpliceModelOracle(Oracle):
 
 
 def spliceai_exon_scores(logits: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
-    """Exon score per sequence: mean of the acceptor logit at the first output position and the donor logit at the last."""
+    """Exon score per sequence: mean of the acceptor logit at the first output
+    position and the donor logit at the last."""
     lyp = logits.log_softmax(-1)
     rows = torch.arange(len(lyp), device=lyp.device)
     acc = lyp[rows, 0, 1]
@@ -129,7 +133,8 @@ def median_threshold(
     device=None,
     chunk=1024
 ):
-    """Median exon score over ``count`` random length-``length`` middles (per-length since the score drifts with length)."""
+    """Median exon score over ``count`` random length-``length`` middles (per-length
+    since the score drifts with length)."""
     model.eval()
     flank_l, flank_r = flanks(exon)
     mids = np.random.default_rng(seed).integers(0, 4, size=(count, length)).tolist()

--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -10,6 +10,11 @@ from orthogonal_dfa.l_star.structures import Oracle
 # (model output tensor, middle lengths tensor) -> accept mask bool tensor
 Readout = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
+# Each flank keeps this many bases beyond the model's cl/2 half-context (matching
+# data.sample_text's trim_zone = cl//2 + 2), so the output spans len(middle) +
+# 2*FLANK_MARGIN positions: the acceptor is the first, the donor the last.
+FLANK_MARGIN = 2
+
 
 def wrap_with_flanks(flank_l, flank_r, strings):
     """Wrap each middle as flank_l+middle+flank_r, right-pad to a rectangle, and return (wrapped, middle_lengths)."""
@@ -37,7 +42,7 @@ class SpliceModelOracle(Oracle):
             if device is not None
             else next(model.parameters()).device
         )
-        trim = exon.cl // 2 + 2
+        trim = exon.cl // 2 + FLANK_MARGIN
         self._flank_l = np.array(exon.text[:trim], dtype=np.int64)
         self._flank_r = np.array(exon.text[-trim:], dtype=np.int64)
         self._length = exon.random_text_length
@@ -69,11 +74,11 @@ class SpliceModelOracle(Oracle):
 
 
 def spliceai_exon_scores(logits: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
-    """Exon score per sequence: mean of the acceptor logit at output position 0 and the donor logit at len(middle)+3."""
+    """Exon score per sequence: mean of the acceptor logit at the first output position and the donor logit at the last."""
     lyp = logits.log_softmax(-1)
     rows = torch.arange(len(lyp), device=lyp.device)
     acc = lyp[rows, 0, 1]
-    don = lyp[rows, lengths + 3, 2]
+    don = lyp[rows, lengths + 2 * FLANK_MARGIN - 1, 2]
     return torch.stack([acc, don], -1).mean(-1)
 
 
@@ -97,7 +102,7 @@ def median_threshold(
     device = (
         torch.device(device) if device is not None else next(model.parameters()).device
     )
-    trim = exon.cl // 2 + 2
+    trim = exon.cl // 2 + FLANK_MARGIN
     flank_l = np.array(exon.text[:trim], dtype=np.int64)
     flank_r = np.array(exon.text[-trim:], dtype=np.int64)
     rng = np.random.default_rng(seed)

--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -3,17 +3,27 @@ from typing import Callable, List
 import numpy as np
 import torch
 import torch.nn.functional as F
+from permacache import permacache, stable_hash
 
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.l_star.structures import Oracle
 
-# (model output tensor, middle lengths tensor) -> accept mask bool tensor
+# (model output tensor, middle lengths tensor) -> per-sequence value tensor
 Readout = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
 # Each flank keeps this many bases beyond the model's cl/2 half-context (matching
 # data.sample_text's trim_zone = cl//2 + 2), so the output spans len(middle) +
 # 2*FLANK_MARGIN positions: the acceptor is the first, the donor the last.
 FLANK_MARGIN = 2
+
+
+def flanks(exon: RawExon):
+    """The (left, right) fixed flanks the middle is wrapped in, as int arrays."""
+    trim = exon.cl // 2 + FLANK_MARGIN
+    return (
+        np.array(exon.text[:trim], dtype=np.int64),
+        np.array(exon.text[-trim:], dtype=np.int64),
+    )
 
 
 def wrap_with_flanks(flank_l, flank_r, strings):
@@ -28,6 +38,24 @@ def wrap_with_flanks(flank_l, flank_r, strings):
     return wrapped, lengths
 
 
+def run_over_middles(model, flank_l, flank_r, strings, readout, *, device, chunk):
+    """Flank-wrap, one-hot, and run ``model`` (no_grad) over ``strings`` in chunks, returning np.concatenate of ``readout(logits, lengths)``."""
+    parts = []
+    for i in range(0, len(strings), chunk):
+        wrapped, lengths = wrap_with_flanks(flank_l, flank_r, strings[i : i + chunk])
+        x = F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
+        lens = torch.as_tensor(lengths, device=device)
+        with torch.no_grad():
+            parts.append(readout(model(x), lens).cpu().numpy())
+    return np.concatenate(parts) if parts else np.empty(0)
+
+
+def _device_of(model, device):
+    return (
+        torch.device(device) if device is not None else next(model.parameters()).device
+    )
+
+
 class SpliceModelOracle(Oracle):
     r"""E-L\* oracle that wraps/one-hots/batches queries and runs ``model`` (eval, no_grad, on ``device``), leaving the accept decision to ``readout``."""
 
@@ -37,14 +65,8 @@ class SpliceModelOracle(Oracle):
         model.eval()
         self._model = model
         self._readout = readout
-        self._device = (
-            torch.device(device)
-            if device is not None
-            else next(model.parameters()).device
-        )
-        trim = exon.cl // 2 + FLANK_MARGIN
-        self._flank_l = np.array(exon.text[:trim], dtype=np.int64)
-        self._flank_r = np.array(exon.text[-trim:], dtype=np.int64)
+        self._device = _device_of(model, device)
+        self._flank_l, self._flank_r = flanks(exon)
         self._length = exon.random_text_length
         self._chunk = chunk
 
@@ -57,17 +79,16 @@ class SpliceModelOracle(Oracle):
         return self._length
 
     def membership_queries(self, strings: List[List[int]]) -> np.ndarray:
-        out = np.empty(len(strings), dtype=bool)
-        for i in range(0, len(strings), self._chunk):
-            wrapped, lengths = wrap_with_flanks(
-                self._flank_l, self._flank_r, strings[i : i + self._chunk]
-            )
-            x = F.one_hot(torch.as_tensor(wrapped, device=self._device), 4).float()
-            lens = torch.as_tensor(lengths, device=self._device)
-            with torch.no_grad():
-                pred = self._readout(self._model(x), lens)
-            out[i : i + self._chunk] = pred.cpu().numpy().astype(bool)
-        return out
+        preds = run_over_middles(
+            self._model,
+            self._flank_l,
+            self._flank_r,
+            strings,
+            self._readout,
+            device=self._device,
+            chunk=self._chunk,
+        )
+        return preds.astype(bool)
 
     def membership_query(self, string: List[int]) -> bool:
         return bool(self.membership_queries([string])[0])
@@ -87,6 +108,15 @@ def calibrated_spliceai_readout(threshold: float) -> Readout:
     return lambda logits, lengths: spliceai_exon_scores(logits, lengths) > threshold
 
 
+@permacache(
+    "orthogonal_dfa/l_star/examples/spliceai_oracle/median_threshold",
+    key_function=dict(
+        model=lambda m: stable_hash(m, version=2),
+        exon=stable_hash,
+        device=lambda _: None,  # does not affect the result
+        chunk=lambda _: None,
+    ),
+)
 def median_threshold(
     model,
     exon: RawExon,
@@ -99,19 +129,15 @@ def median_threshold(
 ):
     """Median exon score over ``count`` random length-``length`` middles (per-length since the score drifts with length)."""
     model.eval()
-    device = (
-        torch.device(device) if device is not None else next(model.parameters()).device
+    flank_l, flank_r = flanks(exon)
+    mids = np.random.default_rng(seed).integers(0, 4, size=(count, length)).tolist()
+    scores = run_over_middles(
+        model,
+        flank_l,
+        flank_r,
+        mids,
+        spliceai_exon_scores,
+        device=_device_of(model, device),
+        chunk=chunk,
     )
-    trim = exon.cl // 2 + FLANK_MARGIN
-    flank_l = np.array(exon.text[:trim], dtype=np.int64)
-    flank_r = np.array(exon.text[-trim:], dtype=np.int64)
-    rng = np.random.default_rng(seed)
-    scores = []
-    for i in range(0, count, chunk):
-        mids = rng.integers(0, 4, size=(min(chunk, count - i), length)).tolist()
-        wrapped, lengths = wrap_with_flanks(flank_l, flank_r, mids)
-        x = F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
-        lens = torch.as_tensor(lengths, device=device)
-        with torch.no_grad():
-            scores.append(spliceai_exon_scores(model(x), lens).cpu().numpy())
-    return float(np.median(np.concatenate(scores)))
+    return float(np.median(scores))

--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -61,8 +61,12 @@ def run_over_middles(model, flank_l, flank_r, strings, readout, *, device, chunk
 
 
 class SpliceModelOracle(Oracle):
-    r"""E-L\* oracle that wraps/one-hots/batches queries and runs ``model`` (eval,
+    r"""E-L\* oracle that wraps/one-hots/batches queries and runs ``model`` (under
     no_grad, on ``device``), deferring the accept decision to ``readout``.
+
+    ``model`` must already be in eval mode -- forward_batch checks that on every
+    query rather than this setting it, so a caller who shares the model with a
+    training loop hears about it instead of having it silently switched.
 
     ``model`` is left on its own device unless ``device`` is passed, which only
     picks where the inputs go -- it does not move the model."""
@@ -70,7 +74,6 @@ class SpliceModelOracle(Oracle):
     def __init__(
         self, exon: RawExon, model, readout: Readout, *, device=None, chunk: int = 1024
     ):
-        model.eval()
         self._model = model
         self._readout = readout
         self._device = device_of(model, device)
@@ -162,8 +165,10 @@ def median_threshold(
     whatever the score distribution's skew, which is what E-L*'s degeneracy
     precondition wants.  The two conventions will disagree on borderline
     sequences, so do not mix a dataset built by one with an oracle built by the
-    other."""
-    model.eval()
+    other.
+
+    ``model`` must already be in eval mode; forward_batch checks it, which a
+    permacache hit would skip along with the rest of the body."""
     flank_l, flank_r = flanks(exon)
     mids = np.random.default_rng(seed).integers(0, 4, size=(count, length)).tolist()
     scores = run_over_middles(

--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable, List
 
 import numpy as np
@@ -101,9 +102,37 @@ class SpliceModelOracle(Oracle):
         return bool(self.membership_queries([string])[0])
 
 
-def calibrated_spliceai_readout(threshold: float) -> Readout:
-    """Readout that accepts when the SpliceAI exon score exceeds ``threshold``."""
-    return lambda logits, lengths: spliceai_exon_scores(logits, lengths) > threshold
+class _CalibratedReadout:
+    """Accepts when the exon score exceeds ``threshold``, warning when queried at
+    a length ``threshold`` was not calibrated for.
+
+    The score drifts with length, so a threshold is only near its intended accept
+    rate close to its own calibration length -- one calibrated at 40 accepts ~77%
+    of random length-80 middles.  E-L* queries a few lengths at once (2L for the
+    probes, L..L+4 for the core), so this warns once per length rather than
+    failing; until the threshold is per-length, expect the off-length rows to sit
+    off 0.5."""
+
+    def __init__(self, threshold: float, length: int):
+        self.threshold = threshold
+        self.calibration_length = length
+        self._warned = set()
+
+    def __call__(self, logits, lengths):
+        for length in set(lengths.tolist()) - self._warned - {self.calibration_length}:
+            self._warned.add(length)
+            warnings.warn(
+                f"threshold {self.threshold:.3f} was calibrated at middle length "
+                f"{self.calibration_length} but is being applied at length {length}; "
+                "the accept rate on these rows will be off its calibrated value"
+            )
+        return spliceai_exon_scores(logits, lengths) > self.threshold
+
+
+def calibrated_spliceai_readout(threshold: float, length: int) -> Readout:
+    """Readout that accepts when the SpliceAI exon score exceeds ``threshold``,
+    which ``median_threshold`` computed at middle length ``length``."""
+    return _CalibratedReadout(threshold, length)
 
 
 @permacache(

--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -1,12 +1,14 @@
 from typing import Callable, List
 
 import numpy as np
+import torch
+import torch.nn.functional as F
 
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.l_star.structures import Oracle
 
-# (wrapped [n, width] int, middle lengths [n]) -> accept mask [n] bool
-Scorer = Callable[[np.ndarray, np.ndarray], np.ndarray]
+# (model output tensor, middle lengths tensor) -> accept mask bool tensor
+Readout = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
 
 def wrap_with_flanks(flank_l, flank_r, strings):
@@ -22,14 +24,23 @@ def wrap_with_flanks(flank_l, flank_r, strings):
 
 
 class SpliceModelOracle(Oracle):
-    r"""E-L\* oracle that only batches: it wraps/pads/chunks queries and defers scoring to ``scorer``."""
+    r"""E-L\* oracle that wraps/one-hots/batches queries and runs ``model`` (eval, no_grad, on ``device``), leaving the accept decision to ``readout``."""
 
-    def __init__(self, exon: RawExon, scorer: Scorer, *, chunk: int = 8192):
+    def __init__(
+        self, exon: RawExon, model, readout: Readout, *, device=None, chunk: int = 1024
+    ):
+        model.eval()
+        self._model = model
+        self._readout = readout
+        self._device = (
+            torch.device(device)
+            if device is not None
+            else next(model.parameters()).device
+        )
         trim = exon.cl // 2 + 2
         self._flank_l = np.array(exon.text[:trim], dtype=np.int64)
         self._flank_r = np.array(exon.text[-trim:], dtype=np.int64)
         self._length = exon.random_text_length
-        self._scorer = scorer
         self._chunk = chunk
 
     @property
@@ -43,49 +54,59 @@ class SpliceModelOracle(Oracle):
     def membership_queries(self, strings: List[List[int]]) -> np.ndarray:
         out = np.empty(len(strings), dtype=bool)
         for i in range(0, len(strings), self._chunk):
-            batch = strings[i : i + self._chunk]
-            wrapped, lengths = wrap_with_flanks(self._flank_l, self._flank_r, batch)
-            out[i : i + self._chunk] = np.asarray(
-                self._scorer(wrapped, lengths), dtype=bool
+            wrapped, lengths = wrap_with_flanks(
+                self._flank_l, self._flank_r, strings[i : i + self._chunk]
             )
+            x = F.one_hot(torch.as_tensor(wrapped, device=self._device), 4).float()
+            lens = torch.as_tensor(lengths, device=self._device)
+            with torch.no_grad():
+                pred = self._readout(self._model(x), lens)
+            out[i : i + self._chunk] = pred.cpu().numpy().astype(bool)
         return out
 
     def membership_query(self, string: List[int]) -> bool:
         return bool(self.membership_queries([string])[0])
 
 
-def spliceai_exon_scores(model, wrapped: np.ndarray, lengths: np.ndarray) -> np.ndarray:
-    """Exon score per wrapped sequence: mean of the acceptor logit at output position 0 and the donor logit at len(middle)+3."""
-    import torch
-
-    from orthogonal_dfa.oracle.run_model import batched_run
-
-    with torch.no_grad():
-        lyp = batched_run(model, wrapped).log_softmax(-1)
-        rows = torch.arange(len(wrapped), device=lyp.device)
-        don_pos = torch.tensor(lengths + 3, device=lyp.device)
-        acc = lyp[rows, 0, 1]
-        don = lyp[rows, don_pos, 2]
-        return torch.stack([acc, don], -1).mean(-1).cpu().numpy()
+def spliceai_exon_scores(logits: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+    """Exon score per sequence: mean of the acceptor logit at output position 0 and the donor logit at len(middle)+3."""
+    lyp = logits.log_softmax(-1)
+    rows = torch.arange(len(lyp), device=lyp.device)
+    acc = lyp[rows, 0, 1]
+    don = lyp[rows, lengths + 3, 2]
+    return torch.stack([acc, don], -1).mean(-1)
 
 
-def calibrated_spliceai_scorer(model, threshold: float) -> Scorer:
-    """Scorer that accepts when the SpliceAI exon score exceeds ``threshold``."""
-
-    def scorer(wrapped, lengths):
-        return spliceai_exon_scores(model, wrapped, lengths) > threshold
-
-    return scorer
+def calibrated_spliceai_readout(threshold: float) -> Readout:
+    """Readout that accepts when the SpliceAI exon score exceeds ``threshold``."""
+    return lambda logits, lengths: spliceai_exon_scores(logits, lengths) > threshold
 
 
-def median_threshold(model, exon: RawExon, length: int, *, count=20000, seed=0xCA11B):
+def median_threshold(
+    model,
+    exon: RawExon,
+    length: int,
+    *,
+    count=20000,
+    seed=0xCA11B,
+    device=None,
+    chunk=1024
+):
     """Median exon score over ``count`` random length-``length`` middles (per-length since the score drifts with length)."""
-    rng = np.random.default_rng(seed)
-    mids = rng.integers(0, 4, size=(count, length)).tolist()
-    trim = exon.cl // 2 + 2
-    wrapped, lengths = wrap_with_flanks(
-        np.array(exon.text[:trim], dtype=np.int64),
-        np.array(exon.text[-trim:], dtype=np.int64),
-        mids,
+    model.eval()
+    device = (
+        torch.device(device) if device is not None else next(model.parameters()).device
     )
-    return float(np.median(spliceai_exon_scores(model, wrapped, lengths)))
+    trim = exon.cl // 2 + 2
+    flank_l = np.array(exon.text[:trim], dtype=np.int64)
+    flank_r = np.array(exon.text[-trim:], dtype=np.int64)
+    rng = np.random.default_rng(seed)
+    scores = []
+    for i in range(0, count, chunk):
+        mids = rng.integers(0, 4, size=(min(chunk, count - i), length)).tolist()
+        wrapped, lengths = wrap_with_flanks(flank_l, flank_r, mids)
+        x = F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
+        lens = torch.as_tensor(lengths, device=device)
+        with torch.no_grad():
+            scores.append(spliceai_exon_scores(model(x), lens).cpu().numpy())
+    return float(np.median(np.concatenate(scores)))

--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -16,6 +16,8 @@ Readout = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 # 2*FLANK_MARGIN positions: the acceptor is the first, the donor the last.
 FLANK_MARGIN = 2
 
+CALIBRATION_SEED = int(stable_hash("calibration"), 16)
+
 
 def flanks(exon: RawExon):
     """The (left, right) fixed flanks the middle is wrapped in, as int arrays."""
@@ -123,7 +125,7 @@ def median_threshold(
     length: int,
     *,
     count=20000,
-    seed=0xCA11B,
+    seed=CALIBRATION_SEED,
     device=None,
     chunk=1024
 ):

--- a/orthogonal_dfa/oracle/run_model.py
+++ b/orthogonal_dfa/oracle/run_model.py
@@ -4,23 +4,28 @@ from permacache import permacache, stable_hash
 
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.data.sample_text import sample_text
+from orthogonal_dfa.spliceai.exon_score import (
+    device_of,
+    forward_batch,
+    full_lengths,
+    spliceai_exon_scores,
+)
 
 
 def batched_run(model, arr, batch_size=1024):
-    ys = []
-    for i in range(0, len(arr), batch_size):
-        xpack = torch.tensor(arr[i : i + batch_size]).cuda()
-        x = torch.eye(4).cuda()[xpack]
-
-        with torch.no_grad():
-            ys.append(model(x))
-    return torch.cat(ys, dim=0)
+    device = device_of(model)
+    return torch.cat(
+        [
+            forward_batch(model, arr[i : i + batch_size], device=device)
+            for i in range(0, len(arr), batch_size)
+        ],
+        dim=0,
+    )
 
 
 def compute_exon_scores(model, arr):
-    yp = batched_run(model, arr).log_softmax(-1)
-    yp = yp[:, [0, -1], [1, 2]].mean(-1)
-    return yp
+    logits = batched_run(model, arr)
+    return spliceai_exon_scores(logits, full_lengths(logits))
 
 
 def run_model(exon, model, arr):

--- a/orthogonal_dfa/oracle/run_model.py
+++ b/orthogonal_dfa/oracle/run_model.py
@@ -5,6 +5,7 @@ from permacache import permacache, stable_hash
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.data.sample_text import sample_text
 from orthogonal_dfa.spliceai.exon_score import (
+    assert_output_width,
     device_of,
     forward_batch,
     full_lengths,
@@ -23,15 +24,19 @@ def batched_run(model, arr, batch_size=1024):
     )
 
 
-def compute_exon_scores(model, arr):
+def compute_exon_scores(model, arr, *, cl):
+    """Exon scores for the full-length windows ``arr``, cut for a cl-``cl`` exon."""
     logits = batched_run(model, arr)
+    # spliceai_exon_scores reads the lengths back off the output width, so its own
+    # width check cannot fail here; the input width is what pins down the cl.
+    assert_output_width(logits.shape[1], arr.shape[1] - cl)
     return spliceai_exon_scores(logits, full_lengths(logits))
 
 
 def run_model(exon, model, arr):
     calibration = calibrate(exon, model, count=100_000)
     with torch.no_grad():
-        yp = compute_exon_scores(model, arr)
+        yp = compute_exon_scores(model, arr, cl=exon.cl)
         normalized_target = (yp - calibration["mean"]) / calibration["std"]
         hard_target = normalized_target > 0
     return normalized_target, hard_target
@@ -73,7 +78,7 @@ def calibrate(exon: RawExon, model, count=100_000):
     """
     _, arr = sample_text(exon, int(stable_hash("calibration"), 16), count)
     with torch.no_grad():
-        yp = compute_exon_scores(model, arr)
+        yp = compute_exon_scores(model, arr, cl=exon.cl)
         median = yp.median()
         mean = yp.mean()
         std = yp.std()

--- a/orthogonal_dfa/spliceai/exon_score.py
+++ b/orthogonal_dfa/spliceai/exon_score.py
@@ -22,7 +22,15 @@ def device_of(model, device=None):
 
 
 def forward_batch(model, wrapped, *, device):
-    """One-hot ``wrapped`` and run ``model`` over it under no_grad."""
+    """One-hot ``wrapped`` and run ``model`` over it under no_grad.
+
+    Checked on every forward rather than once at setup: the padding argument in
+    wrap_with_flanks holds only in eval mode, and a caller sharing the model with
+    a training loop can put it back into train mode at any point."""
+    assert not model.training, (
+        "model must be in eval mode: in train mode BatchNorm normalizes over the "
+        "batch, so padded rows leak into every other row's score"
+    )
     # pylint: disable=not-callable
     x = F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
     with torch.no_grad():
@@ -36,17 +44,21 @@ def full_lengths(logits):
     )
 
 
+def assert_output_width(output_width: int, expected: int):
+    """Guard that the model's cl matches the exon the input was cut for.
+
+    A model that trims a different cl shifts every output position, so the donor
+    gets read off the wrong one and the score comes back as plausible noise."""
+    assert output_width == expected, (
+        f"model output width {output_width} does not match the expected "
+        f"{expected}; the exon's cl and the model's cl probably disagree"
+    )
+
+
 def spliceai_exon_scores(logits: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
     """Exon score per sequence: mean of the acceptor log probability at the first
     output position and the donor log probability at the middle's last."""
-    # The output width pins down the model's context length, so this catches a
-    # model whose cl disagrees with the exon the flanks were cut from -- which
-    # would otherwise just read the donor off the wrong position.
-    assert logits.shape[1] == int(lengths.max()) + 2 * FLANK_MARGIN, (
-        f"model output width {logits.shape[1]} does not match the widest middle "
-        f"({int(lengths.max())}) plus 2*{FLANK_MARGIN}; the exon's cl and the "
-        f"model's cl probably disagree"
-    )
+    assert_output_width(logits.shape[1], int(lengths.max()) + 2 * FLANK_MARGIN)
     lyp = logits.log_softmax(-1)
     rows = torch.arange(len(lyp), device=lyp.device)
     acc = lyp[rows, 0, 1]

--- a/orthogonal_dfa/spliceai/exon_score.py
+++ b/orthogonal_dfa/spliceai/exon_score.py
@@ -1,0 +1,54 @@
+"""The SpliceAI exon score, shared by the dataset pipeline and the E-L* oracle.
+
+`oracle.run_model` scores full-length windows straight out of `data.sample_text`;
+`l_star.examples.spliceai_oracle` scores ragged middles wrapped in the same
+flanks.  Both read the same two positions out of the same model, so the readout
+and the batched forward live here rather than in either caller.
+"""
+
+import torch
+import torch.nn.functional as F
+
+# Each flank keeps this many bases beyond the model's cl/2 half-context (matching
+# data.sample_text's trim_zone = cl//2 + 2), so the output spans len(middle) +
+# 2*FLANK_MARGIN positions: the acceptor is the first, the donor the last.
+FLANK_MARGIN = 2
+
+
+def device_of(model, device=None):
+    return (
+        torch.device(device) if device is not None else next(model.parameters()).device
+    )
+
+
+def forward_batch(model, wrapped, *, device):
+    """One-hot ``wrapped`` and run ``model`` over it under no_grad."""
+    # pylint: disable=not-callable
+    x = F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
+    with torch.no_grad():
+        return model(x)
+
+
+def full_lengths(logits):
+    """The middle lengths of a batch whose rows are all full length."""
+    return torch.full(
+        (len(logits),), logits.shape[1] - 2 * FLANK_MARGIN, device=logits.device
+    )
+
+
+def spliceai_exon_scores(logits: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+    """Exon score per sequence: mean of the acceptor log probability at the first
+    output position and the donor log probability at the middle's last."""
+    # The output width pins down the model's context length, so this catches a
+    # model whose cl disagrees with the exon the flanks were cut from -- which
+    # would otherwise just read the donor off the wrong position.
+    assert logits.shape[1] == int(lengths.max()) + 2 * FLANK_MARGIN, (
+        f"model output width {logits.shape[1]} does not match the widest middle "
+        f"({int(lengths.max())}) plus 2*{FLANK_MARGIN}; the exon's cl and the "
+        f"model's cl probably disagree"
+    )
+    lyp = logits.log_softmax(-1)
+    rows = torch.arange(len(lyp), device=lyp.device)
+    acc = lyp[rows, 0, 1]
+    don = lyp[rows, lengths + 2 * FLANK_MARGIN - 1, 2]
+    return torch.stack([acc, don], -1).mean(-1)

--- a/tests/test_spliceai_oracle.py
+++ b/tests/test_spliceai_oracle.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import torch
 
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.l_star.examples.spliceai_oracle import (
@@ -19,6 +20,20 @@ def wrapped_row(middle, width):
     return row + [0] * (width - len(row))
 
 
+class RecordingModel:
+    """Fake model recording the argmax-decoded one-hot input it is given."""
+
+    def __init__(self):
+        self.seen = []
+
+    def eval(self):
+        return self
+
+    def __call__(self, x):
+        self.seen.append(x.argmax(-1).cpu().numpy())
+        return x
+
+
 class TestWrapWithFlanks(unittest.TestCase):
     def test_wraps_pads_and_reports_lengths(self):
         strings = [[1, 2], [3], []]
@@ -34,31 +49,34 @@ class TestWrapWithFlanks(unittest.TestCase):
 
 class TestSpliceModelOracle(unittest.TestCase):
     def setUp(self):
-        self.calls = []
+        self.model = RecordingModel()
+        self.seen_lengths = []
 
-        def scorer(wrapped, lengths):
-            self.calls.append((wrapped.copy(), lengths.copy()))
+        def readout(logits, lengths):
+            self.seen_lengths.append(lengths.cpu().numpy())
             return lengths >= 2
 
-        self.scorer = scorer
+        self.readout = readout
+
+    def _oracle(self, **kw):
+        return SpliceModelOracle(EXON, self.model, self.readout, device="cpu", **kw)
 
     def test_alphabet_and_length(self):
-        oracle = SpliceModelOracle(EXON, self.scorer)
+        oracle = self._oracle()
         self.assertEqual(oracle.alphabet_size, 4)
         self.assertEqual(oracle.string_length, EXON.random_text_length)
 
     def test_membership_batching_and_wrapping(self):
-        oracle = SpliceModelOracle(EXON, self.scorer, chunk=2)
-        strings = [[1, 2], [3], [0, 1, 2, 3, 0], []]
-        result = oracle.membership_queries(strings)
+        oracle = self._oracle(chunk=2)
+        result = oracle.membership_queries([[1, 2], [3], [0, 1, 2, 3, 0], []])
 
         np.testing.assert_array_equal(result, [True, False, True, False])
         self.assertEqual(result.dtype, bool)
 
-        self.assertEqual(len(self.calls), 2)
-        (w0, l0), (w1, l1) = self.calls
-        np.testing.assert_array_equal(l0, [2, 1])
-        np.testing.assert_array_equal(l1, [5, 0])
+        self.assertEqual(len(self.model.seen), 2)
+        np.testing.assert_array_equal(self.seen_lengths[0], [2, 1])
+        np.testing.assert_array_equal(self.seen_lengths[1], [5, 0])
+        w0, w1 = self.model.seen
         self.assertEqual(w0.shape, (2, 10))
         self.assertEqual(w1.shape, (2, 13))
         np.testing.assert_array_equal(w0[0], wrapped_row([1, 2], 10))
@@ -66,7 +84,7 @@ class TestSpliceModelOracle(unittest.TestCase):
         np.testing.assert_array_equal(w1[1], wrapped_row([], 13))
 
     def test_membership_query_singular(self):
-        oracle = SpliceModelOracle(EXON, self.scorer)
+        oracle = self._oracle()
         self.assertTrue(oracle.membership_query([0, 0, 0]))
         self.assertFalse(oracle.membership_query([0]))
 

--- a/tests/test_spliceai_oracle.py
+++ b/tests/test_spliceai_oracle.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy as np
-import torch
 
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.l_star.examples.spliceai_oracle import (
@@ -53,6 +52,7 @@ class TestSpliceModelOracle(unittest.TestCase):
         self.seen_lengths = []
 
         def readout(logits, lengths):
+            del logits  # unused
             self.seen_lengths.append(lengths.cpu().numpy())
             return lengths >= 2
 
@@ -76,7 +76,7 @@ class TestSpliceModelOracle(unittest.TestCase):
         self.assertEqual(len(self.model.seen), 2)
         np.testing.assert_array_equal(self.seen_lengths[0], [2, 1])
         np.testing.assert_array_equal(self.seen_lengths[1], [5, 0])
-        w0, w1 = self.model.seen
+        w0, w1 = self.model.seen[0], self.model.seen[1]
         self.assertEqual(w0.shape, (2, 10))
         self.assertEqual(w1.shape, (2, 13))
         np.testing.assert_array_equal(w0[0], wrapped_row([1, 2], 10))

--- a/tests/test_spliceai_oracle.py
+++ b/tests/test_spliceai_oracle.py
@@ -1,22 +1,49 @@
 import unittest
 
 import numpy as np
+import torch
 
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.l_star.examples.spliceai_oracle import (
     SpliceModelOracle,
+    calibrated_spliceai_readout,
+    flanks,
+    median_threshold,
+    run_over_middles,
     wrap_with_flanks,
 )
+from orthogonal_dfa.spliceai.exon_score import (
+    FLANK_MARGIN,
+    forward_batch,
+    full_lengths,
+    spliceai_exon_scores,
+)
+from orthogonal_dfa.spliceai.module import SpliceAIModule
 
 # cl=4 -> trim = cl//2+2 = 4, so the flanks are the first/last 4 bases of the text.
 EXON = RawExon.of(4, "ACGTAAAAGGGG")
 FLANK_L = [0, 1, 2, 3]
 FLANK_R = [2, 2, 2, 2]
 
+# The smallest window SpliceAI is defined for; a forward pass takes a few ms.
+SMALL_CL = 80
+FULL_LENGTH = 30
+
 
 def wrapped_row(middle, width):
     row = FLANK_L + list(middle) + FLANK_R
     return row + [0] * (width - len(row))
+
+
+def small_model_and_exon(cl=SMALL_CL):
+    """A randomly initialised SpliceAI of context ``cl``, and an exon to match."""
+    torch.manual_seed(0)
+    model = SpliceAIModule(window=SMALL_CL).eval()
+    rng = np.random.default_rng(0)
+    exon = RawExon(
+        cl, rng.integers(0, 4, size=cl + 2 * FLANK_MARGIN + FULL_LENGTH).tolist()
+    )
+    return model, exon
 
 
 class RecordingModel:
@@ -87,6 +114,112 @@ class TestSpliceModelOracle(unittest.TestCase):
         oracle = self._oracle()
         self.assertTrue(oracle.membership_query([0, 0, 0]))
         self.assertFalse(oracle.membership_query([0]))
+
+    def test_empty_batch(self):
+        result = self._oracle().membership_queries([])
+        self.assertEqual(result.shape, (0,))
+        self.assertEqual(result.dtype, bool)
+
+
+class TestSpliceaiExonScores(unittest.TestCase):
+    """Everything here runs a real SpliceAI, so the readout's output indexing is
+    checked against the model's actual cl trimming rather than a fake."""
+
+    def setUp(self):
+        self.model, self.exon = small_model_and_exon()
+        self.flank_l, self.flank_r = flanks(self.exon)
+        self.rng = np.random.default_rng(1)
+
+    def _scores(self, middles, chunk=64):
+        return run_over_middles(
+            self.model,
+            self.flank_l,
+            self.flank_r,
+            middles,
+            spliceai_exon_scores,
+            device="cpu",
+            chunk=chunk,
+        )
+
+    def test_matches_first_and_last_output_positions(self):
+        """On full-length rows the score is the acceptor at output position 0 and
+        the donor at the last, which is what oracle.run_model has always read."""
+        middles = self.rng.integers(0, 4, size=(4, FULL_LENGTH)).tolist()
+        wrapped, _ = wrap_with_flanks(self.flank_l, self.flank_r, middles)
+        logits = forward_batch(self.model, wrapped, device="cpu")
+        self.assertEqual(logits.shape[1], FULL_LENGTH + 2 * FLANK_MARGIN)
+
+        reference = logits.log_softmax(-1)[:, [0, -1], [1, 2]].mean(-1)
+        np.testing.assert_allclose(
+            spliceai_exon_scores(logits, full_lengths(logits)).numpy(),
+            reference.numpy(),
+            rtol=1e-6,
+        )
+
+    def test_padding_does_not_change_scores(self):
+        """A short middle scores the same whether or not it is padded up to a
+        longer row's width."""
+        middles = [
+            self.rng.integers(0, 4, size=n).tolist() for n in [FULL_LENGTH, 17, 5, 1, 0]
+        ]
+        ragged = self._scores(middles)
+        one_at_a_time = np.concatenate([self._scores([m]) for m in middles])
+        np.testing.assert_allclose(ragged, one_at_a_time, rtol=1e-6)
+
+    def test_rejects_a_model_whose_cl_disagrees(self):
+        """Flanks cut for a cl=400 exon put the donor 320 positions off for an
+        80-context model; that has to fail loudly rather than score noise."""
+        _, wide_exon = small_model_and_exon(cl=400)
+        flank_l, flank_r = flanks(wide_exon)
+        with self.assertRaises(AssertionError):
+            run_over_middles(
+                self.model,
+                flank_l,
+                flank_r,
+                [[0] * FULL_LENGTH],
+                spliceai_exon_scores,
+                device="cpu",
+                chunk=64,
+            )
+
+
+class TestCalibration(unittest.TestCase):
+    def setUp(self):
+        self.model, self.exon = small_model_and_exon()
+
+    def test_threshold_splits_random_middles_in_half(self):
+        length, count = 12, 256
+        # .function skips permacache: nothing here is worth caching to disk.
+        threshold = median_threshold.function(
+            self.model, self.exon, length, count=count, chunk=64, device="cpu"
+        )
+        oracle = SpliceModelOracle(
+            self.exon,
+            self.model,
+            calibrated_spliceai_readout(threshold),
+            device="cpu",
+            chunk=64,
+        )
+        fresh = np.random.default_rng(7).integers(0, 4, size=(count, length)).tolist()
+        self.assertAlmostEqual(oracle.membership_queries(fresh).mean(), 0.5, delta=0.15)
+
+    def test_readout_accepts_exactly_the_scores_above_the_threshold(self):
+        flank_l, flank_r = flanks(self.exon)
+        middles = [
+            np.random.default_rng(3).integers(0, 4, size=n).tolist()
+            for n in [FULL_LENGTH, 9, 2]
+        ]
+        kw = dict(device="cpu", chunk=64)
+        scores = run_over_middles(
+            self.model, flank_l, flank_r, middles, spliceai_exon_scores, **kw
+        )
+        threshold = float(np.median(scores))
+        oracle = SpliceModelOracle(
+            self.exon, self.model, calibrated_spliceai_readout(threshold), **kw
+        )
+        np.testing.assert_array_equal(
+            oracle.membership_queries(middles), scores > threshold
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_spliceai_oracle.py
+++ b/tests/test_spliceai_oracle.py
@@ -1,9 +1,11 @@
 import unittest
+import warnings
 
 import numpy as np
 import torch
 
 from orthogonal_dfa.data.exon import RawExon
+from orthogonal_dfa.data.sample_text import sample_text
 from orthogonal_dfa.l_star.examples.spliceai_oracle import (
     SpliceModelOracle,
     calibrated_spliceai_readout,
@@ -12,6 +14,7 @@ from orthogonal_dfa.l_star.examples.spliceai_oracle import (
     run_over_middles,
     wrap_with_flanks,
 )
+from orthogonal_dfa.oracle.run_model import compute_exon_scores
 from orthogonal_dfa.spliceai.exon_score import (
     FLANK_MARGIN,
     forward_batch,
@@ -51,8 +54,10 @@ class RecordingModel:
 
     def __init__(self):
         self.seen = []
+        self.training = True
 
     def eval(self):
+        self.training = False
         return self
 
     def __call__(self, x):
@@ -119,6 +124,14 @@ class TestSpliceModelOracle(unittest.TestCase):
         result = self._oracle().membership_queries([])
         self.assertEqual(result.shape, (0,))
         self.assertEqual(result.dtype, bool)
+
+    def test_rejects_a_model_put_back_into_train_mode(self):
+        """The oracle sets eval once, but padding invariance has to hold at every
+        query -- a caller sharing the model with a training loop can undo it."""
+        oracle = self._oracle()
+        self.model.training = True
+        with self.assertRaises(AssertionError):
+            oracle.membership_queries([[1, 2]])
 
 
 class TestSpliceaiExonScores(unittest.TestCase):
@@ -196,12 +209,29 @@ class TestCalibration(unittest.TestCase):
         oracle = SpliceModelOracle(
             self.exon,
             self.model,
-            calibrated_spliceai_readout(threshold),
+            calibrated_spliceai_readout(threshold, length),
             device="cpu",
             chunk=64,
         )
         fresh = np.random.default_rng(7).integers(0, 4, size=(count, length)).tolist()
         self.assertAlmostEqual(oracle.membership_queries(fresh).mean(), 0.5, delta=0.15)
+
+    def test_warns_once_per_off_calibration_length(self):
+        oracle = SpliceModelOracle(
+            self.exon,
+            self.model,
+            calibrated_spliceai_readout(0.0, FULL_LENGTH),
+            device="cpu",
+            chunk=64,
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            oracle.membership_queries([[0] * n for n in [FULL_LENGTH, 5, 5, 7]])
+            oracle.membership_queries([[0] * 5])
+        self.assertEqual(len(caught), 2)  # lengths 5 and 7, once each
+        self.assertIn(
+            f"calibrated at middle length {FULL_LENGTH}", str(caught[0].message)
+        )
 
     def test_readout_accepts_exactly_the_scores_above_the_threshold(self):
         flank_l, flank_r = flanks(self.exon)
@@ -215,11 +245,48 @@ class TestCalibration(unittest.TestCase):
         )
         threshold = float(np.median(scores))
         oracle = SpliceModelOracle(
-            self.exon, self.model, calibrated_spliceai_readout(threshold), **kw
+            self.exon,
+            self.model,
+            calibrated_spliceai_readout(threshold, FULL_LENGTH),
+            **kw,
         )
-        np.testing.assert_array_equal(
-            oracle.membership_queries(middles), scores > threshold
+        with warnings.catch_warnings():  # the two short middles are off-calibration
+            warnings.simplefilter("ignore")
+            np.testing.assert_array_equal(
+                oracle.membership_queries(middles), scores > threshold
+            )
+
+
+class TestComputeExonScores(unittest.TestCase):
+    """oracle.run_model's path, where the output width is derived from itself and
+    so the cl check has to come from the input width instead."""
+
+    def setUp(self):
+        self.model, self.exon = small_model_and_exon()
+
+    def test_agrees_with_the_oracle_path(self):
+        middles, arr = sample_text(self.exon, 0, 4)
+        flank_l, flank_r = flanks(self.exon)
+        via_oracle = run_over_middles(
+            self.model,
+            flank_l,
+            flank_r,
+            middles.tolist(),
+            spliceai_exon_scores,
+            device="cpu",
+            chunk=64,
         )
+        np.testing.assert_allclose(
+            compute_exon_scores(self.model, arr, cl=self.exon.cl).numpy(),
+            via_oracle,
+            rtol=1e-6,
+        )
+
+    def test_rejects_a_model_whose_cl_disagrees(self):
+        _, wide_exon = small_model_and_exon(cl=400)
+        _, arr = sample_text(wide_exon, 0, 2)
+        with self.assertRaises(AssertionError):
+            compute_exon_scores(self.model, arr, cl=wide_exon.cl)
 
 
 if __name__ == "__main__":

--- a/tests/test_spliceai_oracle.py
+++ b/tests/test_spliceai_oracle.py
@@ -8,8 +8,7 @@ from orthogonal_dfa.l_star.examples.spliceai_oracle import (
     wrap_with_flanks,
 )
 
-# cl=4 -> trim = cl//2+2 = 4, so flank_l = first 4 bases, flank_r = last 4 bases.
-# text "ACGTAAAAGGGG" -> flank_l = ACGT = [0,1,2,3], flank_r = GGGG = [2,2,2,2].
+# cl=4 -> trim = cl//2+2 = 4, so the flanks are the first/last 4 bases of the text.
 EXON = RawExon.of(4, "ACGTAAAAGGGG")
 FLANK_L = [0, 1, 2, 3]
 FLANK_R = [2, 2, 2, 2]
@@ -26,8 +25,7 @@ class TestWrapWithFlanks(unittest.TestCase):
         wrapped, lengths = wrap_with_flanks(
             np.array(FLANK_L), np.array(FLANK_R), strings
         )
-        # padded to flank (8) + longest middle (2) = 10
-        self.assertEqual(wrapped.shape, (3, 10))
+        self.assertEqual(wrapped.shape, (3, 10))  # flank 8 + longest middle 2
         np.testing.assert_array_equal(lengths, [2, 1, 0])
         np.testing.assert_array_equal(wrapped[0], wrapped_row([1, 2], 10))
         np.testing.assert_array_equal(wrapped[1], wrapped_row([3], 10))
@@ -40,7 +38,7 @@ class TestSpliceModelOracle(unittest.TestCase):
 
         def scorer(wrapped, lengths):
             self.calls.append((wrapped.copy(), lengths.copy()))
-            return lengths >= 2  # deterministic, exercises per-row output
+            return lengths >= 2
 
         self.scorer = scorer
 
@@ -50,7 +48,6 @@ class TestSpliceModelOracle(unittest.TestCase):
         self.assertEqual(oracle.string_length, EXON.random_text_length)
 
     def test_membership_batching_and_wrapping(self):
-        # chunk=2 forces two chunks, each padded to its own max middle length
         oracle = SpliceModelOracle(EXON, self.scorer, chunk=2)
         strings = [[1, 2], [3], [0, 1, 2, 3, 0], []]
         result = oracle.membership_queries(strings)
@@ -58,12 +55,10 @@ class TestSpliceModelOracle(unittest.TestCase):
         np.testing.assert_array_equal(result, [True, False, True, False])
         self.assertEqual(result.dtype, bool)
 
-        # two chunks
         self.assertEqual(len(self.calls), 2)
         (w0, l0), (w1, l1) = self.calls
         np.testing.assert_array_equal(l0, [2, 1])
         np.testing.assert_array_equal(l1, [5, 0])
-        # each chunk padded to flank(8) + its own longest middle
         self.assertEqual(w0.shape, (2, 10))
         self.assertEqual(w1.shape, (2, 13))
         np.testing.assert_array_equal(w0[0], wrapped_row([1, 2], 10))
@@ -72,8 +67,8 @@ class TestSpliceModelOracle(unittest.TestCase):
 
     def test_membership_query_singular(self):
         oracle = SpliceModelOracle(EXON, self.scorer)
-        self.assertTrue(oracle.membership_query([0, 0, 0]))  # length 3 >= 2
-        self.assertFalse(oracle.membership_query([0]))  # length 1 < 2
+        self.assertTrue(oracle.membership_query([0, 0, 0]))
+        self.assertFalse(oracle.membership_query([0]))
 
 
 if __name__ == "__main__":

--- a/tests/test_spliceai_oracle.py
+++ b/tests/test_spliceai_oracle.py
@@ -54,11 +54,7 @@ class RecordingModel:
 
     def __init__(self):
         self.seen = []
-        self.training = True
-
-    def eval(self):
         self.training = False
-        return self
 
     def __call__(self, x):
         self.seen.append(x.argmax(-1).cpu().numpy())
@@ -125,9 +121,9 @@ class TestSpliceModelOracle(unittest.TestCase):
         self.assertEqual(result.shape, (0,))
         self.assertEqual(result.dtype, bool)
 
-    def test_rejects_a_model_put_back_into_train_mode(self):
-        """The oracle sets eval once, but padding invariance has to hold at every
-        query -- a caller sharing the model with a training loop can undo it."""
+    def test_rejects_a_model_in_train_mode(self):
+        """Padding invariance has to hold at every query, so the oracle refuses a
+        train-mode model rather than quietly switching one it does not own."""
         oracle = self._oracle()
         self.model.training = True
         with self.assertRaises(AssertionError):

--- a/tests/test_spliceai_oracle.py
+++ b/tests/test_spliceai_oracle.py
@@ -1,0 +1,80 @@
+import unittest
+
+import numpy as np
+
+from orthogonal_dfa.data.exon import RawExon
+from orthogonal_dfa.l_star.examples.spliceai_oracle import (
+    SpliceModelOracle,
+    wrap_with_flanks,
+)
+
+# cl=4 -> trim = cl//2+2 = 4, so flank_l = first 4 bases, flank_r = last 4 bases.
+# text "ACGTAAAAGGGG" -> flank_l = ACGT = [0,1,2,3], flank_r = GGGG = [2,2,2,2].
+EXON = RawExon.of(4, "ACGTAAAAGGGG")
+FLANK_L = [0, 1, 2, 3]
+FLANK_R = [2, 2, 2, 2]
+
+
+def wrapped_row(middle, width):
+    row = FLANK_L + list(middle) + FLANK_R
+    return row + [0] * (width - len(row))
+
+
+class TestWrapWithFlanks(unittest.TestCase):
+    def test_wraps_pads_and_reports_lengths(self):
+        strings = [[1, 2], [3], []]
+        wrapped, lengths = wrap_with_flanks(
+            np.array(FLANK_L), np.array(FLANK_R), strings
+        )
+        # padded to flank (8) + longest middle (2) = 10
+        self.assertEqual(wrapped.shape, (3, 10))
+        np.testing.assert_array_equal(lengths, [2, 1, 0])
+        np.testing.assert_array_equal(wrapped[0], wrapped_row([1, 2], 10))
+        np.testing.assert_array_equal(wrapped[1], wrapped_row([3], 10))
+        np.testing.assert_array_equal(wrapped[2], wrapped_row([], 10))
+
+
+class TestSpliceModelOracle(unittest.TestCase):
+    def setUp(self):
+        self.calls = []
+
+        def scorer(wrapped, lengths):
+            self.calls.append((wrapped.copy(), lengths.copy()))
+            return lengths >= 2  # deterministic, exercises per-row output
+
+        self.scorer = scorer
+
+    def test_alphabet_and_length(self):
+        oracle = SpliceModelOracle(EXON, self.scorer)
+        self.assertEqual(oracle.alphabet_size, 4)
+        self.assertEqual(oracle.string_length, EXON.random_text_length)
+
+    def test_membership_batching_and_wrapping(self):
+        # chunk=2 forces two chunks, each padded to its own max middle length
+        oracle = SpliceModelOracle(EXON, self.scorer, chunk=2)
+        strings = [[1, 2], [3], [0, 1, 2, 3, 0], []]
+        result = oracle.membership_queries(strings)
+
+        np.testing.assert_array_equal(result, [True, False, True, False])
+        self.assertEqual(result.dtype, bool)
+
+        # two chunks
+        self.assertEqual(len(self.calls), 2)
+        (w0, l0), (w1, l1) = self.calls
+        np.testing.assert_array_equal(l0, [2, 1])
+        np.testing.assert_array_equal(l1, [5, 0])
+        # each chunk padded to flank(8) + its own longest middle
+        self.assertEqual(w0.shape, (2, 10))
+        self.assertEqual(w1.shape, (2, 13))
+        np.testing.assert_array_equal(w0[0], wrapped_row([1, 2], 10))
+        np.testing.assert_array_equal(w1[0], wrapped_row([0, 1, 2, 3, 0], 13))
+        np.testing.assert_array_equal(w1[1], wrapped_row([], 13))
+
+    def test_membership_query_singular(self):
+        oracle = SpliceModelOracle(EXON, self.scorer)
+        self.assertTrue(oracle.membership_query([0, 0, 0]))  # length 3 >= 2
+        self.assertFalse(oracle.membership_query([0]))  # length 1 < 2
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `SpliceModelOracle`, an E-L\* oracle that runs a splice model over queried strings, with the **calibration lifted out** to the caller.

Previously the only way to score a middle was `oracle.run_model`, which assumes a rectangular batch of full-length windows straight out of `data.sample_text`. E-L\* queries `prefix + suffix`, so its strings are ragged and mostly *not* full length — hence a new oracle, plus a shared home for the parts both paths need.

## What's where

- **`spliceai/exon_score.py`** (new) — the exon score and the batched one-hot forward, shared by `oracle.run_model` and the new oracle so there is one definition of "acceptor at the first output position, donor at the middle's last":
  - `spliceai_exon_scores(logits, lengths)` — mean of the two log probabilities, with the donor gathered per row.
  - `forward_batch(model, wrapped, *, device)`, `full_lengths(logits)`, `device_of(model, device)`, `FLANK_MARGIN`.
- **`l_star/examples/spliceai_oracle.py`** (new) — the oracle and its calibration:
  - `SpliceModelOracle(exon, model, readout, *, device=None, chunk=1024)` — wraps each queried middle in the exon's flanks, right-pads ragged batches to a rectangle, chunks, one-hots, runs the model under `eval`/`no_grad`, and hands `(logits, lengths)` to `readout`. It does not decide anything itself.
  - `readout(logits, lengths) -> Tensor` — the accept decision, supplied by the caller.
  - `median_threshold(model, exon, length)` — the accept threshold, computed **outside** the oracle: the median score over random middles **at a given length**.
  - `calibrated_spliceai_readout(threshold)` — turns a threshold into a bool readout.
- **`oracle/run_model.py`** — `batched_run`/`compute_exon_scores` now delegate to `spliceai.exon_score`. Numbers are bit-identical (verified against the old implementation), so its permacached datasets stay valid; it now runs on the model's own device instead of forcing `.cuda()`.

## Usage

```python
model = load_spliceai(400, 0)
threshold = median_threshold(model, exon, length=80)   # calibrate OUTSIDE
readout = calibrated_spliceai_readout(threshold)
oracle = SpliceModelOracle(exon, model, readout)
```

## Calibrate at the length you will query

The score drifts a lot with middle length, so `median_threshold` takes a `length` and is only right near it. Measured on `spliceai-400-0` with `default_exon`, 512 random middles per length:

| median score | len 40 | len 44 | len 80 |
|---|---|---|---|
| | −11.045 | −10.783 | −9.063 |

| threshold calibrated at | → len 40 | → len 44 | → len 80 |
|---|---|---|---|
| 40 | 0.500 | 0.562 | 0.766 |
| 80 | 0.217 | 0.246 | 0.500 |

E-L\* with `sample_length=L` queries at `2L` (probe prefix + suffix) and at `L..L+4` (the short prefix-closed core), so pick the length that dominates — `2L` — and expect the core rows to sit off 0.5. Making the threshold per-length is left for a follow-up.

## Two calibration conventions

`run_model` thresholds its dataset at the *mean* (its z-score `> 0`); `median_threshold` uses the *median*, so the accept rate is exactly 0.5 whatever the distribution's skew, which is what E-L\*'s degeneracy precondition wants. They disagree on borderline sequences — don't pair a dataset built by one with an oracle built by the other. Noted in the docstring.

## Correctness notes

- **Padding is never read.** A row's acceptor and donor positions sit `cl/2` inside that row's own last real base, so neither receptive field reaches the pad, whatever else is in the batch. This holds only with the model in `eval` mode — BatchNorm over batch statistics would let padded rows leak into every other row.
- **`spliceai_exon_scores` asserts `logits.shape[1] == lengths.max() + 2*FLANK_MARGIN`.** An exon whose `cl` disagrees with the model's previously just read the donor off the wrong position and returned plausible-looking noise.

## Tests

`tests/test_spliceai_oracle.py`. The wrapping / ragged-padding / chunking plumbing is covered with a fake model (no GPU, no weights). The parts a fake model *cannot* check — it returns its input, so no `cl` trimming happens — run a real randomly-initialised `SpliceAIModule(window=80)`, a few ms per forward:

- the score matches the first/last-output-position formula `run_model` has always used;
- ragged-batch scores equal one-row-at-a-time scores (padding invariance);
- the `cl`-mismatch assert fires;
- `median_threshold` splits fresh random middles at its calibration length ~50/50;
- the calibrated readout accepts exactly the rows scoring above the threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
