### PR TITLE
Replace the SpliceModelOracle readout with an nn.Module exon-score wrapper

### DIFF
--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -2,12 +2,11 @@ from typing import List
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 from permacache import permacache, stable_hash
 
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.l_star.structures import Oracle
-from orthogonal_dfa.spliceai.exon_score import FLANK_MARGIN, device_of
+from orthogonal_dfa.spliceai.exon_score import FLANK_MARGIN, device_of, one_hot
 
 CALIBRATION_SEED = int(stable_hash("calibration"), 16)
 
@@ -53,12 +52,11 @@ def run_over_middles(score_model, flank_l, flank_r, strings, *, device, chunk):
     parts = []
     for i in range(0, len(strings), chunk):
         wrapped, lengths = wrap_with_flanks(flank_l, flank_r, strings[i : i + chunk])
-        # pylint: disable=not-callable
-        x = F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
+        x = one_hot(wrapped, device=device)
         lens = torch.as_tensor(lengths, device=device)
         with torch.no_grad():
             parts.append(score_model(x, lens).cpu().numpy())
-    return np.concatenate(parts) if parts else np.empty(0)
+    return np.concatenate(parts) if parts else np.empty(0, dtype=np.float32)
 
 
 class SpliceModelOracle(Oracle):

--- a/orthogonal_dfa/l_star/examples/spliceai_oracle.py
+++ b/orthogonal_dfa/l_star/examples/spliceai_oracle.py
@@ -1,21 +1,13 @@
-import warnings
-from typing import Callable, List
+from typing import List
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 from permacache import permacache, stable_hash
 
 from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.l_star.structures import Oracle
-from orthogonal_dfa.spliceai.exon_score import (
-    FLANK_MARGIN,
-    device_of,
-    forward_batch,
-    spliceai_exon_scores,
-)
-
-# (model output tensor, middle lengths tensor) -> per-sequence value tensor
-Readout = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+from orthogonal_dfa.spliceai.exon_score import FLANK_MARGIN, device_of
 
 CALIBRATION_SEED = int(stable_hash("calibration"), 16)
 
@@ -48,35 +40,49 @@ def wrap_with_flanks(flank_l, flank_r, strings):
     return wrapped, lengths
 
 
-def run_over_middles(model, flank_l, flank_r, strings, readout, *, device, chunk):
-    """Flank-wrap and run ``model`` over ``strings`` in chunks, returning
-    np.concatenate of ``readout(logits, lengths)``."""
+def run_over_middles(score_model, flank_l, flank_r, strings, *, device, chunk):
+    """Flank-wrap, one-hot, and run ``score_model(x, lengths)`` (no_grad) over
+    ``strings`` in chunks, returning the concatenated per-sequence scores."""
+    # Checked on every call rather than once at setup: wrap_with_flanks's padding
+    # only stays inert in eval mode, and a caller sharing the model with a training
+    # loop can flip a submodule back into train mode at any point.
+    assert not any(m.training for m in score_model.modules()), (
+        "score_model must be in eval mode: in train mode BatchNorm normalizes over "
+        "the batch, so padded rows leak into every other row's score"
+    )
     parts = []
     for i in range(0, len(strings), chunk):
         wrapped, lengths = wrap_with_flanks(flank_l, flank_r, strings[i : i + chunk])
-        logits = forward_batch(model, wrapped, device=device)
+        # pylint: disable=not-callable
+        x = F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
         lens = torch.as_tensor(lengths, device=device)
-        parts.append(readout(logits, lens).cpu().numpy())
-    return np.concatenate(parts) if parts else np.empty(0, dtype=bool)
+        with torch.no_grad():
+            parts.append(score_model(x, lens).cpu().numpy())
+    return np.concatenate(parts) if parts else np.empty(0)
 
 
 class SpliceModelOracle(Oracle):
-    r"""E-L\* oracle that wraps/one-hots/batches queries and runs ``model`` (under
-    no_grad, on ``device``), deferring the accept decision to ``readout``.
+    r"""E-L\* oracle that wraps/one-hots/batches queries, runs ``score_model(x,
+    lengths)`` (no_grad, on ``device``), and accepts when the score exceeds
+    ``threshold``.
 
-    ``model`` must already be in eval mode -- forward_batch checks that on every
-    query rather than this setting it, so a caller who shares the model with a
-    training loop hears about it instead of having it silently switched.
-
-    ``model`` is left on its own device unless ``device`` is passed, which only
-    picks where the inputs go -- it does not move the model."""
+    ``score_model`` must already be in eval mode -- run_over_middles checks that on
+    every query rather than this setting it, so a caller who shares the model with a
+    training loop hears about it instead of having it silently switched.  ``device``
+    only picks where the inputs go; it does not move the model."""
 
     def __init__(
-        self, exon: RawExon, model, readout: Readout, *, device=None, chunk: int = 1024
+        self,
+        exon: RawExon,
+        score_model,
+        threshold: float,
+        *,
+        device=None,
+        chunk: int = 1024,
     ):
-        self._model = model
-        self._readout = readout
-        self._device = device_of(model, device)
+        self._score_model = score_model
+        self._threshold = threshold
+        self._device = device_of(score_model, device)
         self._flank_l, self._flank_r = flanks(exon)
         self._length = exon.random_text_length
         self._chunk = chunk
@@ -90,65 +96,31 @@ class SpliceModelOracle(Oracle):
         return self._length
 
     def membership_queries(self, strings: List[List[int]]) -> np.ndarray:
-        preds = run_over_middles(
-            self._model,
+        scores = run_over_middles(
+            self._score_model,
             self._flank_l,
             self._flank_r,
             strings,
-            self._readout,
             device=self._device,
             chunk=self._chunk,
         )
-        return preds.astype(bool)
+        return scores > self._threshold
 
     def membership_query(self, string: List[int]) -> bool:
         return bool(self.membership_queries([string])[0])
 
 
-class _CalibratedReadout:
-    """Accepts when the exon score exceeds ``threshold``, warning when queried at
-    a length ``threshold`` was not calibrated for.
-
-    The score drifts with length, so a threshold is only near its intended accept
-    rate close to its own calibration length -- one calibrated at 40 accepts ~77%
-    of random length-80 middles.  E-L* queries a few lengths at once (2L for the
-    probes, L..L+4 for the core), so this warns once per length rather than
-    failing; until the threshold is per-length, expect the off-length rows to sit
-    off 0.5."""
-
-    def __init__(self, threshold: float, length: int):
-        self.threshold = threshold
-        self.calibration_length = length
-        self._warned = set()
-
-    def __call__(self, logits, lengths):
-        for length in set(lengths.tolist()) - self._warned - {self.calibration_length}:
-            self._warned.add(length)
-            warnings.warn(
-                f"threshold {self.threshold:.3f} was calibrated at middle length "
-                f"{self.calibration_length} but is being applied at length {length}; "
-                "the accept rate on these rows will be off its calibrated value"
-            )
-        return spliceai_exon_scores(logits, lengths) > self.threshold
-
-
-def calibrated_spliceai_readout(threshold: float, length: int) -> Readout:
-    """Readout that accepts when the SpliceAI exon score exceeds ``threshold``,
-    which ``median_threshold`` computed at middle length ``length``."""
-    return _CalibratedReadout(threshold, length)
-
-
 @permacache(
     "orthogonal_dfa/l_star/examples/spliceai_oracle/median_threshold",
     key_function=dict(
-        model=lambda m: stable_hash(m, version=2),
+        score_model=lambda m: stable_hash(m, version=2),
         exon=stable_hash,
         device=lambda _: None,  # does not affect the result
         chunk=lambda _: None,
     ),
 )
 def median_threshold(
-    model,
+    score_model,
     exon: RawExon,
     length: int,
     *,
@@ -158,26 +130,23 @@ def median_threshold(
     chunk=1024,
 ):
     """Median exon score over ``count`` random length-``length`` middles (per-length
-    since the score drifts with length).
+    since the score drifts with length), i.e. the threshold that makes
+    ``SpliceModelOracle`` accept ~50% of length-``length`` middles.
 
-    oracle.run_model calibrates its dataset with a z-score thresholded at 0, i.e.
-    at the *mean*; the median here instead puts the accept rate at exactly 0.5
-    whatever the score distribution's skew, which is what E-L*'s degeneracy
-    precondition wants.  The two conventions will disagree on borderline
-    sequences, so do not mix a dataset built by one with an oracle built by the
-    other.
+    run_model calibrates its dataset with a z-score thresholded at 0 (the *mean*);
+    the median here puts the accept rate at exactly 0.5 whatever the distribution's
+    skew, so do not mix a dataset built by one with an oracle built by the other.
 
-    ``model`` must already be in eval mode; forward_batch checks it, which a
-    permacache hit would skip along with the rest of the body."""
+    ``score_model`` must already be in eval mode; a permacache hit skips the check
+    along with the rest of the body."""
     flank_l, flank_r = flanks(exon)
     mids = np.random.default_rng(seed).integers(0, 4, size=(count, length)).tolist()
     scores = run_over_middles(
-        model,
+        score_model,
         flank_l,
         flank_r,
         mids,
-        spliceai_exon_scores,
-        device=device_of(model, device),
+        device=device_of(score_model, device),
         chunk=chunk,
     )
     return float(np.median(scores))

--- a/orthogonal_dfa/spliceai/exon_score.py
+++ b/orthogonal_dfa/spliceai/exon_score.py
@@ -8,6 +8,7 @@ and the batched forward live here rather than in either caller.
 
 import torch
 import torch.nn.functional as F
+from torch import nn
 
 # Each flank keeps this many bases beyond the model's cl/2 half-context (matching
 # data.sample_text's trim_zone = cl//2 + 2), so the output spans len(middle) +
@@ -64,3 +65,16 @@ def spliceai_exon_scores(logits: torch.Tensor, lengths: torch.Tensor) -> torch.T
     acc = lyp[rows, 0, 1]
     don = lyp[rows, lengths + 2 * FLANK_MARGIN - 1, 2]
     return torch.stack([acc, don], -1).mean(-1)
+
+
+class SpliceAIExonScore(nn.Module):
+    """Wraps a splice model so its forward maps (one-hot ``x``, middle ``lengths``)
+    to the per-sequence exon score; a composition-residual model can wrap this in
+    turn and adjust the scalar it returns."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, x, lengths):
+        return spliceai_exon_scores(self.model(x), lengths)

--- a/orthogonal_dfa/spliceai/exon_score.py
+++ b/orthogonal_dfa/spliceai/exon_score.py
@@ -2,8 +2,9 @@
 
 `oracle.run_model` scores full-length windows straight out of `data.sample_text`;
 `l_star.examples.spliceai_oracle` scores ragged middles wrapped in the same
-flanks.  Both read the same two positions out of the same model, so the readout
-and the batched forward live here rather than in either caller.
+flanks.  Both read the same two positions out of the same model and feed it the
+same one-hot encoding, so the score and the input encoding live here rather than
+in either caller.
 """
 
 import torch
@@ -22,6 +23,12 @@ def device_of(model, device=None):
     )
 
 
+def one_hot(wrapped, *, device):
+    """The float one-hot encoding of the base-index array ``wrapped``."""
+    # pylint: disable=not-callable
+    return F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
+
+
 def forward_batch(model, wrapped, *, device):
     """One-hot ``wrapped`` and run ``model`` over it under no_grad.
 
@@ -32,10 +39,8 @@ def forward_batch(model, wrapped, *, device):
         "model must be in eval mode: in train mode BatchNorm normalizes over the "
         "batch, so padded rows leak into every other row's score"
     )
-    # pylint: disable=not-callable
-    x = F.one_hot(torch.as_tensor(wrapped, device=device), 4).float()
     with torch.no_grad():
-        return model(x)
+        return model(one_hot(wrapped, device=device))
 
 
 def full_lengths(logits):

--- a/tests/test_spliceai_oracle.py
+++ b/tests/test_spliceai_oracle.py
@@ -125,7 +125,7 @@ class TestSpliceModelOracle(unittest.TestCase):
 
 
 class TestSpliceaiExonScore(unittest.TestCase):
-    """Everything here runs a real SpliceAI, so the readout's output indexing is
+    """Everything here runs a real SpliceAI, so the score's output indexing is
     checked against the model's actual cl trimming rather than a fake."""
 
     def setUp(self):

--- a/tests/test_spliceai_oracle.py
+++ b/tests/test_spliceai_oracle.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 import numpy as np
 import torch
@@ -8,7 +7,6 @@ from orthogonal_dfa.data.exon import RawExon
 from orthogonal_dfa.data.sample_text import sample_text
 from orthogonal_dfa.l_star.examples.spliceai_oracle import (
     SpliceModelOracle,
-    calibrated_spliceai_readout,
     flanks,
     median_threshold,
     run_over_middles,
@@ -17,6 +15,7 @@ from orthogonal_dfa.l_star.examples.spliceai_oracle import (
 from orthogonal_dfa.oracle.run_model import compute_exon_scores
 from orthogonal_dfa.spliceai.exon_score import (
     FLANK_MARGIN,
+    SpliceAIExonScore,
     forward_batch,
     full_lengths,
     spliceai_exon_scores,
@@ -49,16 +48,18 @@ def small_model_and_exon(cl=SMALL_CL):
     return model, exon
 
 
-class RecordingModel:
-    """Fake model recording the argmax-decoded one-hot input it is given."""
+class RecordingScore(torch.nn.Module):
+    """Fake score model recording its argmax-decoded input; scores a row by length."""
 
     def __init__(self):
+        super().__init__()
         self.seen = []
-        self.training = False
+        self.seen_lengths = []
 
-    def __call__(self, x):
+    def forward(self, x, lengths):
         self.seen.append(x.argmax(-1).cpu().numpy())
-        return x
+        self.seen_lengths.append(lengths.cpu().numpy())
+        return lengths.float()
 
 
 class TestWrapWithFlanks(unittest.TestCase):
@@ -76,18 +77,10 @@ class TestWrapWithFlanks(unittest.TestCase):
 
 class TestSpliceModelOracle(unittest.TestCase):
     def setUp(self):
-        self.model = RecordingModel()
-        self.seen_lengths = []
+        self.model = RecordingScore().eval()
 
-        def readout(logits, lengths):
-            del logits  # unused
-            self.seen_lengths.append(lengths.cpu().numpy())
-            return lengths >= 2
-
-        self.readout = readout
-
-    def _oracle(self, **kw):
-        return SpliceModelOracle(EXON, self.model, self.readout, device="cpu", **kw)
+    def _oracle(self, threshold=1.5, **kw):
+        return SpliceModelOracle(EXON, self.model, threshold, device="cpu", **kw)
 
     def test_alphabet_and_length(self):
         oracle = self._oracle()
@@ -95,15 +88,16 @@ class TestSpliceModelOracle(unittest.TestCase):
         self.assertEqual(oracle.string_length, EXON.random_text_length)
 
     def test_membership_batching_and_wrapping(self):
-        oracle = self._oracle(chunk=2)
+        oracle = self._oracle(threshold=1.5, chunk=2)
         result = oracle.membership_queries([[1, 2], [3], [0, 1, 2, 3, 0], []])
 
+        # the score is the middle length, so length > 1.5 -> [T, F, T, F]
         np.testing.assert_array_equal(result, [True, False, True, False])
         self.assertEqual(result.dtype, bool)
 
         self.assertEqual(len(self.model.seen), 2)
-        np.testing.assert_array_equal(self.seen_lengths[0], [2, 1])
-        np.testing.assert_array_equal(self.seen_lengths[1], [5, 0])
+        np.testing.assert_array_equal(self.model.seen_lengths[0], [2, 1])
+        np.testing.assert_array_equal(self.model.seen_lengths[1], [5, 0])
         w0, w1 = self.model.seen[0], self.model.seen[1]
         self.assertEqual(w0.shape, (2, 10))
         self.assertEqual(w1.shape, (2, 13))
@@ -112,9 +106,9 @@ class TestSpliceModelOracle(unittest.TestCase):
         np.testing.assert_array_equal(w1[1], wrapped_row([], 13))
 
     def test_membership_query_singular(self):
-        oracle = self._oracle()
-        self.assertTrue(oracle.membership_query([0, 0, 0]))
-        self.assertFalse(oracle.membership_query([0]))
+        oracle = self._oracle(threshold=1.5)
+        self.assertTrue(oracle.membership_query([0, 0, 0]))  # length 3 > 1.5
+        self.assertFalse(oracle.membership_query([0]))  # length 1 < 1.5
 
     def test_empty_batch(self):
         result = self._oracle().membership_queries([])
@@ -125,27 +119,27 @@ class TestSpliceModelOracle(unittest.TestCase):
         """Padding invariance has to hold at every query, so the oracle refuses a
         train-mode model rather than quietly switching one it does not own."""
         oracle = self._oracle()
-        self.model.training = True
+        self.model.train()
         with self.assertRaises(AssertionError):
             oracle.membership_queries([[1, 2]])
 
 
-class TestSpliceaiExonScores(unittest.TestCase):
+class TestSpliceaiExonScore(unittest.TestCase):
     """Everything here runs a real SpliceAI, so the readout's output indexing is
     checked against the model's actual cl trimming rather than a fake."""
 
     def setUp(self):
         self.model, self.exon = small_model_and_exon()
+        self.score_model = SpliceAIExonScore(self.model).eval()
         self.flank_l, self.flank_r = flanks(self.exon)
         self.rng = np.random.default_rng(1)
 
     def _scores(self, middles, chunk=64):
         return run_over_middles(
-            self.model,
+            self.score_model,
             self.flank_l,
             self.flank_r,
             middles,
-            spliceai_exon_scores,
             device="cpu",
             chunk=chunk,
         )
@@ -164,6 +158,7 @@ class TestSpliceaiExonScores(unittest.TestCase):
             reference.numpy(),
             rtol=1e-6,
         )
+        np.testing.assert_allclose(self._scores(middles), reference.numpy(), rtol=1e-6)
 
     def test_padding_does_not_change_scores(self):
         """A short middle scores the same whether or not it is padded up to a
@@ -182,11 +177,10 @@ class TestSpliceaiExonScores(unittest.TestCase):
         flank_l, flank_r = flanks(wide_exon)
         with self.assertRaises(AssertionError):
             run_over_middles(
-                self.model,
+                self.score_model,
                 flank_l,
                 flank_r,
                 [[0] * FULL_LENGTH],
-                spliceai_exon_scores,
                 device="cpu",
                 chunk=64,
             )
@@ -195,62 +189,33 @@ class TestSpliceaiExonScores(unittest.TestCase):
 class TestCalibration(unittest.TestCase):
     def setUp(self):
         self.model, self.exon = small_model_and_exon()
+        self.score_model = SpliceAIExonScore(self.model).eval()
 
     def test_threshold_splits_random_middles_in_half(self):
         length, count = 12, 256
         # .function skips permacache: nothing here is worth caching to disk.
         threshold = median_threshold.function(
-            self.model, self.exon, length, count=count, chunk=64, device="cpu"
+            self.score_model, self.exon, length, count=count, chunk=64, device="cpu"
         )
         oracle = SpliceModelOracle(
-            self.exon,
-            self.model,
-            calibrated_spliceai_readout(threshold, length),
-            device="cpu",
-            chunk=64,
+            self.exon, self.score_model, threshold, device="cpu", chunk=64
         )
         fresh = np.random.default_rng(7).integers(0, 4, size=(count, length)).tolist()
         self.assertAlmostEqual(oracle.membership_queries(fresh).mean(), 0.5, delta=0.15)
 
-    def test_warns_once_per_off_calibration_length(self):
-        oracle = SpliceModelOracle(
-            self.exon,
-            self.model,
-            calibrated_spliceai_readout(0.0, FULL_LENGTH),
-            device="cpu",
-            chunk=64,
-        )
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            oracle.membership_queries([[0] * n for n in [FULL_LENGTH, 5, 5, 7]])
-            oracle.membership_queries([[0] * 5])
-        self.assertEqual(len(caught), 2)  # lengths 5 and 7, once each
-        self.assertIn(
-            f"calibrated at middle length {FULL_LENGTH}", str(caught[0].message)
-        )
-
-    def test_readout_accepts_exactly_the_scores_above_the_threshold(self):
+    def test_oracle_accepts_exactly_the_scores_above_the_threshold(self):
         flank_l, flank_r = flanks(self.exon)
         middles = [
             np.random.default_rng(3).integers(0, 4, size=n).tolist()
             for n in [FULL_LENGTH, 9, 2]
         ]
         kw = dict(device="cpu", chunk=64)
-        scores = run_over_middles(
-            self.model, flank_l, flank_r, middles, spliceai_exon_scores, **kw
-        )
+        scores = run_over_middles(self.score_model, flank_l, flank_r, middles, **kw)
         threshold = float(np.median(scores))
-        oracle = SpliceModelOracle(
-            self.exon,
-            self.model,
-            calibrated_spliceai_readout(threshold, FULL_LENGTH),
-            **kw,
+        oracle = SpliceModelOracle(self.exon, self.score_model, threshold, **kw)
+        np.testing.assert_array_equal(
+            oracle.membership_queries(middles), scores > threshold
         )
-        with warnings.catch_warnings():  # the two short middles are off-calibration
-            warnings.simplefilter("ignore")
-            np.testing.assert_array_equal(
-                oracle.membership_queries(middles), scores > threshold
-            )
 
 
 class TestComputeExonScores(unittest.TestCase):
@@ -264,11 +229,10 @@ class TestComputeExonScores(unittest.TestCase):
         middles, arr = sample_text(self.exon, 0, 4)
         flank_l, flank_r = flanks(self.exon)
         via_oracle = run_over_middles(
-            self.model,
+            SpliceAIExonScore(self.model).eval(),
             flank_l,
             flank_r,
             middles.tolist(),
-            spliceai_exon_scores,
             device="cpu",
             chunk=64,
         )


### PR DESCRIPTION
Prep for making the composition-residual a model wrapper rather than a bespoke oracle. This PR removes the `readout` from `SpliceModelOracle` and packages the exon-score computation as an `nn.Module`.

## Change
- **`SpliceModelOracle(exon, score_model, threshold, ...)`** — takes an `nn.Module` score model with `forward(x, lengths) -> per-sequence exon score`, plus a `threshold`, instead of a `readout` callable. Membership = `score > threshold`.
- **`SpliceAIExonScore(nn.Module)`** (in `spliceai/exon_score.py`) wraps a splice model so its forward returns the exon score (`spliceai_exon_scores(self.model(x), lengths)`).
- **`run_over_middles(score_model, ...)`** applies the score model directly — still one-hots, `no_grad`s, and asserts eval mode on every call (now via `any(m.training for m in score_model.modules())`, so a flipped submodule is still caught).
- Drops `calibrated_spliceai_readout` / `_CalibratedReadout` and its off-length warning; calibration is just `median_threshold` + the oracle's `threshold`.

## Why
The composition residual is `raw_score − β·bow(middle)` — a shift on the scalar score. A logits-space readout can't express that through the readout's `log_softmax`, and the readout never sees the input sequence. With the score computed by an `nn.Module(x, lengths) → score`, a residual module can wrap it, pull the middle from `x`+`lengths`, and adjust the scalar. That's the follow-up PR.

## Unaffected
`oracle.run_model` still uses `forward_batch` / `spliceai_exon_scores` / `full_lengths` / `compute_exon_scores` unchanged; `compute_exon_scores` stays numerically identical (covered by `TestComputeExonScores`).

Tests 13/13, pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)