### PR TITLE
Make SpliceAI stable-hashable via __permacache_hash__

### DIFF
--- a/orthogonal_dfa/spliceai/module.py
+++ b/orthogonal_dfa/spliceai/module.py
@@ -86,6 +86,21 @@ class SpliceAI(nn.Module):
 
         self.hooks_handles = []
 
+    def __permacache_hash__(self):
+        """Identify this model to ``permacache.stable_hash``.
+
+        Without this, stable_hash's generic nn.Module encoding hashes every public
+        entry of ``__dict__``, which here includes ``preprocess`` -- a function, and
+        so not JSON-serializable, making every SpliceAI unhashable.  Naming the
+        contents explicitly also survives ``load_spliceai``, which unpickles whole
+        modules and restores that attribute whatever a constructor does about it.
+
+        ``w`` and ``cl`` come along because the weights alone do not identify the
+        model: ``ar`` sets the dilations, which change the receptive field without
+        changing a single parameter shape, so two models differing only in ``ar``
+        have byte-identical state_dicts.  ``cl`` is a function of both."""
+        return dict(state_dict=self.state_dict(), w=self.w, cl=self.cl)
+
     def forward(self, x):
         if isinstance(x, dict):
             x = x["x"]

--- a/tests/test_spliceai_hash.py
+++ b/tests/test_spliceai_hash.py
@@ -1,0 +1,65 @@
+import io
+import unittest
+
+import numpy as np
+import torch
+from permacache import stable_hash
+
+from orthogonal_dfa.spliceai.exon_score import SpliceAIExonScore
+from orthogonal_dfa.spliceai.module import SpliceAI, SpliceAIModule
+
+SMALL_CL = 80
+
+
+def stable(model):
+    return stable_hash(model, version=2)
+
+
+def exon_score(seed, cl=SMALL_CL):
+    torch.manual_seed(seed)
+    return SpliceAIExonScore(SpliceAIModule(window=cl)).eval()
+
+
+class TestSpliceAIStableHash(unittest.TestCase):
+    def test_a_wrapped_model_is_hashable(self):
+        # stable_hash's generic Module encoding walks __dict__, which holds the
+        # preprocess function; without __permacache_hash__ this raises TypeError.
+        self.assertIsInstance(stable(exon_score(0)), str)
+
+    def test_same_weights_hash_the_same(self):
+        self.assertEqual(stable(exon_score(0)), stable(exon_score(0)))
+
+    def test_different_weights_hash_differently(self):
+        self.assertNotEqual(stable(exon_score(0)), stable(exon_score(1)))
+
+    def test_dilation_is_not_invisible(self):
+        # ar sets the dilations, which move the receptive field without changing any
+        # parameter shape, so these two have byte-identical state_dicts.  Hashing the
+        # weights alone would collide them.
+        w = np.array([11, 11])
+        wide = SpliceAI(l=8, w=w, ar=np.array([1, 4]))
+        narrow = SpliceAI(l=8, w=w, ar=np.array([1, 1]))
+        wide.load_state_dict(narrow.state_dict())
+        self.assertNotEqual(narrow.cl, wide.cl)
+        self.assertNotEqual(stable(narrow), stable(wide))
+
+    def test_hash_survives_a_pickle_round_trip(self):
+        # load_spliceai unpickles whole modules, which restores preprocess onto the
+        # instance; the hook is on the class, so the hash is unaffected.
+        model = exon_score(0)
+        buffer = io.BytesIO()
+        torch.save(model, buffer)
+        buffer.seek(0)
+        loaded = torch.load(buffer, weights_only=False)
+        self.assertTrue(hasattr(loaded.model.spliceai, "preprocess"))
+        self.assertEqual(stable(loaded), stable(model))
+
+    def test_loading_weights_makes_hashes_agree(self):
+        model, other = exon_score(0), exon_score(1)
+        self.assertNotEqual(stable(model), stable(other))
+        other.load_state_dict(model.state_dict())
+        self.assertEqual(stable(model), stable(other))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`permacache.stable_hash` cannot hash *any* SpliceAI model:

```
TypeError: Object of type function is not JSON serializable
```

Its version-2 `nn.Module` encoding hashes every public entry of `__dict__`, and `SpliceAI` keeps `preprocess` there — a function, so not JSON-serializable.

The effect is that every permacached helper keyed on a splice model is dead weight. `median_threshold` (and the composition-residual fit in #152) declare `score_model=lambda m: stable_hash(m, version=2)` as their key function, so calling them raises instead of caching, and callers have to reach past the decorator to `.function` and recompute. That's why the tests all call `median_threshold.function(...)`.

## Fix

`stable_hash` checks `type(o).__permacache_hash__` *before* its generic Module path, so defining one on `SpliceAI` black-boxes the awkward class while every other model in the graph (`SpliceAIExonScore`, `SpliceAIModule`) keeps the automatic attribute pickup.

Two things beyond the obvious:

**The weights alone do not identify the model.** `ar` sets the dilations, which move the receptive field without changing any parameter shape, so two models differing only in `ar` have byte-identical `state_dict`s:

```
identical state_dict despite different ar: True
  a.cl = 40   b.cl = 100
```

The hook carries `w` and `cl` alongside the state_dict for that reason.

**It goes on the class, not in `__init__`.** `load_spliceai` unpickles whole modules (`weights_only=False`), so pretrained checkpoints restore `preprocess` onto the instance regardless of what a constructor does about it — and those are exactly the models the cache is for.

## No cache invalidation

Nothing on disk is keyed on a SpliceAI hash today, because computing that key always raised. So this only enables caching that never worked; it doesn't orphan existing entries.

## Tests

`tests/test_spliceai_hash.py` — hashability, weight sensitivity, that two models differing only in dilation are distinguished, that the hash survives a pickle round-trip (the loaded model does have `preprocess` restored), and that `load_state_dict` makes hashes agree. `6 passed`; isort/black/pylint clean.

Verified the suite has teeth: deleting the hook restores the original `TypeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)