### PR TITLE
Add SetDifferenceOracle and the FM loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@ env
 dist
 build
 
-# FM model TorchScript traces (regenerate via scripts/convert_fm_to_torchscript.py)
+# FM model TorchScript traces (regenerate via scripts/convert_fm_to_torchscript.py).
+# Seed 1 is checked in (the only seed the oracle uses); 2..5 stay regenerable.
 data/pretrained_models/fm-*.traced.pt
+!data/pretrained_models/fm-1.traced.pt

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ env
 *.egg-info
 dist
 build
+
+# FM model TorchScript traces (regenerate via scripts/convert_fm_to_torchscript.py)
+data/pretrained_models/fm-*.traced.pt

--- a/orthogonal_dfa/l_star/examples/set_difference.py
+++ b/orthogonal_dfa/l_star/examples/set_difference.py
@@ -1,0 +1,65 @@
+r"""The set-difference oracle and the fixed-motif (FM) model it contrasts SpliceAI against.
+
+``a \ b`` accepts exactly the strings ``a`` accepts and ``b`` rejects, so running E-L\*
+on it isolates what one splice model captures that another does not.  In practice that
+is SpliceAI against the fixed-motif model loaded by :func:`load_fm`; both are wrapped
+the same way (e.g. by ``SpliceAIExonScore`` into a ``SpliceModelOracle``) and differenced.
+"""
+
+import sys
+from typing import List
+
+import numpy as np
+
+from orthogonal_dfa.l_star.structures import Oracle
+
+# The fixed-motif ("FM") model is a trained modular_splicing model living in a separate
+# repo on this machine (BothLSSIModels + an 82-motif RBNS PSAMMotifModel).
+FM_REPO = "/mnt/md0/ExpeditionsCommon/spliceai/Canonical"
+FM_MODEL_PREFIX = f"{FM_REPO}/model/msp-273.665a3"
+
+
+def load_fm(seed=1):
+    """Load the fixed-motif model (seed 1..5) as an eval/cuda nn.Module.
+
+    ``modular_splicing`` lives in ``FM_REPO`` (added to ``sys.path`` here), not in this
+    package's dependencies.  The returned model reads the same acceptor/donor logits as
+    SpliceAI, so ``SpliceAIExonScore`` wraps it identically."""
+    if FM_REPO not in sys.path:
+        sys.path.insert(0, FM_REPO)
+    from modular_splicing.utils.io import load_model  # pylint: disable=import-error
+
+    _, model = load_model(f"{FM_MODEL_PREFIX}_{seed}")  # picks the latest step
+    return model.eval().cuda()
+
+
+class SetDifferenceOracle(Oracle):
+    r"""``a \ b``: accepts iff ``a`` accepts and ``b`` does not.
+
+    A generic combinator over two oracles on the same alphabet; used to contrast
+    SpliceAI against the FM (e.g. two balanced oracles, or two composition-residual
+    oracles with composition stripped from both before differencing).
+    """
+
+    def __init__(self, oracle_a: Oracle, oracle_b: Oracle):
+        assert (
+            oracle_a.alphabet_size == oracle_b.alphabet_size
+        ), "the two oracles must share an alphabet"
+        self._a = oracle_a
+        self._b = oracle_b
+
+    @property
+    def alphabet_size(self) -> int:
+        return self._a.alphabet_size
+
+    @property
+    def string_length(self) -> int:
+        return self._a.string_length
+
+    def membership_queries(self, strings: List[List[int]]) -> np.ndarray:
+        return self._a.membership_queries(strings) & ~self._b.membership_queries(
+            strings
+        )
+
+    def membership_query(self, string: List[int]) -> bool:
+        return bool(self.membership_queries([string])[0])

--- a/orthogonal_dfa/l_star/examples/set_difference.py
+++ b/orthogonal_dfa/l_star/examples/set_difference.py
@@ -14,8 +14,9 @@ import torch
 
 from orthogonal_dfa.l_star.structures import Oracle
 
-# Where the self-contained FM TorchScript traces live (gitignored; produced by
-# scripts/convert_fm_to_torchscript.py on the machine that has the modular_splicing repo).
+# Where the self-contained FM TorchScript traces live. Seed 1 (the one the oracle uses)
+# is checked in; other seeds are gitignored, regenerable via
+# scripts/convert_fm_to_torchscript.py on the machine with the modular_splicing repo.
 FM_TRACED_DIR = "data/pretrained_models"
 
 

--- a/orthogonal_dfa/l_star/examples/set_difference.py
+++ b/orthogonal_dfa/l_star/examples/set_difference.py
@@ -1,37 +1,17 @@
-r"""The set-difference oracle and the fixed-motif (FM) model it contrasts SpliceAI against.
+r"""The set-difference oracle: ``a \ b`` accepts the strings ``a`` accepts and ``b``
+rejects.
 
-``a \ b`` accepts exactly the strings ``a`` accepts and ``b`` rejects, so running E-L\*
-on it isolates what one splice model captures that another does not.  In practice that
-is SpliceAI against the fixed-motif model loaded by :func:`load_fm`; both are wrapped
-the same way (e.g. by ``SpliceAIExonScore`` into a ``SpliceModelOracle``) and differenced.
+Running E-L\* on it isolates what one splice model captures that another does not -- in
+practice SpliceAI against the fixed-motif model (``load_fm`` in
+``orthogonal_dfa.spliceai.load_model``); both are wrapped the same way (e.g. by
+``SpliceAIExonScore`` into a ``SpliceModelOracle``) and differenced.
 """
 
-import os
 from typing import List
 
 import numpy as np
-import torch
 
 from orthogonal_dfa.l_star.structures import Oracle
-
-# Where the self-contained FM TorchScript traces live. Seed 1 (the one the oracle uses)
-# is checked in; other seeds are gitignored, regenerable via
-# scripts/convert_fm_to_torchscript.py on the machine with the modular_splicing repo.
-FM_TRACED_DIR = "data/pretrained_models"
-
-
-def load_fm(seed=1):
-    """Load the fixed-motif model (seed 1..5) as an eval/cuda TorchScript module.
-
-    A trained modular_splicing model (BothLSSIModels + an 82-motif RBNS PSAMMotifModel),
-    converted to a self-contained trace so loading needs only torch.  Reads the same
-    acceptor/donor logits as SpliceAI, so ``SpliceAIExonScore`` wraps it identically."""
-    path = os.path.join(FM_TRACED_DIR, f"fm-{seed}.traced.pt")
-    assert os.path.exists(path), (
-        f"{path} is missing; generate the FM traces (on the machine with the "
-        f"modular_splicing repo) via scripts/convert_fm_to_torchscript.py"
-    )
-    return torch.jit.load(path).eval().cuda()
 
 
 class SetDifferenceOracle(Oracle):

--- a/orthogonal_dfa/l_star/examples/set_difference.py
+++ b/orthogonal_dfa/l_star/examples/set_difference.py
@@ -1,12 +1,3 @@
-r"""The set-difference oracle: ``a \ b`` accepts the strings ``a`` accepts and ``b``
-rejects.
-
-Running E-L\* on it isolates what one splice model captures that another does not -- in
-practice SpliceAI against the fixed-motif model (``load_fm`` in
-``orthogonal_dfa.spliceai.load_model``); both are wrapped the same way (e.g. by
-``SpliceAIExonScore`` into a ``SpliceModelOracle``) and differenced.
-"""
-
 from typing import List
 
 import numpy as np
@@ -15,13 +6,6 @@ from orthogonal_dfa.l_star.structures import Oracle
 
 
 class SetDifferenceOracle(Oracle):
-    r"""``a \ b``: accepts iff ``a`` accepts and ``b`` does not.
-
-    A generic combinator over two oracles on the same alphabet; used to contrast
-    SpliceAI against the FM (e.g. two balanced oracles, or two composition-residual
-    oracles with composition stripped from both before differencing).
-    """
-
     def __init__(self, oracle_a: Oracle, oracle_b: Oracle):
         assert (
             oracle_a.alphabet_size == oracle_b.alphabet_size

--- a/orthogonal_dfa/l_star/examples/set_difference.py
+++ b/orthogonal_dfa/l_star/examples/set_difference.py
@@ -6,31 +6,31 @@ is SpliceAI against the fixed-motif model loaded by :func:`load_fm`; both are wr
 the same way (e.g. by ``SpliceAIExonScore`` into a ``SpliceModelOracle``) and differenced.
 """
 
-import sys
+import os
 from typing import List
 
 import numpy as np
+import torch
 
 from orthogonal_dfa.l_star.structures import Oracle
 
-# The fixed-motif ("FM") model is a trained modular_splicing model living in a separate
-# repo on this machine (BothLSSIModels + an 82-motif RBNS PSAMMotifModel).
-FM_REPO = "/mnt/md0/ExpeditionsCommon/spliceai/Canonical"
-FM_MODEL_PREFIX = f"{FM_REPO}/model/msp-273.665a3"
+# Where the self-contained FM TorchScript traces live (gitignored; produced by
+# scripts/convert_fm_to_torchscript.py on the machine that has the modular_splicing repo).
+FM_TRACED_DIR = "data/pretrained_models"
 
 
 def load_fm(seed=1):
-    """Load the fixed-motif model (seed 1..5) as an eval/cuda nn.Module.
+    """Load the fixed-motif model (seed 1..5) as an eval/cuda TorchScript module.
 
-    ``modular_splicing`` lives in ``FM_REPO`` (added to ``sys.path`` here), not in this
-    package's dependencies.  The returned model reads the same acceptor/donor logits as
-    SpliceAI, so ``SpliceAIExonScore`` wraps it identically."""
-    if FM_REPO not in sys.path:
-        sys.path.insert(0, FM_REPO)
-    from modular_splicing.utils.io import load_model  # pylint: disable=import-error
-
-    _, model = load_model(f"{FM_MODEL_PREFIX}_{seed}")  # picks the latest step
-    return model.eval().cuda()
+    A trained modular_splicing model (BothLSSIModels + an 82-motif RBNS PSAMMotifModel),
+    converted to a self-contained trace so loading needs only torch.  Reads the same
+    acceptor/donor logits as SpliceAI, so ``SpliceAIExonScore`` wraps it identically."""
+    path = os.path.join(FM_TRACED_DIR, f"fm-{seed}.traced.pt")
+    assert os.path.exists(path), (
+        f"{path} is missing; generate the FM traces (on the machine with the "
+        f"modular_splicing repo) via scripts/convert_fm_to_torchscript.py"
+    )
+    return torch.jit.load(path).eval().cuda()
 
 
 class SetDifferenceOracle(Oracle):

--- a/orthogonal_dfa/spliceai/load_model.py
+++ b/orthogonal_dfa/spliceai/load_model.py
@@ -1,7 +1,9 @@
+import hashlib
 import os
 import pickle
 
 import torch
+from torch import nn
 
 MODULE_RENAME_MAP = {
     "spliceai_torch": "orthogonal_dfa.spliceai.module",
@@ -72,16 +74,50 @@ def load_lssi(which, seed):
     )
 
 
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+class TracedFM(nn.Module):
+    """The FM TorchScript trace, tagged with the hash of the file it came from.
+
+    permacache's ``stable_hash`` walks an eager model's state dict, but a
+    ScriptModule is opaque to it and raises instead, so anything permacached on
+    the model (``median_threshold``, the E-L* oracle) cannot compute a key.
+    ``__permacache_hash__`` answers with the artifact's hash, which identifies
+    the weights just as precisely: regenerating a trace changes the file.
+    """
+
+    def __init__(self, model, trace_sha256: str):
+        super().__init__()
+        self.model = model
+        self.trace_sha256 = trace_sha256
+
+    def forward(self, x):
+        return self.model(x)
+
+    def __permacache_hash__(self):
+        return {"fm_trace_sha256": self.trace_sha256}
+
+
 def load_fm(seed=1):
     """
     Load the fixed-motif (FM) model as a self-contained TorchScript artifact.
 
     Reads the same acceptor/donor logits as SpliceAI, so ``SpliceAIExonScore``
     wraps it identically.
+
+    The trace has ``cuda:0`` baked into every device it names, so select a GPU
+    with ``CUDA_VISIBLE_DEVICES`` rather than moving the module: ``.to("cuda:1")``
+    moves the parameters while the baked constants keep producing cuda:0 tensors.
     """
     path = os.path.join(PRETRAINED_DIR, f"fm-{seed}.traced.pt")
     assert os.path.exists(path), (
         f"{path} is missing; generate the FM traces (on the machine with the "
         f"modular_splicing repo) via scripts/convert_fm_to_torchscript.py"
     )
-    return torch.jit.load(path).eval().cuda()
+    return TracedFM(torch.jit.load(path), file_sha256(path)).eval().cuda()

--- a/orthogonal_dfa/spliceai/load_model.py
+++ b/orthogonal_dfa/spliceai/load_model.py
@@ -73,12 +73,12 @@ def load_lssi(which, seed):
 
 
 def load_fm(seed=1):
-    """Load the fixed-motif (FM) model (seed 1..5) as an eval/cuda TorchScript module.
+    """
+    Load the fixed-motif (FM) model as a self-contained TorchScript artifact.
 
-    A trained modular_splicing model (BothLSSIModels + an 82-motif RBNS PSAMMotifModel),
-    converted to a self-contained trace so loading needs only torch (unlike the eager
-    model, which needs the modular_splicing repo).  Reads the same acceptor/donor logits
-    as SpliceAI, so ``SpliceAIExonScore`` wraps it identically."""
+    Reads the same acceptor/donor logits as SpliceAI, so ``SpliceAIExonScore``
+    wraps it identically.
+    """
     path = os.path.join(PRETRAINED_DIR, f"fm-{seed}.traced.pt")
     assert os.path.exists(path), (
         f"{path} is missing; generate the FM traces (on the machine with the "

--- a/orthogonal_dfa/spliceai/load_model.py
+++ b/orthogonal_dfa/spliceai/load_model.py
@@ -41,13 +41,16 @@ class remapping_pickle:
         return hasattr(pickle, name)
 
 
+PRETRAINED_DIR = "data/pretrained_models"
+
+
 def load_spliceai(size, seed):
     assert size in (400, 10000, "10k")
     if size == 10000:
         size = "10k"
     return (
         torch.load(
-            os.path.join("data/pretrained_models", f"spliceai-{size}-{seed}.pt"),
+            os.path.join(PRETRAINED_DIR, f"spliceai-{size}-{seed}.pt"),
             weights_only=False,
             pickle_module=remapping_pickle(),
         )
@@ -60,7 +63,7 @@ def load_lssi(which, seed):
     assert which in ("donor", "acceptor")
     return (
         torch.load(
-            os.path.join("data/pretrained_models", f"{which}-{seed}.pt"),
+            os.path.join(PRETRAINED_DIR, f"{which}-{seed}.pt"),
             weights_only=False,
             pickle_module=remapping_pickle(),
         )
@@ -76,7 +79,7 @@ def load_fm(seed=1):
     converted to a self-contained trace so loading needs only torch (unlike the eager
     model, which needs the modular_splicing repo).  Reads the same acceptor/donor logits
     as SpliceAI, so ``SpliceAIExonScore`` wraps it identically."""
-    path = os.path.join("data/pretrained_models", f"fm-{seed}.traced.pt")
+    path = os.path.join(PRETRAINED_DIR, f"fm-{seed}.traced.pt")
     assert os.path.exists(path), (
         f"{path} is missing; generate the FM traces (on the machine with the "
         f"modular_splicing repo) via scripts/convert_fm_to_torchscript.py"

--- a/orthogonal_dfa/spliceai/load_model.py
+++ b/orthogonal_dfa/spliceai/load_model.py
@@ -67,3 +67,23 @@ def load_lssi(which, seed):
         .eval()
         .cuda()
     )
+
+
+# Seed 1 (the one the oracle uses) is checked in; other seeds are gitignored, regenerable
+# via scripts/convert_fm_to_torchscript.py on the machine with the modular_splicing repo.
+FM_TRACED_DIR = "data/pretrained_models"
+
+
+def load_fm(seed=1):
+    """Load the fixed-motif (FM) model (seed 1..5) as an eval/cuda TorchScript module.
+
+    A trained modular_splicing model (BothLSSIModels + an 82-motif RBNS PSAMMotifModel),
+    converted to a self-contained trace so loading needs only torch (unlike the eager
+    model, which needs the modular_splicing repo).  Reads the same acceptor/donor logits
+    as SpliceAI, so ``SpliceAIExonScore`` wraps it identically."""
+    path = os.path.join(FM_TRACED_DIR, f"fm-{seed}.traced.pt")
+    assert os.path.exists(path), (
+        f"{path} is missing; generate the FM traces (on the machine with the "
+        f"modular_splicing repo) via scripts/convert_fm_to_torchscript.py"
+    )
+    return torch.jit.load(path).eval().cuda()

--- a/orthogonal_dfa/spliceai/load_model.py
+++ b/orthogonal_dfa/spliceai/load_model.py
@@ -69,11 +69,6 @@ def load_lssi(which, seed):
     )
 
 
-# Seed 1 (the one the oracle uses) is checked in; other seeds are gitignored, regenerable
-# via scripts/convert_fm_to_torchscript.py on the machine with the modular_splicing repo.
-FM_TRACED_DIR = "data/pretrained_models"
-
-
 def load_fm(seed=1):
     """Load the fixed-motif (FM) model (seed 1..5) as an eval/cuda TorchScript module.
 
@@ -81,7 +76,7 @@ def load_fm(seed=1):
     converted to a self-contained trace so loading needs only torch (unlike the eager
     model, which needs the modular_splicing repo).  Reads the same acceptor/donor logits
     as SpliceAI, so ``SpliceAIExonScore`` wraps it identically."""
-    path = os.path.join(FM_TRACED_DIR, f"fm-{seed}.traced.pt")
+    path = os.path.join("data/pretrained_models", f"fm-{seed}.traced.pt")
     assert os.path.exists(path), (
         f"{path} is missing; generate the FM traces (on the machine with the "
         f"modular_splicing repo) via scripts/convert_fm_to_torchscript.py"

--- a/scripts/convert_fm_to_torchscript.py
+++ b/scripts/convert_fm_to_torchscript.py
@@ -1,12 +1,4 @@
-r"""Convert the fixed-motif (FM) model to self-contained TorchScript artifacts.
-
-Run once, on the machine that has the ``modular_splicing`` repo (``FM_REPO``). Loading
-the FM eagerly pulls in ~55 modular_splicing/shelved modules, but only ~21 files / ~345
-lines actually run in a forward pass, and ``torch.jit.trace`` captures exactly that path.
-The trace was verified bit-identical to eager across the whole length range the E-L*
-oracle queries, so afterwards :func:`load_fm` needs only torch -- no modular_splicing.
-
-Writes ``data/pretrained_models/fm-<seed>.traced.pt`` (gitignored; ~23 MB each).
+"""Convert the fixed-motif (FM) model to self-contained TorchScript artifacts.
 
     python scripts/convert_fm_to_torchscript.py           # seeds 1..5
     python scripts/convert_fm_to_torchscript.py 1 3       # specific seeds
@@ -42,7 +34,7 @@ def convert(seed):
     example = torch.zeros(2, TRACE_WIDTH, 4, device="cuda")
     example[:, torch.arange(TRACE_WIDTH), torch.randint(0, 4, (TRACE_WIDTH,))] = 1.0
     with torch.no_grad():
-        traced = torch.jit.trace(model, (example,), check_trace=False)
+        traced = torch.jit.trace(model, (example,), check_trace=True)
     os.makedirs(FM_TRACED_DIR, exist_ok=True)
     path = os.path.join(FM_TRACED_DIR, f"fm-{seed}.traced.pt")
     torch.jit.save(traced, path)

--- a/scripts/convert_fm_to_torchscript.py
+++ b/scripts/convert_fm_to_torchscript.py
@@ -30,6 +30,9 @@ def _load_eager(seed):
 
 def convert(seed):
     model = _load_eager(seed)
+    # Seeded so the artifact is byte-reproducible: its sha256 is the permacache key
+    # that load_fm tags the model with.
+    torch.manual_seed(seed)
     example = torch.zeros(2, TRACE_WIDTH, 4, device="cuda")
     example[:, torch.arange(TRACE_WIDTH), torch.randint(0, 4, (TRACE_WIDTH,))] = 1.0
     with torch.no_grad():

--- a/scripts/convert_fm_to_torchscript.py
+++ b/scripts/convert_fm_to_torchscript.py
@@ -1,0 +1,60 @@
+r"""Convert the fixed-motif (FM) model to self-contained TorchScript artifacts.
+
+Run once, on the machine that has the ``modular_splicing`` repo (``FM_REPO``). Loading
+the FM eagerly pulls in ~55 modular_splicing/shelved modules, but only ~21 files / ~345
+lines actually run in a forward pass, and ``torch.jit.trace`` captures exactly that path.
+The trace was verified bit-identical to eager across the whole length range the E-L*
+oracle queries, so afterwards :func:`load_fm` needs only torch -- no modular_splicing.
+
+Writes ``data/pretrained_models/fm-<seed>.traced.pt`` (gitignored; ~23 MB each).
+
+    python scripts/convert_fm_to_torchscript.py           # seeds 1..5
+    python scripts/convert_fm_to_torchscript.py 1 3       # specific seeds
+"""
+
+import os
+import sys
+
+import torch
+
+from orthogonal_dfa.l_star.examples.set_difference import FM_TRACED_DIR
+
+FM_REPO = "/mnt/md0/ExpeditionsCommon/spliceai/Canonical"
+FM_MODEL_PREFIX = f"{FM_REPO}/model/msp-273.665a3"
+# Any width > cl (400); the trace generalizes across lengths (conv/attention crop off
+# tensor shapes), verified bit-exact over the oracle's 499..593 input range.
+TRACE_WIDTH = 560
+
+
+def _load_eager(seed):
+    if FM_REPO not in sys.path:
+        sys.path.insert(0, FM_REPO)
+    # modular_splicing lives in FM_REPO (on sys.path above), not in this package.
+    from modular_splicing.utils.io import load_model  # pylint: disable=import-error
+
+    _, model = load_model(f"{FM_MODEL_PREFIX}_{seed}")  # picks the latest step
+    return model.eval().cuda()
+
+
+def convert(seed):
+    """Trace FM seed ``seed`` and save it, returning the artifact path."""
+    model = _load_eager(seed)
+    example = torch.zeros(2, TRACE_WIDTH, 4, device="cuda")
+    example[:, torch.arange(TRACE_WIDTH), torch.randint(0, 4, (TRACE_WIDTH,))] = 1.0
+    with torch.no_grad():
+        traced = torch.jit.trace(model, (example,), check_trace=False)
+    os.makedirs(FM_TRACED_DIR, exist_ok=True)
+    path = os.path.join(FM_TRACED_DIR, f"fm-{seed}.traced.pt")
+    torch.jit.save(traced, path)
+    return path
+
+
+def main():
+    seeds = [int(s) for s in sys.argv[1:]] or [1, 2, 3, 4, 5]
+    for seed in seeds:
+        path = convert(seed)
+        print(f"seed {seed}: {path} ({os.path.getsize(path) / 1e6:.1f} MB)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_fm_to_torchscript.py
+++ b/scripts/convert_fm_to_torchscript.py
@@ -17,7 +17,7 @@ import sys
 
 import torch
 
-from orthogonal_dfa.l_star.examples.set_difference import FM_TRACED_DIR
+from orthogonal_dfa.spliceai.load_model import FM_TRACED_DIR
 
 FM_REPO = "/mnt/md0/ExpeditionsCommon/spliceai/Canonical"
 FM_MODEL_PREFIX = f"{FM_REPO}/model/msp-273.665a3"

--- a/scripts/convert_fm_to_torchscript.py
+++ b/scripts/convert_fm_to_torchscript.py
@@ -9,12 +9,12 @@ import sys
 
 import torch
 
-from orthogonal_dfa.spliceai.load_model import FM_TRACED_DIR
+from orthogonal_dfa.spliceai.load_model import PRETRAINED_DIR
 
 FM_REPO = "/mnt/md0/ExpeditionsCommon/spliceai/Canonical"
 FM_MODEL_PREFIX = f"{FM_REPO}/model/msp-273.665a3"
 # Any width > cl (400); the trace generalizes across lengths (conv/attention crop off
-# tensor shapes), verified bit-exact over the oracle's 499..593 input range.
+# tensor shapes).
 TRACE_WIDTH = 560
 
 
@@ -35,8 +35,8 @@ def convert(seed):
     example[:, torch.arange(TRACE_WIDTH), torch.randint(0, 4, (TRACE_WIDTH,))] = 1.0
     with torch.no_grad():
         traced = torch.jit.trace(model, (example,), check_trace=True)
-    os.makedirs(FM_TRACED_DIR, exist_ok=True)
-    path = os.path.join(FM_TRACED_DIR, f"fm-{seed}.traced.pt")
+    os.makedirs(PRETRAINED_DIR, exist_ok=True)
+    path = os.path.join(PRETRAINED_DIR, f"fm-{seed}.traced.pt")
     torch.jit.save(traced, path)
     return path
 

--- a/scripts/convert_fm_to_torchscript.py
+++ b/scripts/convert_fm_to_torchscript.py
@@ -29,7 +29,6 @@ def _load_eager(seed):
 
 
 def convert(seed):
-    """Trace FM seed ``seed`` and save it, returning the artifact path."""
     model = _load_eager(seed)
     example = torch.zeros(2, TRACE_WIDTH, 4, device="cuda")
     example[:, torch.arange(TRACE_WIDTH), torch.randint(0, 4, (TRACE_WIDTH,))] = 1.0

--- a/tests/test_load_fm.py
+++ b/tests/test_load_fm.py
@@ -2,10 +2,57 @@ import os
 import unittest
 
 import torch
+from permacache import stable_hash
+from torch import nn
 
-from orthogonal_dfa.spliceai.load_model import PRETRAINED_DIR, load_fm
+from orthogonal_dfa.spliceai.exon_score import SpliceAIExonScore
+from orthogonal_dfa.spliceai.load_model import (
+    PRETRAINED_DIR,
+    TracedFM,
+    file_sha256,
+    load_fm,
+)
 
 FM_SEED1 = os.path.join(PRETRAINED_DIR, "fm-1.traced.pt")
+
+
+def traced_stub():
+    """A tiny traced module standing in for the FM trace, so the tests below need
+    neither the artifact nor a GPU."""
+    return torch.jit.trace(nn.Linear(4, 4).eval(), (torch.zeros(2, 4),))
+
+
+class TestTracedFMHash(unittest.TestCase):
+    def test_bare_trace_is_unhashable(self):
+        # The reason TracedFM exists: stable_hash cannot walk a ScriptModule.
+        with self.assertRaises(TypeError):
+            stable_hash(traced_stub(), version=2)
+
+    def test_hash_follows_the_artifact_hash(self):
+        # Same declared hash, different underlying weights: equal, because the
+        # trace itself is never walked.
+        self.assertEqual(
+            stable_hash(TracedFM(traced_stub(), "abc"), version=2),
+            stable_hash(TracedFM(traced_stub(), "abc"), version=2),
+        )
+        self.assertNotEqual(
+            stable_hash(TracedFM(traced_stub(), "abc"), version=2),
+            stable_hash(TracedFM(traced_stub(), "def"), version=2),
+        )
+
+    def test_hash_survives_being_wrapped_for_scoring(self):
+        def wrap(sha):
+            return stable_hash(
+                SpliceAIExonScore(TracedFM(traced_stub(), sha)), version=2
+            )
+
+        self.assertEqual(wrap("abc"), wrap("abc"))
+        self.assertNotEqual(wrap("abc"), wrap("def"))
+
+    def test_forwards_to_the_wrapped_trace(self):
+        trace = traced_stub()
+        x = torch.zeros(2, 4)
+        self.assertTrue(torch.equal(TracedFM(trace, "abc")(x), trace(x)))
 
 
 @unittest.skipUnless(
@@ -22,6 +69,9 @@ class TestLoadFM(unittest.TestCase):
             out = model(x)
         # (N, L - cl, 3): the cl=400 acceptor/donor/null logits SpliceAIExonScore reads.
         self.assertEqual(tuple(out.shape), (2, length - 400, 3))
+
+    def test_tagged_with_the_artifact_hash(self):
+        self.assertEqual(load_fm(1).trace_sha256, file_sha256(FM_SEED1))
 
 
 if __name__ == "__main__":

--- a/tests/test_load_fm.py
+++ b/tests/test_load_fm.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+
+import torch
+
+from orthogonal_dfa.spliceai.load_model import FM_TRACED_DIR, load_fm
+
+FM_SEED1 = os.path.join(FM_TRACED_DIR, "fm-1.traced.pt")
+
+
+@unittest.skipUnless(
+    os.path.exists(FM_SEED1) and torch.cuda.is_available(),
+    "FM trace / cuda not available; regenerate via scripts/convert_fm_to_torchscript.py",
+)
+class TestLoadFM(unittest.TestCase):
+    def test_trace_loads_and_forwards_without_modular_splicing(self):
+        model = load_fm(1)
+        length = 500
+        x = torch.zeros(2, length, 4, device="cuda")
+        x[:, torch.arange(length), torch.randint(0, 4, (length,))] = 1.0
+        with torch.no_grad():
+            out = model(x)
+        # (N, L - cl, 3): the cl=400 acceptor/donor/null logits SpliceAIExonScore reads.
+        self.assertEqual(tuple(out.shape), (2, length - 400, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_load_fm.py
+++ b/tests/test_load_fm.py
@@ -6,12 +6,7 @@ from permacache import stable_hash
 from torch import nn
 
 from orthogonal_dfa.spliceai.exon_score import SpliceAIExonScore
-from orthogonal_dfa.spliceai.load_model import (
-    PRETRAINED_DIR,
-    TracedFM,
-    file_sha256,
-    load_fm,
-)
+from orthogonal_dfa.spliceai.load_model import PRETRAINED_DIR, TracedFM, load_fm
 
 FM_SEED1 = os.path.join(PRETRAINED_DIR, "fm-1.traced.pt")
 
@@ -23,11 +18,6 @@ def traced_stub():
 
 
 class TestTracedFMHash(unittest.TestCase):
-    def test_bare_trace_is_unhashable(self):
-        # The reason TracedFM exists: stable_hash cannot walk a ScriptModule.
-        with self.assertRaises(TypeError):
-            stable_hash(traced_stub(), version=2)
-
     def test_hash_follows_the_artifact_hash(self):
         # Same declared hash, different underlying weights: equal, because the
         # trace itself is never walked.
@@ -69,9 +59,6 @@ class TestLoadFM(unittest.TestCase):
             out = model(x)
         # (N, L - cl, 3): the cl=400 acceptor/donor/null logits SpliceAIExonScore reads.
         self.assertEqual(tuple(out.shape), (2, length - 400, 3))
-
-    def test_tagged_with_the_artifact_hash(self):
-        self.assertEqual(load_fm(1).trace_sha256, file_sha256(FM_SEED1))
 
 
 if __name__ == "__main__":

--- a/tests/test_load_fm.py
+++ b/tests/test_load_fm.py
@@ -3,9 +3,9 @@ import unittest
 
 import torch
 
-from orthogonal_dfa.spliceai.load_model import FM_TRACED_DIR, load_fm
+from orthogonal_dfa.spliceai.load_model import PRETRAINED_DIR, load_fm
 
-FM_SEED1 = os.path.join(FM_TRACED_DIR, "fm-1.traced.pt")
+FM_SEED1 = os.path.join(PRETRAINED_DIR, "fm-1.traced.pt")
 
 
 @unittest.skipUnless(

--- a/tests/test_set_difference.py
+++ b/tests/test_set_difference.py
@@ -1,0 +1,81 @@
+import unittest
+
+import numpy as np
+
+from orthogonal_dfa.l_star.examples.set_difference import SetDifferenceOracle
+from orthogonal_dfa.l_star.structures import Oracle
+
+
+class PredicateOracle(Oracle):
+    """Accepts a string iff ``predicate(string)``; records what it was asked."""
+
+    def __init__(self, predicate, *, alphabet_size=4, string_length=8):
+        self._predicate = predicate
+        self._alphabet_size = alphabet_size
+        self._string_length = string_length
+        self.seen = []
+
+    @property
+    def alphabet_size(self):
+        return self._alphabet_size
+
+    @property
+    def string_length(self):
+        return self._string_length
+
+    def membership_queries(self, strings):
+        self.seen.append([list(s) for s in strings])
+        return np.array([bool(self._predicate(s)) for s in strings], dtype=bool)
+
+    def membership_query(self, string):
+        return bool(self._predicate(string))
+
+
+class TestSetDifferenceOracle(unittest.TestCase):
+    def setUp(self):
+        # a accepts strings starting with 0; b accepts strings ending with 0.
+        self.a = PredicateOracle(lambda s: s[0] == 0)
+        self.b = PredicateOracle(lambda s: s[-1] == 0)
+        self.oracle = SetDifferenceOracle(self.a, self.b)
+
+    def test_accepts_exactly_a_and_not_b(self):
+        strings = [[0, 1, 0], [0, 1, 1], [1, 1, 0], [1, 1, 1]]
+        result = self.oracle.membership_queries(strings)
+        # a: [T, T, F, F], b: [T, F, T, F] -> a & ~b: [F, T, F, F]
+        np.testing.assert_array_equal(result, [False, True, False, False])
+        self.assertEqual(result.dtype, bool)
+
+    def test_membership_query_singular(self):
+        self.assertTrue(self.oracle.membership_query([0, 1, 1]))  # a yes, b no
+        self.assertFalse(self.oracle.membership_query([0, 1, 0]))  # a yes, b yes
+        self.assertFalse(self.oracle.membership_query([1, 1, 1]))  # a no
+
+    def test_both_sub_oracles_see_every_string(self):
+        strings = [[0, 0], [1, 0]]
+        self.oracle.membership_queries(strings)
+        self.assertEqual(self.a.seen[-1], strings)
+        self.assertEqual(self.b.seen[-1], strings)
+
+    def test_dimensions_come_from_the_first_oracle(self):
+        oracle = SetDifferenceOracle(
+            PredicateOracle(lambda s: True, alphabet_size=4, string_length=12),
+            PredicateOracle(lambda s: False, alphabet_size=4, string_length=12),
+        )
+        self.assertEqual(oracle.alphabet_size, 4)
+        self.assertEqual(oracle.string_length, 12)
+
+    def test_rejects_mismatched_alphabets(self):
+        with self.assertRaises(AssertionError):
+            SetDifferenceOracle(
+                PredicateOracle(lambda s: True, alphabet_size=4),
+                PredicateOracle(lambda s: True, alphabet_size=2),
+            )
+
+    def test_empty_batch(self):
+        result = self.oracle.membership_queries([])
+        self.assertEqual(result.shape, (0,))
+        self.assertEqual(result.dtype, bool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_set_difference.py
+++ b/tests/test_set_difference.py
@@ -1,17 +1,9 @@
-import os
 import unittest
 
 import numpy as np
-import torch
 
-from orthogonal_dfa.l_star.examples.set_difference import (
-    FM_TRACED_DIR,
-    SetDifferenceOracle,
-    load_fm,
-)
+from orthogonal_dfa.l_star.examples.set_difference import SetDifferenceOracle
 from orthogonal_dfa.l_star.structures import Oracle
-
-FM_SEED1 = os.path.join(FM_TRACED_DIR, "fm-1.traced.pt")
 
 
 class PredicateOracle(Oracle):
@@ -83,22 +75,6 @@ class TestSetDifferenceOracle(unittest.TestCase):
         result = self.oracle.membership_queries([])
         self.assertEqual(result.shape, (0,))
         self.assertEqual(result.dtype, bool)
-
-
-@unittest.skipUnless(
-    os.path.exists(FM_SEED1) and torch.cuda.is_available(),
-    "FM trace is gitignored and cuda-only; regenerate via scripts/convert_fm_to_torchscript.py",
-)
-class TestLoadFM(unittest.TestCase):
-    def test_trace_loads_and_forwards_without_modular_splicing(self):
-        model = load_fm(1)
-        length = 500
-        x = torch.zeros(2, length, 4, device="cuda")
-        x[:, torch.arange(length), torch.randint(0, 4, (length,))] = 1.0
-        with torch.no_grad():
-            out = model(x)
-        # (N, L - cl, 3): the cl=400 acceptor/donor/null logits SpliceAIExonScore reads.
-        self.assertEqual(tuple(out.shape), (2, length - 400, 3))
 
 
 if __name__ == "__main__":

--- a/tests/test_set_difference.py
+++ b/tests/test_set_difference.py
@@ -1,9 +1,17 @@
+import os
 import unittest
 
 import numpy as np
+import torch
 
-from orthogonal_dfa.l_star.examples.set_difference import SetDifferenceOracle
+from orthogonal_dfa.l_star.examples.set_difference import (
+    FM_TRACED_DIR,
+    SetDifferenceOracle,
+    load_fm,
+)
 from orthogonal_dfa.l_star.structures import Oracle
+
+FM_SEED1 = os.path.join(FM_TRACED_DIR, "fm-1.traced.pt")
 
 
 class PredicateOracle(Oracle):
@@ -75,6 +83,22 @@ class TestSetDifferenceOracle(unittest.TestCase):
         result = self.oracle.membership_queries([])
         self.assertEqual(result.shape, (0,))
         self.assertEqual(result.dtype, bool)
+
+
+@unittest.skipUnless(
+    os.path.exists(FM_SEED1) and torch.cuda.is_available(),
+    "FM trace is gitignored and cuda-only; regenerate via scripts/convert_fm_to_torchscript.py",
+)
+class TestLoadFM(unittest.TestCase):
+    def test_trace_loads_and_forwards_without_modular_splicing(self):
+        model = load_fm(1)
+        length = 500
+        x = torch.zeros(2, length, 4, device="cuda")
+        x[:, torch.arange(length), torch.randint(0, 4, (length,))] = 1.0
+        with torch.no_grad():
+            out = model(x)
+        # (N, L - cl, 3): the cl=400 acceptor/donor/null logits SpliceAIExonScore reads.
+        self.assertEqual(tuple(out.shape), (2, length - 400, 3))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Splits the set-difference oracle and the fixed-motif (FM) machinery out of the E-L* SpliceAI work (#145) into a self-contained, mergeable unit.

## What

**`orthogonal_dfa/l_star/examples/set_difference.py`** — `SetDifferenceOracle(a, b)`, a generic combinator: `a \ b` accepts iff `a` accepts and `b` rejects. It derives `alphabet_size`/`string_length` from the first oracle (asserting the alphabets match) and depends on nothing SpliceAI-specific, so it's a plain building block that E-L* runs to isolate what one splice model captures that another does not.

**`load_fm(seed)` in `orthogonal_dfa/spliceai/load_model.py`** — loads the fixed-motif model as an eval/cuda module. FM is a trained `modular_splicing` model (BothLSSIModels + an 82-motif RBNS PSAMMotifModel) living in a separate on-machine repo; rather than depend on that repo at runtime, it ships as a self-contained TorchScript trace, so loading needs only torch. It reads the same acceptor/donor logits as SpliceAI, so `SpliceAIExonScore` wraps it identically; the two are then differenced.

**`scripts/convert_fm_to_torchscript.py`** — the one-shot converter, run on the machine that has the `modular_splicing` repo. Loading FM eagerly pulls in ~55 modular_splicing modules, but only ~21 files / ~345 lines run in a forward pass, and `torch.jit.trace` captures exactly that path. `TRACE_WIDTH` is arbitrary above `cl`: the trace generalizes across lengths (conv/attention crop off tensor shapes), verified bit-exact over the oracle's 499..593 input range.

**`data/pretrained_models/fm-1.traced.pt`** — the seed-1 trace (~23 MB), checked in so the default set-difference path needs no conversion step. Seeds 2..5 are gitignored and stay regenerable. The trace has `cuda:0` baked into it (from a literal `.to(cuda)` inside modular_splicing's LSSI), so it is GPU-only — consistent with `load_spliceai`/`load_lssi`, which also `.cuda()`.

## Why

#145 bundled these with the SpliceAI oracle builders, the driver, and the findings. Peeling them into their own module lets them land independently and keeps `SetDifferenceOracle` a clean generic combinator rather than something tangled with the SpliceAI-specific code.

## Tests

`tests/test_set_difference.py` — the truth table of `a \ b`, dimension derivation, alphabet-mismatch assertion, that both sub-oracles see every query, and the empty batch. All against a fake `PredicateOracle`, so no model is needed.

`tests/test_load_fm.py` — loads the checked-in seed-1 trace and forwards it, asserting the `(N, L - cl, 3)` logits `SpliceAIExonScore` reads. Skipped unless both the trace and CUDA are present, so it does not run on CI's CPU runners.

## Follow-up

Once this lands, #145's `spliceai_oracles.py` will import `SetDifferenceOracle`/`load_fm` from here instead of carrying its own copies (a one-line signature change, since this version drops the vestigial `exon` argument in favor of deriving the length from oracle `a`).
