### PR TITLE
Port upstream capal.DFAs back to automata-lib

### DIFF
--- a/orthogonal_dfa/capal_official/__init__.py
+++ b/orthogonal_dfa/capal_official/__init__.py
@@ -14,4 +14,4 @@ from .adapter import (
     resolve_capal_dir,
     verify_pinned,
 )
-from .porters import build_modulo_dfa, build_regex_dfa
+from .porters import build_modulo_dfa, build_regex_dfa, to_automata_dfa

--- a/orthogonal_dfa/capal_official/porters.py
+++ b/orthogonal_dfa/capal_official/porters.py
@@ -1,5 +1,9 @@
-"""Build this repo's target languages as upstream `capal.DFA`s, so CAPAL's
-PerfectEQ can run its product-BFS counterexample search against them."""
+"""Convert target languages between this repo's DFA format and upstream's.
+
+`build_*` go this repo -> upstream `capal.DFA`, so CAPAL's PerfectEQ can run
+its product-BFS counterexample search against them. `to_automata_dfa` goes back
+the other way, for the oracles E-L* reads.
+"""
 
 from __future__ import annotations
 
@@ -60,4 +64,28 @@ def build_regex_dfa(regex: str, alphabet_size: int = 2) -> Any:
         start=sidx[aut.initial_state],
         accept={sidx[s] for s in aut.final_states},
         delta=delta,
+    )
+
+
+def to_automata_dfa(target: Any) -> Any:
+    """Upstream `capal.DFA` -> automata-lib DFA over integer symbols.
+
+    `DFAOracle` (and hence E-L*) works in symbol *indices*; upstream works in
+    characters. Index i always means `target.alphabet[i]`, the same mapping the
+    CAPAL side is handed.
+    """
+    from automata.fa.dfa import DFA as AutDFA
+
+    alphabet = list(target.alphabet)
+    idx = {c: i for i, c in enumerate(alphabet)}
+    transitions = {
+        q: {idx[c]: target.step(q, c) for c in alphabet}
+        for q in range(target.num_states)
+    }
+    return AutDFA(
+        states=set(range(target.num_states)),
+        input_symbols=set(idx.values()),
+        transitions=transitions,
+        initial_state=target.start,
+        final_states=set(target.accept),
     )

--- a/tests/test_capal_bridge.py
+++ b/tests/test_capal_bridge.py
@@ -17,6 +17,7 @@ from orthogonal_dfa.capal_official import (
     import_capal,
     make_learner,
     resolve_capal_dir,
+    to_automata_dfa,
     verify_pinned,
 )
 from orthogonal_dfa.capal_official.adapter import UPSTREAM_URL
@@ -111,6 +112,28 @@ class TestCapalBridge(unittest.TestCase):
         for word in _all_words("01", 8):
             truth = oracle.membership_query([int(c) for c in word])
             self.assertEqual(dfa.run(word), truth, word)
+
+    def test_round_trip_preserves_the_language_and_symbol_order(self):
+        # `to_automata_dfa` is the inverse leg: E-L* reads symbol indices while
+        # upstream reads characters, so a round trip has to agree on both the
+        # language and which index means which character.
+        for regex, symbols in ((r".*1010101.*", 2), (r".*(111|000).*", 3)):
+            upstream = build_regex_dfa(regex, symbols)
+            back = to_automata_dfa(upstream)
+            alphabet = list(upstream.alphabet)
+            for word in _all_words("".join(alphabet), 7):
+                indices = [alphabet.index(c) for c in word]
+                self.assertEqual(
+                    upstream.run(word), back.accepts_input(indices), (regex, word)
+                )
+
+    def test_round_trip_is_total(self):
+        # automata-lib rejects by dying; upstream requires every (state, symbol),
+        # so the port has to leave a complete transition function behind.
+        back = to_automata_dfa(build_modulo_dfa(9, (3, 6)))
+        self.assertEqual(back.input_symbols, {0, 1})
+        for state in back.states:
+            self.assertEqual(set(back.transitions[state]), {0, 1})
 
     def test_end_to_end_fit(self):
         # Trivial noiseless target: CAPAL + PerfectEQ should learn it exactly.


### PR DESCRIPTION
Split off `capal-comparison` (#138), which needs this to present CAPAL's own `.taf` targets to E-L\*.

`porters.py` already goes one way — `build_modulo_dfa` / `build_regex_dfa` turn this repo's targets into upstream `capal.DFA`s so CAPAL's PerfectEQ can run its product-BFS counterexample search against them. `to_automata_dfa` is the other leg, for targets that *originate* upstream, so this repo's `DFAOracle` can read them.

## The symbol mapping is the point

The two sides disagree on alphabets: upstream works in characters, `DFAOracle` in integer indices. Index `i` means `target.alphabet[i]` — the same mapping the CAPAL side is handed — so a round trip preserves the language *and* which index denotes which character. Getting that wrong would silently compare two learners on different languages, which is why it is tested over all short words rather than spot-checked.

`automata-lib` also rejects by dying, while upstream requires a transition for every `(state, symbol)`, so the port has to leave a complete transition function behind. Also tested.

## Tests

Two added to `tests/test_capal_bridge.py`, alongside the existing `test_ported_dfa_matches_the_oracle` which does the mirror-image check for the forward direction:

- `test_round_trip_preserves_the_language_and_symbol_order` — every word up to length 7, over a 2-symbol and a 3-symbol regex target.
- `test_round_trip_is_total` — the ported DFA has every `(state, symbol)`.

12/12 pass, pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)