### PR TITLE
Measure CAPAL at its authors' benchmark settings

### DIFF
--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -120,18 +120,29 @@ def make_learner(
     max_iters: int = 200,
     seed: int = 0,
     verbose: bool = False,
-    max_same_samples: int = 60,
+    max_same_samples: int = 80,
     tau_cap: float = 0.2,
-    suffix_pool_init: int = 32,
-    suffix_pool_len_max: int = 8,
+    suffix_pool_init: int = 100,
+    suffix_pool_len_max: int = 10,
     alpha: float = 1e-3,
+    discr_search_max_len: int = 6,
+    discr_search_random: int = 2000,
     enum_depth: int = 3,
     extra_len_max: int = 8,
 ) -> Any:
     """An unfitted CAPALLearner over `target`.
 
-    `enum_depth`/`extra_len_max` are the matched-query-budget knob; LearnerConfig
-    does not forward them, so they go straight on the live SameStateConfig.
+    Defaults are upstream's *benchmark script* values (`run_capal_benchmark.py`
+    argparse defaults), not `LearnerConfig`'s dataclass defaults, which are
+    stingier on four knobs -- max_same_samples 60, suffix_pool_init 32,
+    suffix_pool_len_max 8, discr_search_random 200. Running the dataclass
+    defaults would measure CAPAL with less evidence per pairwise test and a
+    10x smaller discriminator search than the values its authors publish with.
+
+    `enum_depth`/`extra_len_max` stay at the dataclass defaults: the benchmark
+    script does not expose them. They are the matched-query-budget knob, and
+    LearnerConfig does not forward them, so they go straight on the live
+    SameStateConfig.
 
     LearnerConfig's K_pos/K_neg are left at their defaults: upstream reads them
     only in its CLI, never in CAPALLearner or SameStateOracle, so setting them
@@ -147,6 +158,8 @@ def make_learner(
         tau_cap=tau_cap,
         suffix_pool_init=suffix_pool_init,
         suffix_pool_len_max=suffix_pool_len_max,
+        discr_search_max_len=discr_search_max_len,
+        discr_search_random=discr_search_random,
         verbose=verbose,
     )
     # target= builds PersistentNoisyMQ + PerfectEQ (capal.py:907-914).

--- a/orthogonal_dfa/capal_official/adapter.py
+++ b/orthogonal_dfa/capal_official/adapter.py
@@ -24,8 +24,9 @@ from typing import Any, Optional, Tuple
 
 UPSTREAM_URL = "https://github.com/lkwargs/CAPAL"
 
-#: The single source of truth for the commit every number in
-#: `data/capal_findings.md` was measured against. Bumping it means re-measuring.
+#: The commit every recorded CAPAL number was measured against. Bumping it
+#: means re-measuring -- and so does changing `make_learner`'s defaults, which
+#: are equally part of what those numbers mean.
 PINNED_COMMIT = "57d877f6a083d58852660fac388ff49c052dc2d2"
 
 #: What upstream's fit() says when it runs out of iterations (capal.py:1294).

--- a/tests/test_capal_bridge.py
+++ b/tests/test_capal_bridge.py
@@ -4,7 +4,9 @@ Clones the pinned CAPAL checkout to ../capal if absent, skipping (not failing)
 when that is impossible, e.g. offline. Catches a broken adapter or commit drift.
 """
 
+import inspect
 import itertools
+import re
 import subprocess
 import unittest
 from pathlib import Path
@@ -111,6 +113,29 @@ class TestCapalBridge(unittest.TestCase):
         for word in _all_words("01", 8):
             truth = oracle.membership_query([int(c) for c in word])
             self.assertEqual(dfa.run(word), truth, word)
+
+    def test_defaults_match_the_upstream_benchmark_script(self):
+        # The comparison is only fair if CAPAL runs at the settings its authors
+        # publish with, so read them out of run_capal_benchmark.py rather than
+        # restating them: a drift in the pinned checkout should fail here.
+        script = (resolve_capal_dir() / "run_capal_benchmark.py").read_text()
+        wanted = {
+            "max-same-samples": "max_same_samples",
+            "suffix-pool-init": "suffix_pool_init",
+            "suffix-pool-len-max": "suffix_pool_len_max",
+            "discr-search-max-len": "discr_search_max_len",
+            "discr-search-random": "discr_search_random",
+            "max-iters": "max_iters",
+            "tau-cap": "tau_cap",
+            "alpha": "alpha",
+        }
+        ours = inspect.signature(make_learner).parameters
+        for flag, param in wanted.items():
+            match = re.search(
+                rf'add_argument\("--{flag}",[^)]*default=([0-9.e-]+)', script
+            )
+            self.assertIsNotNone(match, flag)
+            self.assertEqual(float(match.group(1)), float(ours[param].default), flag)
 
     def test_end_to_end_fit(self):
         # Trivial noiseless target: CAPAL + PerfectEQ should learn it exactly.


### PR DESCRIPTION
Split off `capal-comparison` (#138). This is the one change in that PR that alters what the head-to-head *measures*, so it is worth reviewing on its own rather than under 900 lines of harness.

`make_learner` took `LearnerConfig`'s dataclass defaults. Upstream's own benchmark script, `run_capal_benchmark.py`, runs with different values on four knobs — and two of them were not reachable through `make_learner` at all:

| knob | `LearnerConfig` | `run_capal_benchmark.py` |
| --- | ---: | ---: |
| `max_same_samples` | 60 | **80** |
| `suffix_pool_init` | 32 | **100** |
| `suffix_pool_len_max` | 8 | **10** |
| `discr_search_random` | 200 | **2000** |
| `discr_search_max_len` | — (unreachable) | 6 |

Every one is stingier than what the authors publish with. Measuring CAPAL with a **10x smaller discriminator search** and less evidence per pairwise test is not a fair read of the method, and a head-to-head that gets this wrong flatters us for free.

`enum_depth` / `extra_len_max` stay at the dataclass defaults, since the benchmark script does not expose them. They remain the matched-query-budget knob, set on the live `SameStateConfig` because `LearnerConfig` does not forward them.

## Effect

This moves every CAPAL number. On #138's experiment 1 the total membership-query count roughly **halves** — CAPAL gets more evidence per test and converges in fewer iterations. Any figures measured before this are not comparable.

## Test

`test_defaults_match_the_upstream_benchmark_script` parses the `add_argument` defaults out of `run_capal_benchmark.py` in the pinned checkout and asserts `make_learner` agrees, rather than restating the numbers. If the pin moves and upstream retunes, the test fails loudly instead of the comparison silently measuring something else.

Verified against the pinned commit: all six values match.

11/11 pass, pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)