### PR TITLE
Screen candidate suffixes before paying for a full column

### DIFF
--- a/orthogonal_dfa/l_star/cluster.py
+++ b/orthogonal_dfa/l_star/cluster.py
@@ -105,6 +105,9 @@ def sample_suffix_family(pst, v: int) -> Tuple[List[int], float]:
         )
 
         if strategy == "suffix":
-            pst.sample_more_suffixes(amount=pst.config.suffix_family_size)
+            kept = pst.sample_more_suffixes(
+                amount=pst.config.suffix_family_size, reference=v
+            )
+            print(f"  kept {kept}/{pst.config.suffix_family_size} after screening")
         else:
             pst.sample_more_prefixes()

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -55,9 +55,8 @@ class SearchConfig:
     fnr_limit: float = 0.02
     split_pval: float = 0.001
     min_suffix_frequency: float = 0.02
-    #: Chance of screening out a suffix that does belong to the family.  Spent
-    #: across the whole staircase, not per test.  Raising it rejects more of the
-    #: population on fewer prefixes; the cost of a mistake is one extra draw.
+    #: Chance of screening out a suffix that does belong, spent across the
+    #: whole staircase rather than per test.
     screening_alpha: float = 0.1
 
 
@@ -151,37 +150,14 @@ class PrefixSuffixTracker:
         return out
 
     def _screen_cohort(self, rows: List[int], reference: int) -> List[int]:
-        """The rows whose membership pattern is still explicable as
-        ``reference``'s plus per-cell noise, after testing the whole cohort on a
-        growing subset of prefixes and dropping each row at the first subset that
-        settles it.
-
-        A suffix in the same family as ``reference`` induces the same accept /
-        reject labelling of the prefixes, so the two columns differ only where
-        one of the two queries was flipped -- a rate of ``2*eta*(1-eta)``, with
-        ``eta`` the per-query noise.  ``min_signal_strength`` lower-bounds the
-        signal, hence upper-bounds ``eta``, so this null holds without knowing
-        anything about the family being assembled; a candidate significantly
-        above it is not in the family and does not need its remaining cells.
-
-        The cohort shares one prefix ordering, which is what lets a whole
-        staircase step go to the oracle as a single batch -- one call per step
-        rather than one per candidate.  Each row is still judged only on its own
-        disagreement count, so the decisions are the ones a per-candidate screen
-        would make.
-
-        Only representative prefixes are used, matching the population the
-        clustering and the decision boundary are calibrated over.
-        """
+        """The rows still explicable as ``reference`` plus per-cell noise, which
+        flips one of the two observations at rate ``2*eta*(1-eta)``."""
         eta = 0.5 - self.config.min_signal_strength
         same_family_rate = 2 * eta * (1 - eta)
         ref = self.table.column(reference)
         candidates = np.flatnonzero(self.table.representative)
         order = candidates[self.rng.permutation(len(candidates))]
         staircase = self._screening_staircase(len(order))
-        # The staircase gets one shot at rejecting per step, so the per-test rate
-        # has to be the budget split across them for screening_alpha to mean what
-        # it says.
         alpha = self.config.screening_alpha / len(staircase)
         alive = list(rows)
         for p in staircase:
@@ -246,24 +222,8 @@ class PrefixSuffixTracker:
         self.table.add_prefixes(sorted(list(x) for x in new_prefixes))
 
     def sample_more_suffixes(self, *, amount: int, reference: Optional[int] = None):
-        """Grow the pool of clustering candidates by ``amount``.
-
-        ``amount`` counts survivors, not draws: the caller loops until the pool
-        supports a family of ``suffix_family_size`` and treats a round that
-        grows it less as failure to progress, so a screened round has to deliver
-        as much as an unscreened one did -- it just pays a screening subset per
-        rejection instead of a full column.
-
-        Draws are capped using ``min_suffix_frequency``, the assumed floor on
-        how often a family member comes up, so a reference that nothing matches
-        cannot spin here forever.
-
-        Candidates are drawn and screened a cohort at a time so each staircase
-        step is one oracle call for the whole cohort.  A cohort's survivors are
-        all completed even if that overshoots ``amount``: they passed, and
-        stranding a passed suffix half-observed would waste the screening
-        already paid for and lose it for good, since it can never be redrawn.
-        """
+        """Grow the pool of clustering candidates by ``amount`` suffixes that
+        survive screening against ``reference``."""
         kept = 0
         drawn = 0
         max_draws = int(np.ceil(amount / self.config.min_suffix_frequency))
@@ -278,10 +238,8 @@ class PrefixSuffixTracker:
                     else self._screen_cohort(cohort, reference)
                 )
                 if survivors:
-                    # Fully observe them, so they can be used in clustering.  The
-                    # ones the screen dropped keep the cells it paid for and stay
-                    # out of fully_observed(), so they are neither clustering
-                    # candidates nor columns add_prefixes has to top up.
+                    # The dropped ones stay partial, keeping them out of
+                    # fully_observed() and so out of add_prefixes' top-ups.
                     self.table.observed_masks(survivors, every)
                 kept += len(survivors)
                 pbar.update(len(survivors))

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -150,10 +150,11 @@ class PrefixSuffixTracker:
         out.append(available)
         return out
 
-    def _diverges_from(self, row: int, reference: int) -> bool:
-        """Whether ``row``'s membership pattern differs from ``reference``'s by
-        more than per-cell noise can explain, measured on a growing subset of
-        prefixes and stopping at the first subset that settles it.
+    def _screen_cohort(self, rows: List[int], reference: int) -> List[int]:
+        """The rows whose membership pattern is still explicable as
+        ``reference``'s plus per-cell noise, after testing the whole cohort on a
+        growing subset of prefixes and dropping each row at the first subset that
+        settles it.
 
         A suffix in the same family as ``reference`` induces the same accept /
         reject labelling of the prefixes, so the two columns differ only where
@@ -162,6 +163,12 @@ class PrefixSuffixTracker:
         signal, hence upper-bounds ``eta``, so this null holds without knowing
         anything about the family being assembled; a candidate significantly
         above it is not in the family and does not need its remaining cells.
+
+        The cohort shares one prefix ordering, which is what lets a whole
+        staircase step go to the oracle as a single batch -- one call per step
+        rather than one per candidate.  Each row is still judged only on its own
+        disagreement count, so the decisions are the ones a per-candidate screen
+        would make.
 
         Only representative prefixes are used, matching the population the
         clustering and the decision boundary are calibrated over.
@@ -176,35 +183,31 @@ class PrefixSuffixTracker:
         # has to be the budget split across them for screening_alpha to mean what
         # it says.
         alpha = self.config.screening_alpha / len(staircase)
+        alive = list(rows)
         for p in staircase:
+            if not alive:
+                break
             subset = np.zeros(self.num_prefixes, dtype=bool)
             subset[order[:p]] = True
-            observed = self.table.observed_masks([row], subset)[0]
-            disagreements = int((observed != ref[subset]).sum())
-            if binomial_side_of_boundary(
-                disagreements, p, same_family_rate, failure_prob=alpha
-            ):
-                return True
-        return False
+            disagreements = (self.table.observed_masks(alive, subset) != ref[subset]).sum(1)
+            alive = [
+                row
+                for row, count in zip(alive, disagreements)
+                if not binomial_side_of_boundary(
+                    int(count), p, same_family_rate, failure_prob=alpha
+                )
+            ]
+        return alive
 
-    def _sample_suffix(self, reference: Optional[int] = None) -> Optional[int]:
-        """Draw an unseen suffix and fully observe it, returning its row.
-
-        Returns None if the suffix was screened out against ``reference``: it
-        keeps the cells the screen paid for and stays out of ``fully_observed``,
-        so it is neither a clustering candidate nor a column that
-        ``add_prefixes`` has to keep topped up.
-        """
-        while True:
+    def _draw_cohort(self, size: int) -> List[int]:
+        """``size`` unseen suffixes, interned but not yet observed."""
+        rows = []
+        while len(rows) < size:
             v = self.sampler.sample(rng=self.rng, alphabet_size=self.alphabet_size)
             if self.table.contains_suffix(v):
                 continue
-            row = self.table.intern_suffix(v)
-            if reference is not None and self._diverges_from(row, reference):
-                return None
-            # Fully observe the new suffix row, so it can be used in clustering
-            self.table.column(row)
-            return row
+            rows.append(self.table.intern_suffix(v))
+        return rows
 
     def compute_fnr(self, vs):
         """
@@ -252,16 +255,34 @@ class PrefixSuffixTracker:
         Draws are capped using ``min_suffix_frequency``, the assumed floor on
         how often a family member comes up, so a reference that nothing matches
         cannot spin here forever.
+
+        Candidates are drawn and screened a cohort at a time so each staircase
+        step is one oracle call for the whole cohort.  A cohort's survivors are
+        all completed even if that overshoots ``amount``: they passed, and
+        stranding a passed suffix half-observed would waste the screening
+        already paid for and lose it for good, since it can never be redrawn.
         """
         kept = 0
-        max_draws = int(np.ceil(amount / self.config.min_suffix_frequency))
         drawn = 0
+        max_draws = int(np.ceil(amount / self.config.min_suffix_frequency))
+        every = np.ones(self.num_prefixes, dtype=bool)
         with tqdm.tqdm(total=amount, desc="Completing suffix family", delay=1) as pbar:
             while kept < amount and drawn < max_draws:
-                drawn += 1
-                if self._sample_suffix(reference) is not None:
-                    kept += 1
-                    pbar.update()
+                cohort = self._draw_cohort(min(amount, max_draws - drawn))
+                drawn += len(cohort)
+                survivors = (
+                    cohort
+                    if reference is None
+                    else self._screen_cohort(cohort, reference)
+                )
+                if survivors:
+                    # Fully observe them, so they can be used in clustering.  The
+                    # ones the screen dropped keep the cells it paid for and stay
+                    # out of fully_observed(), so they are neither clustering
+                    # candidates nor columns add_prefixes has to top up.
+                    self.table.observed_masks(survivors, every)
+                kept += len(survivors)
+                pbar.update(len(survivors))
         return kept
 
     def compute_decision(self, vs, subset_prefixes) -> np.ndarray:

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -6,6 +6,7 @@ import tqdm.auto as tqdm
 
 from .mask_table import MaskTable
 from .sampler import Sampler
+from .statistics import binomial_side_of_boundary
 from .structures import Oracle
 
 
@@ -54,6 +55,10 @@ class SearchConfig:
     fnr_limit: float = 0.02
     split_pval: float = 0.001
     min_suffix_frequency: float = 0.02
+    #: Chance of screening out a suffix that does belong to the family.  Spent
+    #: across the whole staircase, not per test.  Raising it rejects more of the
+    #: population on fewer prefixes; the cost of a mistake is one extra draw.
+    screening_alpha: float = 0.1
 
 
 @dataclass
@@ -135,12 +140,68 @@ class PrefixSuffixTracker:
             table=MaskTable(oracle, prefixes, representative),
         )
 
-    def _sample_suffix(self) -> int:
+    def _screening_staircase(self, available: int) -> List[int]:
+        """Prefix counts to test a candidate at, smallest first."""
+        out = []
+        p = 16
+        while p < available:
+            out.append(p)
+            p *= 2
+        out.append(available)
+        return out
+
+    def _diverges_from(self, row: int, reference: int) -> bool:
+        """Whether ``row``'s membership pattern differs from ``reference``'s by
+        more than per-cell noise can explain, measured on a growing subset of
+        prefixes and stopping at the first subset that settles it.
+
+        A suffix in the same family as ``reference`` induces the same accept /
+        reject labelling of the prefixes, so the two columns differ only where
+        one of the two queries was flipped -- a rate of ``2*eta*(1-eta)``, with
+        ``eta`` the per-query noise.  ``min_signal_strength`` lower-bounds the
+        signal, hence upper-bounds ``eta``, so this null holds without knowing
+        anything about the family being assembled; a candidate significantly
+        above it is not in the family and does not need its remaining cells.
+
+        Only representative prefixes are used, matching the population the
+        clustering and the decision boundary are calibrated over.
+        """
+        eta = 0.5 - self.config.min_signal_strength
+        same_family_rate = 2 * eta * (1 - eta)
+        ref = self.table.column(reference)
+        candidates = np.flatnonzero(self.table.representative)
+        order = candidates[self.rng.permutation(len(candidates))]
+        staircase = self._screening_staircase(len(order))
+        # The staircase gets one shot at rejecting per step, so the per-test rate
+        # has to be the budget split across them for screening_alpha to mean what
+        # it says.
+        alpha = self.config.screening_alpha / len(staircase)
+        for p in staircase:
+            subset = np.zeros(self.num_prefixes, dtype=bool)
+            subset[order[:p]] = True
+            observed = self.table.observed_masks([row], subset)[0]
+            disagreements = int((observed != ref[subset]).sum())
+            if binomial_side_of_boundary(
+                disagreements, p, same_family_rate, failure_prob=alpha
+            ):
+                return True
+        return False
+
+    def _sample_suffix(self, reference: Optional[int] = None) -> Optional[int]:
+        """Draw an unseen suffix and fully observe it, returning its row.
+
+        Returns None if the suffix was screened out against ``reference``: it
+        keeps the cells the screen paid for and stays out of ``fully_observed``,
+        so it is neither a clustering candidate nor a column that
+        ``add_prefixes`` has to keep topped up.
+        """
         while True:
             v = self.sampler.sample(rng=self.rng, alphabet_size=self.alphabet_size)
             if self.table.contains_suffix(v):
                 continue
             row = self.table.intern_suffix(v)
+            if reference is not None and self._diverges_from(row, reference):
+                return None
             # Fully observe the new suffix row, so it can be used in clustering
             self.table.column(row)
             return row
@@ -179,9 +240,29 @@ class PrefixSuffixTracker:
             new_prefixes.add(prefix)
         self.table.add_prefixes(sorted(list(x) for x in new_prefixes))
 
-    def sample_more_suffixes(self, *, amount: int):
-        for _ in tqdm.trange(amount, desc="Completing suffix family", delay=1):
-            self._sample_suffix()
+    def sample_more_suffixes(self, *, amount: int, reference: Optional[int] = None):
+        """Grow the pool of clustering candidates by ``amount``.
+
+        ``amount`` counts survivors, not draws: the caller loops until the pool
+        supports a family of ``suffix_family_size`` and treats a round that
+        grows it less as failure to progress, so a screened round has to deliver
+        as much as an unscreened one did -- it just pays a screening subset per
+        rejection instead of a full column.
+
+        Draws are capped using ``min_suffix_frequency``, the assumed floor on
+        how often a family member comes up, so a reference that nothing matches
+        cannot spin here forever.
+        """
+        kept = 0
+        max_draws = int(np.ceil(amount / self.config.min_suffix_frequency))
+        drawn = 0
+        with tqdm.tqdm(total=amount, desc="Completing suffix family", delay=1) as pbar:
+            while kept < amount and drawn < max_draws:
+                drawn += 1
+                if self._sample_suffix(reference) is not None:
+                    kept += 1
+                    pbar.update()
+        return kept
 
     def compute_decision(self, vs, subset_prefixes) -> np.ndarray:
         """Mean over the suffix rows ``vs`` of the membership matrix, restricted

--- a/orthogonal_dfa/l_star/prefix_suffix_tracker.py
+++ b/orthogonal_dfa/l_star/prefix_suffix_tracker.py
@@ -189,7 +189,9 @@ class PrefixSuffixTracker:
                 break
             subset = np.zeros(self.num_prefixes, dtype=bool)
             subset[order[:p]] = True
-            disagreements = (self.table.observed_masks(alive, subset) != ref[subset]).sum(1)
+            disagreements = (
+                self.table.observed_masks(alive, subset) != ref[subset]
+            ).sum(1)
             alive = [
                 row
                 for row, count in zip(alive, disagreements)


### PR DESCRIPTION
## Query count — `suffix-screening` vs `main`

|   | task | queries `main` | queries `suffix-screening` | ratio | acc `main` | acc `suffix-screening` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| 🟢 | modulo | 875,691 | 457,202 | 0.52x | 1.000 | 1.000 | 9 |
| 🟢 | subseq | 1,278,089 | 796,913 | 0.62x | 1.000 | 1.000 | 8 |
| 🟢 | two_subseq | 916,315 | 796,527 | 0.87x | 1.000 | 1.000 | 9 |
| 🔴 | poor_case | 5,202,946 | 838,695 | 0.16x | 0.977 | 1.000 | 9→10 ‼️ |
| 🟢 | modulo_hard | 1,787,905 | 1,251,782 | 0.70x | 1.000 | 1.000 | 9 |
| 🟢 | modulo_asym | 3,490,354 | 2,764,865 | 0.79x | 1.000 | 1.000 | 9 |
| 🟢 | **geomean** |  |  | **0.54x** |  |  |  |

**❌ REGRESSION** (queries up or accuracy/states broke on ≥1 task)

### Forward passes — `suffix-screening` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 27,584 → 14,401 (0.52x, 99% packed) | 7,076 → 3,726 (0.53x, 96% packed) | 1,164 → 622 (0.53x, 72% packed) |
| subseq | 45,111 → 28,339 (0.63x, 88% packed) | 17,060 → 10,981 (0.64x, 57% packed) | 9,234 → 6,153 (0.67x, 13% packed) |
| two_subseq | 31,035 → 27,499 (0.89x, 91% packed) | 10,581 → 9,922 (0.94x, 63% packed) | 4,834 → 5,112 (1.06x, 15% packed) |
| poor_case | 180,567 → 30,257 (0.17x, 87% packed) | 72,313 → 12,242 (0.17x, 54% packed) | 44,215 → 7,372 (0.17x, 11% packed) |
| modulo_hard | 56,573 → 39,224 (0.69x, 100% packed) | 14,693 → 9,939 (0.68x, 98% packed) | 2,590 → 1,424 (0.55x, 86% packed) |
| modulo_asym | 109,966 → 86,518 (0.79x, 100% packed) | 28,398 → 21,771 (0.77x, 99% packed) | 4,479 → 2,884 (0.64x, 94% packed) |
