### PR TITLE
Add E-L* suffix-shattering reproduction with simple grammars

### DIFF
--- a/orthogonal_dfa/analysis/shattering_repro.py
+++ b/orthogonal_dfa/analysis/shattering_repro.py
@@ -1,0 +1,296 @@
+"""Reproduce E-L*'s suffix-family "shattering" with tiny, deterministic grammars -- no
+SpliceAI, no GPU, no learned weights.
+
+Hypothesis (from the gate-deconfounded run): E-L* shatters -- suffix family and state
+count grow without bound, ~0 held-out signal -- when the oracle is **deterministic but
+not compactly regular**, so its observation-table rows never collapse into finitely many
+states.  We show this with grammars you can read:
+
+- ``RandomDFAOracle`` -- a random k-state DFA: genuinely regular, saturates at k states.
+- ``AllFramesClosedOracle`` (imported) -- the no-ORF language: regular, ~20 states.
+- ``HalfCountCompareOracle`` -- "first half has more A's than the second half".  A
+  comparison, but of a *statistic*, so it collapses to ~(length/2) states.  The control
+  that shows shattering is not just "many states".
+- ``HalfLexCompareOracle`` -- "first half > second half, lexicographically".  Same idea,
+  but comparing the *whole* prefix: two prefixes are E-L*-equivalent only if they are
+  identical, so every prefix is its own state.  This shatters.
+
+Measured directly and cheaply: over a fixed prefix set, count the distinct
+observation-table rows (= states E-L* would create by exact deterministic distinguishing)
+as the random suffix set grows.  Regular/statistic targets saturate; the lexicographic
+grammar runs away to one-state-per-prefix.  ``run_round0`` runs the real (slow) synthesis
+if you want to confirm end to end.
+"""
+
+import collections
+
+import numpy as np
+
+from orthogonal_dfa.l_star.examples.bernoulli_parity import AllFramesClosedOracle
+from orthogonal_dfa.l_star.lstar import counterexample_driven_synthesis
+from orthogonal_dfa.l_star.preconditions import _endpoint
+from orthogonal_dfa.l_star.prefix_suffix_tracker import PrefixSuffixTracker, SearchConfig
+from orthogonal_dfa.l_star.sampler import UniformSampler
+from orthogonal_dfa.l_star.statistics import (
+    compute_suffix_size_counterexample_gen,
+    population_size_and_evidence_margin,
+)
+from orthogonal_dfa.l_star.structures import NoiseModel, Oracle
+
+
+class NoNoise(NoiseModel):
+    def apply_noise(self, correct_value, string, seed):
+        return correct_value
+
+
+class RandomDFAOracle(Oracle):
+    """A random k-state DFA over the 4-letter alphabet -- a genuinely regular target that
+    E-L* should learn (saturates at k states)."""
+
+    def __init__(self, *, n_states=6, accept_frac=0.5, seed=1):
+        rng = np.random.default_rng(seed)
+        self.trans = rng.integers(0, n_states, (n_states, 4))
+        acc = rng.random(n_states) < accept_frac
+        acc[0] = acc[0] or not acc.any()
+        self.accept = acc
+        self.n_states = n_states
+
+    @property
+    def alphabet_size(self):
+        return 4
+
+    def membership_queries(self, strings):
+        strings = list(strings)
+        n = len(strings)
+        lens = np.fromiter((len(s) for s in strings), int, n)
+        ML = int(lens.max()) if n else 0
+        arr = np.zeros((n, ML), dtype=np.int64)
+        for i, s in enumerate(strings):
+            arr[i, : len(s)] = s
+        st = np.zeros(n, dtype=np.int64)
+        for pos in range(ML):
+            st = np.where(pos < lens, self.trans[st, arr[:, pos]], st)
+        return self.accept[st]
+
+    def membership_query(self, string):
+        return bool(self.membership_queries([string])[0])
+
+
+class HalfLexCompareOracle(Oracle):
+    """accept iff the first half of the string is lexicographically greater than the
+    second half.
+
+    Non-regular / shattering: for prefixes p1 != p2 there is always a suffix s with
+    [p1 > s] != [p2 > s] (any s lying between them), so E-L* can never merge two distinct
+    prefixes -- every prefix becomes its own state.  Balanced (~0.5)."""
+
+    @property
+    def alphabet_size(self):
+        return 4
+
+    def membership_queries(self, strings):
+        strings = [list(s) for s in strings]
+        n = len(strings)
+        if n and len({len(s) for s in strings}) == 1:
+            a = np.asarray(strings, dtype=np.int64)
+            h = a.shape[1] // 2
+            A, B = a[:, :h], a[:, h : 2 * h]
+            diff = A != B
+            first = diff.argmax(1)
+            gt = A[np.arange(n), first] > B[np.arange(n), first]
+            return np.where(diff.any(1), gt, False)
+        out = np.empty(n, bool)
+        for i, s in enumerate(strings):
+            h = len(s) // 2
+            out[i] = s[:h] > s[h : 2 * h]
+        return out
+
+    def membership_query(self, string):
+        return bool(self.membership_queries([string])[0])
+
+
+class HalfCountCompareOracle(Oracle):
+    """accept iff the first half has more A's than the second half.  A comparison, but of
+    a *count*, so E-L* only needs to remember the running A-count -- it collapses to about
+    length/2 states rather than shattering.  The control that isolates *why* lex compare
+    shatters (whole prefix) while this does not (a statistic)."""
+
+    @property
+    def alphabet_size(self):
+        return 4
+
+    def membership_queries(self, strings):
+        strings = [list(s) for s in strings]
+        n = len(strings)
+        if n and len({len(s) for s in strings}) == 1:
+            a = np.asarray(strings, dtype=np.int64)
+            h = a.shape[1] // 2
+            return (a[:, :h] == 0).sum(1) > (a[:, h : 2 * h] == 0).sum(1)
+        out = np.empty(n, bool)
+        for i, s in enumerate(strings):
+            h = len(s) // 2
+            out[i] = s[:h].count(0) > s[h : 2 * h].count(0)
+        return out
+
+    def membership_query(self, string):
+        return bool(self.membership_queries([string])[0])
+
+
+def shattering_curve(oracle, *, length, n_prefixes=300, n_suffixes=4000, seed=0):
+    """Distinct observation-table rows (= states, by E-L*'s exact deterministic
+    distinguishing) as the suffix set grows.  Saturates for regular/statistic targets;
+    climbs toward n_prefixes for a shattering one."""
+    rng = np.random.default_rng(seed)
+    prefixes = rng.integers(0, 4, (n_prefixes, length))
+    suffixes = rng.integers(0, 4, (n_suffixes, length))
+    M = np.empty((n_prefixes, n_suffixes), dtype=bool)
+    for i in range(n_prefixes):
+        p = prefixes[i].tolist()
+        M[i] = oracle.membership_queries([p + suffixes[j].tolist() for j in range(n_suffixes)])
+    ks = [k for k in (1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2000, 4000) if k <= n_suffixes]
+    counts = [int(len(np.unique(M[:, :k], axis=0))) for k in ks]
+    return dict(n_prefixes=n_prefixes, ks=ks, distinct_rows=counts,
+                final_frac=counts[-1] / n_prefixes)
+
+
+def _phi(pred, truth):
+    pred, truth = np.asarray(pred, float), np.asarray(truth, float)
+    if pred.std() == 0 or truth.std() == 0:
+        return 0.0
+    return float(np.corrcoef(pred, truth)[0, 1])
+
+
+def _mi_bits(pred, truth):
+    pred, truth = np.asarray(pred, bool), np.asarray(truth, bool)
+    mi = 0.0
+    for a in (False, True):
+        pa = np.mean(pred == a)
+        if pa == 0:
+            continue
+        for b in (False, True):
+            pb = np.mean(truth == b)
+            pab = np.mean((pred == a) & (truth == b))
+            if pab > 0:
+                mi += pab * np.log2(pab / (pa * pb))
+    return float(mi)
+
+
+def _elstar_pred(dfa, strings, start):
+    return np.array([q in dfa.final_states for q in (_endpoint(dfa, s, start) for s in strings)], bool)
+
+
+def _measure(dfa, oracle, *, length, n, seed):
+    """Held-out phi/MI of the DFA vs the oracle, choosing the best start state on a
+    validation half and scoring on a disjoint test half (self-contained)."""
+    rng = np.random.default_rng(seed)
+    strings = rng.integers(0, 4, (n, length)).tolist()
+    truth = np.asarray(oracle.membership_queries(strings), bool)
+    h = n // 2
+    val, test, vt, tt = strings[:h], strings[h:], truth[:h], truth[h:]
+    rr = max(dfa.states, key=lambda q: abs(_phi(_elstar_pred(dfa, val, q), vt)))
+    pred = _elstar_pred(dfa, test, rr)
+    return dict(num_states=len(dfa.states), accept_rate=float(truth.mean()),
+                phi_rerooted=_phi(pred, tt), mi_rerooted=_mi_bits(pred, tt))
+
+
+def _search_config(mss, addtl, fnr_limit):
+    """The E-L* search config for a given minimum signal strength (same recipe the
+    learnability driver uses)."""
+    n, eps = population_size_and_evidence_margin(
+        signal_strength=mss, acceptable_fpr=0.01, acceptable_fnr=0.01
+    )
+    return SearchConfig(
+        suffix_family_size=n,
+        evidence_margin=eps,
+        decision_rule_fpr=0.01,
+        suffix_size_counterexample_gen=compute_suffix_size_counterexample_gen(0.01, 0.5 + mss),
+        min_signal_strength=mss,
+        num_addtl_prefixes=addtl,
+        fnr_limit=fnr_limit,
+    )
+
+
+def run_round0(oracle, *, length, mss=0.06, num_prefixes=200, addtl=100, seed=0, eval_n=8000):
+    """Run the real (slow) round-0 synthesis and report suffix-family size, state count,
+    and held-out phi/MI vs the oracle."""
+    config = _search_config(mss, addtl, fnr_limit=0.05)
+    pst = PrefixSuffixTracker.create(
+        UniformSampler(length), np.random.default_rng(seed), oracle, config,
+        num_prefixes=num_prefixes,
+    )
+    gen = counterexample_driven_synthesis(pst, additional_counterexamples=addtl, acc_threshold=0.98)
+    dfa, dt, _ = next(gen)
+    n_suffixes = len(pst.table._suffixes)  # pylint: disable=protected-access
+    m = _measure(dfa, oracle, length=length, n=eval_n, seed=999)
+    return dict(n_suffixes=int(n_suffixes), **m)
+
+
+def scenarios():
+    return {
+        "randomDFA (6 states, regular)": RandomDFAOracle(n_states=6, seed=1),
+        "all-frames-closed (regular)": AllFramesClosedOracle(NoNoise(), seed=0),
+        "half count-compare (statistic)": HalfCountCompareOracle(),
+        "half lex-compare (whole prefix)": HalfLexCompareOracle(),
+    }
+
+
+REPORT_KS = (10, 100, 1000, 4000)
+
+
+def to_markdown(results, length, n_prefixes):
+    cols = " | ".join(f"{k} suf" for k in REPORT_KS)
+    lines = [
+        "# Reproducing E-L* suffix shattering with a simple grammar",
+        "",
+        f"No SpliceAI, no GPU, no learned weights.  Over {n_prefixes} random length-{length} "
+        "prefixes we count the **distinct observation-table rows** (= states E-L* would "
+        "create by exact deterministic distinguishing) as the random suffix set grows.  A "
+        "regular target saturates at its state count; a non-regular one climbs toward one "
+        "state per prefix -- that runaway is the shattering, the 397k-suffix SpliceAI "
+        "explosion in miniature.",
+        "",
+        f"| oracle (grammar) | {cols} | final frac |",
+        "|---|" + "---:|" * (len(REPORT_KS) + 1),
+    ]
+    for name, r in results.items():
+        at = dict(zip(r["ks"], r["distinct_rows"]))
+        cells = " | ".join(str(at.get(k, "")) for k in REPORT_KS)
+        lines.append(f"| {name} | {cells} | {r['final_frac']:.2f} |")
+    lines += [
+        "",
+        "**Reading.** Both comparison grammars ask \"is the first half bigger than the "
+        "second half?\" -- the only difference is *bigger how*:",
+        "",
+        "- **count-compare** (more A's) compares a *statistic*, so E-L* only needs the "
+        "running A-count -> it collapses to ~length/2 states and saturates.",
+        "- **lex-compare** compares the *whole* prefix, so two prefixes are E-L*-equivalent "
+        "only if identical -> every prefix becomes its own state, and the table shatters "
+        "(final frac -> 1.0 as suffixes grow; still climbing where the others are flat).",
+        "",
+        "The random DFA (~5) and all-frames-closed (~20) also saturate -- so shattering is "
+        "not \"many states\", it is **unbounded, non-regular** state growth.  And "
+        "all-frames-closed is regular and learnable in isolation; it is only lost when "
+        "embedded in a shattering function (as in SpliceAI's residual), which explodes "
+        "E-L* before it can isolate the frame automaton.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+
+    length = int(sys.argv[2]) if len(sys.argv) > 2 else 48
+    out_path = sys.argv[1] if len(sys.argv) > 1 else "results/shattering_repro.md"
+    n_prefixes = 300
+    results = {}
+    for name, oracle in scenarios().items():
+        results[name] = shattering_curve(oracle, length=length, n_prefixes=n_prefixes)
+        r = results[name]
+        print(f"{name}: {dict(zip(r['ks'], r['distinct_rows']))} "
+              f"final_frac={r['final_frac']:.2f}", flush=True)
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, "w") as f:
+        f.write(to_markdown(results, length, n_prefixes))
+    print("\n" + to_markdown(results, length, n_prefixes))

--- a/results/shattering_repro.md
+++ b/results/shattering_repro.md
@@ -1,0 +1,17 @@
+# Reproducing E-L* suffix shattering with a simple grammar
+
+No SpliceAI, no GPU, no learned weights.  Over 300 random length-48 prefixes we count the **distinct observation-table rows** (= states E-L* would create by exact deterministic distinguishing) as the random suffix set grows.  A regular target saturates at its state count; a non-regular one climbs toward one state per prefix -- that runaway is the shattering, the 397k-suffix SpliceAI explosion in miniature.
+
+| oracle (grammar) | 10 suf | 100 suf | 1000 suf | 4000 suf | final frac |
+|---|---:|---:|---:|---:|---:|
+| randomDFA (6 states, regular) | 1 | 1 | 5 | 5 | 0.02 |
+| all-frames-closed (regular) | 9 | 20 | 20 | 20 | 0.07 |
+| half count-compare (statistic) | 8 | 16 | 19 | 19 | 0.06 |
+| half lex-compare (whole prefix) | 10 | 81 | 231 | 273 | 0.91 |
+
+**Reading.** Both comparison grammars ask "is the first half bigger than the second half?" -- the only difference is *bigger how*:
+
+- **count-compare** (more A's) compares a *statistic*, so E-L* only needs the running A-count -> it collapses to ~length/2 states and saturates.
+- **lex-compare** compares the *whole* prefix, so two prefixes are E-L*-equivalent only if identical -> every prefix becomes its own state, and the table shatters (final frac -> 1.0 as suffixes grow; still climbing where the others are flat).
+
+The random DFA (~5) and all-frames-closed (~20) also saturate -- so shattering is not "many states", it is **unbounded, non-regular** state growth.  And all-frames-closed is regular and learnable in isolation; it is only lost when embedded in a shattering function (as in SpliceAI's residual), which explodes E-L* before it can isolate the frame automaton.

--- a/results/shattering_writeup.md
+++ b/results/shattering_writeup.md
@@ -1,0 +1,109 @@
+# Why E-L\* shatters on the composition-deconfounded SpliceAI oracle
+
+## The phenomenon
+
+We built a composition-deconfounded oracle — SpliceAI's exon call with a monotonic
+bag-of-k-mers **gate** subtracted (`gate_composition_residual.py`), so only
+non-compositional structure remains — and ran E-L\* on it (`gate_elstar.py`).
+
+It did not converge to a compact DFA. It **shattered**:
+
+- Round 0: **92 states**, but held-out signal ≈ 0 (φ = 0.005, MI = 1.6e-5 bits vs the
+  oracle). In-sample splits that do not generalize.
+- The observation table's suffix family exploded to **397,219 suffixes** (round-0 pickle
+  is 682 MB).
+- Round 1 **OOMed** (exit 137) doing `resolve_dfa`/`deepcopy` on that table — the same
+  wall the linear `composition_residual` run hit.
+
+This is not a SpliceAI quirk. It is what E-L\* does to a **deterministic but not
+compactly-regular** target.
+
+## The frame signal is real — and regular in isolation
+
+The deconfounded oracle carries a genuine, non-compositional signal: it **rejects no-ORF
+(all-frames-closed) strings** and accepts strings with an open reading frame.
+
+- signed φ(accept, all-frames-closed) = **−0.21**
+- accept | no ORF = 0.38 vs accept | ≥1 ORF open = 0.60
+- I(call; all-frames-closed | full composition) ≈ 0.016 bits (gate); ~0.03 bits as a
+  thresholded oracle at length 95.
+
+And E-L\*'s own round-0 suffixes **do track this** (`suffix_frame_analysis.py`): the more
+reading frames a prefix has closed, the more the suffix family drives the oracle to
+reject (correlation −0.21, matching the oracle), and it is **phase-specific** — which
+frame is open changes the call, not just how many. So the probes see the frame signal.
+
+Crucially, **all-frames-closed is itself a regular language** (~20 states) and E-L\*
+learns it fine in isolation. The failure is not blindness to frame; it is that the frame
+automaton is buried inside SpliceAI's non-regular residual, which shatters the learner
+before it can isolate the ~20-state signal from the noise-level exact distinctions.
+
+## Reproduction with a simple grammar
+
+Shattering reproduces with a grammar you can write in three lines — no SpliceAI, no GPU,
+no learned weights (`shattering_repro.py`). Over 300 random length-48 prefixes, count the
+**distinct observation-table rows** (= states E-L\* would create by its exact
+deterministic distinguishing) as the random suffix set grows:
+
+| oracle (grammar) | 10 suf | 100 suf | 1000 suf | 4000 suf | final frac |
+|---|---:|---:|---:|---:|---:|
+| randomDFA (6 states, regular) | 1 | 1 | 5 | 5 | 0.02 |
+| all-frames-closed (regular) | 9 | 20 | 20 | 20 | 0.07 |
+| half **count**-compare (statistic) | 8 | 16 | 19 | 19 | 0.06 |
+| half **lex**-compare (whole prefix) | 10 | 81 | 231 | **273** | **0.91** |
+
+The two comparison grammars are almost identical — both ask *"is the first half bigger
+than the second half?"* The only difference is **bigger how**:
+
+```python
+# saturates (~length/2 states): compares a STATISTIC
+def count_compare(x):
+    h = len(x) // 2
+    return x[:h].count('A') > x[h:2*h].count('A')
+
+# shatters (one state per prefix): compares the WHOLE prefix
+def lex_compare(x):
+    h = len(x) // 2
+    return x[:h] > x[h:2*h]          # lexicographic
+```
+
+`count`-compare only needs the running A-count, so E-L\* collapses it to ~length/2 states
+and it saturates. `lex`-compare needs the entire prefix: two prefixes are
+E-L\*-equivalent only if identical, so **every prefix becomes its own state** and the
+table runs away toward one-state-per-prefix.
+
+## The mechanism (Myhill–Nerode, with E-L\*'s exact distinguishing)
+
+E-L\* merges two prefixes `p1, p2` into one state iff `oracle(p1 + s) == oracle(p2 + s)`
+for every distinguishing suffix `s`. For a **regular** target the number of such
+equivalence classes is bounded (the DFA's states), so the table saturates. For a target
+that is a fine function of the whole prefix (lex-compare; SpliceAI's residual), for
+*every* pair `p1 ≠ p2` there exists a suffix that separates them — no merging is ever
+final, and the family grows without bound. That unbounded growth is the shattering, and
+because each state is pinned by in-sample-only distinctions, it carries no held-out
+signal.
+
+"Many states" is not the problem — the random DFA (5) and all-frames-closed (20) have
+many and still converge. The problem is **unbounded, non-regular** growth.
+
+## Implication
+
+The lever is the **synthesis rule, not the oracle**. E-L\* distinguishes states
+*exactly*: any reproducible difference forces a split. Against a deterministic non-regular
+target that manufactures endless real-but-non-generalizing differences, exact
+distinguishing shatters. To recover a weak regular signal (the frame automaton) from
+inside a non-regular function, the merge step needs to be **noise/complexity-tolerant** —
+e.g. merge prefixes whose accept-rate signatures agree to within a tolerance, or bound
+model complexity — so the ~20-state frame structure can survive instead of being buried
+under one-state-per-prefix shrapnel.
+
+## Artifacts (this change)
+
+- `orthogonal_dfa/analysis/shattering_repro.py` — the grammars (`RandomDFAOracle`,
+  `HalfCountCompareOracle`, `HalfLexCompareOracle`) and `shattering_curve`; `run_round0`
+  optionally runs the real synthesis end to end.
+- `results/shattering_repro.md` — the generated table.
+
+The SpliceAI composition-deconfounding pipeline that motivated this (the gate oracle, the
+E-L\* run, the suffix analysis) is a separate change; the numbers cited above come from
+it.


### PR DESCRIPTION
## What

A small, self-contained reproduction of the suffix-family **shattering** E-L\* exhibits on deterministic-but-non-regular oracles — grammars you can read in three lines, no SpliceAI / GPU / learned weights.

`shattering_curve` counts distinct observation-table rows (= states E-L\* would create by exact deterministic distinguishing) over 300 random length-48 prefixes as the random suffix set grows:

| grammar | 10 suf | 100 suf | 1000 suf | 4000 suf | final frac |
|---|---:|---:|---:|---:|---:|
| randomDFA (6 states, regular) | 1 | 1 | 5 | 5 | 0.02 |
| all-frames-closed (regular) | 9 | 20 | 20 | 20 | 0.07 |
| count-compare (a statistic) | 8 | 16 | 19 | 19 | 0.06 |
| lex-compare (whole prefix) | 10 | 81 | 231 | 273 | 0.91 |

Both comparison grammars ask *"is the first half bigger than the second half?"* — `count`-compare compares a **statistic** (needs only a running count → saturates at ~length/2 states), `lex`-compare compares the **whole prefix** (two prefixes merge only if identical → shatters toward one-state-per-prefix). Same question; that's the entire difference between converging and shattering.

`results/shattering_writeup.md` is the narrative: the Myhill–Nerode mechanism under E-L\*'s exact distinguishing, and why it matters — all-frames-closed is regular and learnable in isolation (~20 states), but buried inside a non-regular function E-L\* shatters before it can isolate it, so the lever is the **synthesis rule** (a noise/complexity-tolerant merge), not the oracle.

## Files
- `orthogonal_dfa/analysis/shattering_repro.py` — the grammars (`RandomDFAOracle`, `HalfCountCompareOracle`, `HalfLexCompareOracle`) + `shattering_curve`; `run_round0` runs the real synthesis end to end.
- `results/shattering_repro.md`, `results/shattering_writeup.md`

Depends only on committed `l_star` code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
