### PR TITLE
Add the CAPAL hyperparameter sweep and matched-budget probe

### DIFF
--- a/orthogonal_dfa/experiments/capal_comparison/core.py
+++ b/orthogonal_dfa/experiments/capal_comparison/core.py
@@ -66,6 +66,15 @@ EVAL_MAX_LEN = 40
 EVAL_SEED = 0x1234
 
 
+class BudgetExhausted(BaseException):
+    """Raised when a cell has issued its allowance of distinct membership queries.
+
+    BaseException for the same reason as `CellTimeout`: it is a stopping rule
+    imposed from outside, not a learner failure, so the drivers' broad
+    `except Exception` must not swallow it.
+    """
+
+
 class CellTimeout(BaseException):
     """Raised when a cell outruns `CELL_TIMEOUT_SECONDS`.
 
@@ -185,9 +194,32 @@ def run_capal_cell(
     truth: Callable[[List[int]], bool],
     alphabet: Sequence[str],
     timeout: int = CELL_TIMEOUT_SECONDS,
+    query_budget: Optional[int] = None,
+    **learner_kwargs: Any,
 ) -> Cell:
-    """Run upstream CAPAL on `target` and score it on the shared word list."""
-    learner = make_learner(target, eta, seed=seed)
+    """Run upstream CAPAL on `target` and score it on the shared word list.
+
+    `learner_kwargs` go to `make_learner`, whose defaults are upstream's own
+    benchmark settings. Overriding them is what the hyperparameter sweep does;
+    the config is read back off the learner below either way, so the record
+    always says what CAPAL actually ran with.
+
+    `query_budget` stops the fit once that many *distinct* membership queries
+    have been issued, and scores whatever hypothesis CAPAL had reached. That is
+    what makes a like-for-like comparison against E-L*'s own spend possible:
+    without it, CAPAL's query count is whatever its configuration happens to
+    consume, which on this repo's targets ranged from 1% to 16x E-L*'s.
+
+    A budgeted cell ends one of four ways, and `error_type` says which:
+
+    - `None` -- converged inside the budget.
+    - `"BudgetExhausted"` -- spent the budget; the scored hypothesis is real,
+      it simply is not CAPAL's final answer.
+    - `"Stalled"` -- ran out of iterations without spending the budget, so the
+      budget never bound and this is not a matched-budget measurement.
+    - `"Timeout"` -- the wall clock ended it, with no hypothesis to score.
+    """
+    learner = make_learner(target, eta, seed=seed, **learner_kwargs)
     cell = Cell(
         benchmark=benchmark,
         family=family,
@@ -213,6 +245,17 @@ def run_capal_cell(
         },
     )
 
+    if query_budget is not None:
+        inner_mq = learner.mq.query
+
+        def budgeted_query(string: str) -> bool:
+            answer = inner_mq(string)
+            if len(learner.mq.cache) >= query_budget:
+                raise BudgetExhausted()
+            return answer
+
+        learner.mq.query = budgeted_query  # type: ignore[method-assign]
+
     eq_calls = {"n": 0}
     inner_eq = learner.eq.query
 
@@ -227,6 +270,14 @@ def run_capal_cell(
         with time_limit(timeout), contextlib.redirect_stdout(io.StringIO()):
             dfa, converged = fit_with_fallback(learner)
         cell.converged = converged
+    except BudgetExhausted:
+        # The last hypothesis is what CAPAL would have answered had it been
+        # stopped here, so it is the thing to score -- not a failure.
+        last = getattr(learner, "_last_hyp", None)
+        dfa = getattr(last, "dfa", None)
+        cell.converged = False
+        cell.error_type = "BudgetExhausted"
+        cell.error = f"stopped at the {query_budget} distinct-query budget"
     except CellTimeout:
         cell.error_type = "Timeout"
         cell.error = f"no hypothesis within {timeout}s"
@@ -243,6 +294,24 @@ def run_capal_cell(
     # the MQ, so repeats never get here.
     cell.queries_total = len(learner.mq.cache)
     cell.equivalence_queries = eq_calls["n"]
+
+    # Given a budget and unable to spend it: CAPAL ran out of iterations at a
+    # fixed point. Further rounds issue no new queries at all -- on
+    # regex_alt_111_or_000_3sym the distinct count is identical at 50 iterations
+    # and at 10000 -- so the budget can never bind and this is not a
+    # matched-budget measurement. It is its own outcome, and a stronger claim
+    # than a low score: CAPAL stops improving and cannot use more.
+    if (
+        query_budget is not None
+        and cell.error_type is None
+        and not cell.converged
+        and cell.queries_total < query_budget
+    ):
+        cell.error_type = "Stalled"
+        cell.error = (
+            f"stopped after {cell.equivalence_queries} iterations having used "
+            f"{cell.queries_total} of the {query_budget} query budget"
+        )
 
     if dfa is not None:
         cell.learned_states = dfa.num_states

--- a/orthogonal_dfa/experiments/capal_comparison/core.py
+++ b/orthogonal_dfa/experiments/capal_comparison/core.py
@@ -199,25 +199,13 @@ def run_capal_cell(
 ) -> Cell:
     """Run upstream CAPAL on `target` and score it on the shared word list.
 
-    `learner_kwargs` go to `make_learner`, whose defaults are upstream's own
-    benchmark settings. Overriding them is what the hyperparameter sweep does;
-    the config is read back off the learner below either way, so the record
-    always says what CAPAL actually ran with.
+    learner_kwargs override make_learner's defaults, which are upstream's own
+    benchmark settings.
 
-    `query_budget` stops the fit once that many *distinct* membership queries
-    have been issued, and scores whatever hypothesis CAPAL had reached. That is
-    what makes a like-for-like comparison against E-L*'s own spend possible:
-    without it, CAPAL's query count is whatever its configuration happens to
-    consume, which on this repo's targets ranged from 1% to 16x E-L*'s.
-
-    A budgeted cell ends one of four ways, and `error_type` says which:
-
-    - `None` -- converged inside the budget.
-    - `"BudgetExhausted"` -- spent the budget; the scored hypothesis is real,
-      it simply is not CAPAL's final answer.
-    - `"Stalled"` -- ran out of iterations without spending the budget, so the
-      budget never bound and this is not a matched-budget measurement.
-    - `"Timeout"` -- the wall clock ended it, with no hypothesis to score.
+    query_budget stops the fit after that many distinct membership queries and
+    scores the hypothesis reached, so CAPAL can be compared against E-L* at
+    equal spend. Stalled means it ran out of iterations under budget, so the
+    budget never bound and the cell is not a matched-budget measurement.
     """
     learner = make_learner(target, eta, seed=seed, **learner_kwargs)
     cell = Cell(
@@ -295,12 +283,6 @@ def run_capal_cell(
     cell.queries_total = len(learner.mq.cache)
     cell.equivalence_queries = eq_calls["n"]
 
-    # Given a budget and unable to spend it: CAPAL ran out of iterations at a
-    # fixed point. Further rounds issue no new queries at all -- on
-    # regex_alt_111_or_000_3sym the distinct count is identical at 50 iterations
-    # and at 10000 -- so the budget can never bind and this is not a
-    # matched-budget measurement. It is its own outcome, and a stronger claim
-    # than a low score: CAPAL stops improving and cannot use more.
     if (
         query_budget is not None
         and cell.error_type is None

--- a/orthogonal_dfa/experiments/capal_comparison/run_wall_sweep.py
+++ b/orthogonal_dfa/experiments/capal_comparison/run_wall_sweep.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Experiment 3: full CAPAL hyperparameter sweep across every benchmark cell.
+
+A full factorial over CAPAL's three real knobs -- `max_same_samples` (evidence
+per pairwise test), `suffix_pool_len_max` (suffix pool length), and `alpha`
+(comparison significance) -- run on every benchmark cell (target x noise) for
+three seeds. For each cell this tells a *cell-specific structural wall* (fails
+at every config and seed) from a *default-config artifact* (some config or seed
+cracks it), and whether the modulo-9 wall is "one hard DFA at high noise" or
+"high noise is bad for everything".
+
+The grid starts at upstream's own benchmark settings and only goes up, so its
+low corner is exactly the configuration experiments 1 and 2 measure. A cell that
+fails everywhere in this grid failed with at least the evidence, pool and search
+budget CAPAL's authors publish with, and more.
+
+`max_same_samples` is capped at 240: it is the entire runtime cost (m=80 ~3s,
+m=240 ~19s, m=480 ~146s with minutes-long outliers), and the preliminary m=480
+sweep showed larger m adds no convergence under persistent noise. `max_iters`
+stays at upstream's 200 rather than the 50 an earlier revision used, so
+convergence here means the same thing it does in sections 1-2.
+
+Example:
+    python -m orthogonal_dfa.experiments.capal_comparison.run_wall_sweep \
+        --etas 0.05 0.10 0.20 0.30 --seeds 0 1 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from .core import (
+    REPO_ROOT,
+    Cell,
+    eval_words,
+    run_capal_cell,
+    run_elstar_cell,
+    write_experiment,
+)
+from .our_targets import our_benchmarks
+
+DEFAULT_ETAS = [0.05, 0.10, 0.20, 0.30]
+DEFAULT_SEEDS = [0, 1, 2]
+
+#: Full factorial over the three knobs that actually move CAPAL, anchored at
+#: upstream's benchmark settings (m=80, pool=10, alpha=1e-3) and sweeping up.
+M_VALUES = [80, 240]
+POOL_VALUES = [10, 24]
+ALPHA_VALUES = [1e-3, 0.05]
+CONFIGS: List[Tuple[str, Dict[str, Any]]] = [
+    (
+        f"m={m},pool={p},alpha={a}",
+        dict(max_same_samples=m, suffix_pool_len_max=p, alpha=a),
+    )
+    for m, p, a in itertools.product(M_VALUES, POOL_VALUES, ALPHA_VALUES)
+]
+
+#: The matched-budget probe: CAPAL given exactly the distinct membership
+#: queries E-L* spent on the same cell, then stopped and scored on whatever
+#: hypothesis it had reached.
+#:
+#: The knobs uncap suffix enumeration so that CAPAL has somewhere productive to
+#: spend the budget -- at its shipped settings it stops after a few thousand
+#: queries, far short of E-L*'s millions, and the comparison would be vacuous.
+#: `max_iters` is raised for the same reason: the run should end because the
+#: budget ran out, not because the iteration cap did. 500 is well clear of what
+#: a productive run needs -- the parity cells spend their whole budget in 6 to 8
+#: iterations -- and a stalled run gets no value from more: on
+#: regex_alt_111_or_000_3sym the distinct-query count and the learned automaton
+#: are identical at 50 iterations and at 10000, so the extra rounds only cost
+#: wall clock.
+#:
+#: Every knob here is at or above the sweep's range, so this cannot be read as
+#: CAPAL being under-provisioned on some axis relative to experiment 3:
+#: `suffix_pool_len_max` matches the sweep's 24, `max_same_samples` is 8x its
+#: top, and `enum_depth`/`extra_len_max` are above the defaults the sweep holds
+#: them at.
+MATCHED_BUDGET_CONFIGS: List[Tuple[str, Dict[str, Any]]] = [
+    (
+        "matched,enum=8,extra=16,pool=24,m=2000",
+        dict(
+            max_same_samples=2000,
+            suffix_pool_len_max=24,
+            enum_depth=8,
+            extra_len_max=16,
+            max_iters=500,
+        ),
+    ),
+]
+
+
+def elstar_budgets() -> Dict[Tuple[str, float], int]:
+    """E-L*'s distinct membership queries per (benchmark, eta), from experiment 2.
+
+    Only cells E-L* actually solved carry a budget: matching CAPAL against a
+    number E-L* did not itself achieve would not be a comparison.
+    """
+    path = REPO_ROOT / "data" / "capal" / "our_benchmarks.json"
+    if not path.exists():
+        raise SystemExit(
+            f"{path} is missing; run run_our_bench first -- the matched budget "
+            "is defined by what E-L* spent."
+        )
+    cells = json.loads(path.read_text())["cells"]
+    return {
+        (c["benchmark"], c["eta"]): c["queries_total"]
+        for c in cells
+        if c["learner"] == "E-L*" and c.get("queries_total") is not None
+    }
+
+
+def select_configs(
+    configs: List[Tuple[str, Dict[str, Any]]], labels: Optional[Sequence[str]]
+) -> List[Tuple[str, Dict[str, Any]]]:
+    """Apply `--configs`, in the order the caller named them."""
+    if not labels:
+        return list(configs)
+    by_label = dict(configs)
+    missing = sorted(set(labels) - by_label.keys())
+    if missing:
+        raise SystemExit(f"unknown config(s): {missing}\nknown: {sorted(by_label)}")
+    return [(label, by_label[label]) for label in labels]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--etas", nargs="+", type=float, default=None)
+    ap.add_argument("--seeds", nargs="+", type=int, default=DEFAULT_SEEDS)
+    ap.add_argument(
+        "--targets", nargs="+", default=None, help="Restrict to these benchmarks."
+    )
+    ap.add_argument(
+        "--matched-budget",
+        action="store_true",
+        help="Section-10 mode: uncap suffix enumeration to match E-L*'s query "
+        "budget (slow); defaults to eta=0.30 and its own output file.",
+    )
+    ap.add_argument(
+        "--with-elstar",
+        action="store_true",
+        help="Also run one E-L* reference per (cell, eta). Slow.",
+    )
+    ap.add_argument(
+        "--configs",
+        nargs="+",
+        default=None,
+        help="Restrict to these config labels (see CONFIGS / MATCHED_BUDGET_CONFIGS).",
+    )
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    sweep_configs = select_configs(
+        MATCHED_BUDGET_CONFIGS if args.matched_budget else CONFIGS, args.configs
+    )
+    etas = args.etas or ([0.30] if args.matched_budget else DEFAULT_ETAS)
+    experiment = "matched_budget" if args.matched_budget else "wall_sweep"
+    default_out = REPO_ROOT / "data" / "capal" / f"{experiment}.json"
+
+    budgets = elstar_budgets() if args.matched_budget else {}
+    benchmarks = our_benchmarks()
+    if args.targets:
+        by = {b.name: b for b in benchmarks}
+        missing = set(args.targets) - by.keys()
+        if missing:
+            raise SystemExit(f"unknown target(s): {sorted(missing)}")
+        benchmarks = [by[n] for n in args.targets]
+
+    out_path = Path(args.out) if args.out else default_out
+    cells: List[Cell] = []
+    config = {
+        "etas": list(etas),
+        "seeds": list(args.seeds),
+        "benchmarks": [b.name for b in benchmarks],
+        "configs": [label for label, _ in sweep_configs],
+        "matched_budget": args.matched_budget,
+        "with_elstar": args.with_elstar,
+    }
+
+    description = (
+        "CAPAL at a matched query budget (uncapped suffix enumeration) on the "
+        "eta=0.30 wall cells: does hitting E-L*'s distinct-query count break "
+        "the wall?"
+        if args.matched_budget
+        else (
+            "CAPAL hyperparameter sweep (max_same_samples x pool x alpha x seeds) "
+            "across every benchmark cell, to separate cell-specific structural "
+            "walls from default-config artifacts."
+        )
+    )
+
+    def flush(complete: bool = False) -> None:
+        write_experiment(
+            out_path,
+            experiment=experiment,
+            generated_by="orthogonal_dfa.experiments.capal_comparison.run_wall_sweep",
+            description=description,
+            config=config,
+            cells=cells,
+            complete=complete,
+        )
+
+    total = len(benchmarks) * len(etas) * len(sweep_configs) * len(args.seeds)
+    done = 0
+    for b in benchmarks:
+        words = eval_words(b.symbols)
+        truth = b.truth()
+        for eta in etas:
+            for (label, kwargs), seed in itertools.product(sweep_configs, args.seeds):
+                done += 1
+                print(
+                    f"[{done}/{total}] {b.name} eta={eta:.2f} {label} seed={seed}",
+                    flush=True,
+                )
+                budget = budgets.get((b.name, eta)) if args.matched_budget else None
+                if args.matched_budget and budget is None:
+                    print("   skipped: E-L* has no spend recorded here", flush=True)
+                    continue
+                cell = run_capal_cell(
+                    b.target,
+                    benchmark=b.name,
+                    family=b.family,
+                    eta=eta,
+                    seed=seed,
+                    words=words,
+                    truth=truth,
+                    alphabet=b.alphabet,
+                    query_budget=budget,
+                    **kwargs,
+                )
+                cell.learner_config["label"] = label
+                cells.append(cell)
+                print(
+                    f"   -> acc={cell.accuracy} conv={cell.converged} "
+                    f"states={cell.learned_states}/{b.target_states} "
+                    f"mq={cell.queries_total} eq={cell.equivalence_queries} ({cell.seconds:.1f}s)",
+                    flush=True,
+                )
+                flush()
+
+            if args.with_elstar:
+                print(f"[E-L*] {b.name} eta={eta:.2f} reference", flush=True)
+                cell = run_elstar_cell(
+                    b.oracle_creator,
+                    benchmark=b.name,
+                    family=b.family,
+                    eta=eta,
+                    seed=0,
+                    symbols=b.symbols,
+                    words=words,
+                    truth=truth,
+                    target_states=b.target_states,
+                )
+                cell.learner_config["label"] = "E-L* reference"
+                cells.append(cell)
+                flush()
+
+    flush(complete=True)
+    print(f"\nWrote {out_path} ({len(cells)} cells)")
+
+
+if __name__ == "__main__":
+    main()

--- a/orthogonal_dfa/experiments/capal_comparison/run_wall_sweep.py
+++ b/orthogonal_dfa/experiments/capal_comparison/run_wall_sweep.py
@@ -33,15 +33,9 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from .core import (
-    REPO_ROOT,
-    Cell,
-    eval_words,
-    run_capal_cell,
-    run_elstar_cell,
-    write_experiment,
-)
+from .core import REPO_ROOT, Cell, eval_words, write_experiment
 from .our_targets import our_benchmarks
+from .sweep import capal_cell
 
 DEFAULT_ETAS = [0.05, 0.10, 0.20, 0.30]
 DEFAULT_SEEDS = [0, 1, 2]
@@ -140,11 +134,6 @@ def main() -> None:
         "budget (slow); defaults to eta=0.30 and its own output file.",
     )
     ap.add_argument(
-        "--with-elstar",
-        action="store_true",
-        help="Also run one E-L* reference per (cell, eta). Slow.",
-    )
-    ap.add_argument(
         "--configs",
         nargs="+",
         default=None,
@@ -177,7 +166,6 @@ def main() -> None:
         "benchmarks": [b.name for b in benchmarks],
         "configs": [label for label, _ in sweep_configs],
         "matched_budget": args.matched_budget,
-        "with_elstar": args.with_elstar,
     }
 
     description = (
@@ -219,15 +207,12 @@ def main() -> None:
                 if args.matched_budget and budget is None:
                     print("   skipped: E-L* has no spend recorded here", flush=True)
                     continue
-                cell = run_capal_cell(
-                    b.target,
-                    benchmark=b.name,
-                    family=b.family,
+                cell = capal_cell(
+                    b,
                     eta=eta,
                     seed=seed,
                     words=words,
                     truth=truth,
-                    alphabet=b.alphabet,
                     query_budget=budget,
                     **kwargs,
                 )
@@ -239,23 +224,6 @@ def main() -> None:
                     f"mq={cell.queries_total} eq={cell.equivalence_queries} ({cell.seconds:.1f}s)",
                     flush=True,
                 )
-                flush()
-
-            if args.with_elstar:
-                print(f"[E-L*] {b.name} eta={eta:.2f} reference", flush=True)
-                cell = run_elstar_cell(
-                    b.oracle_creator,
-                    benchmark=b.name,
-                    family=b.family,
-                    eta=eta,
-                    seed=0,
-                    symbols=b.symbols,
-                    words=words,
-                    truth=truth,
-                    target_states=b.target_states,
-                )
-                cell.learner_config["label"] = "E-L* reference"
-                cells.append(cell)
                 flush()
 
     flush(complete=True)

--- a/orthogonal_dfa/experiments/capal_comparison/run_wall_sweep.py
+++ b/orthogonal_dfa/experiments/capal_comparison/run_wall_sweep.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
-"""Experiment 3, the hyperparameter sweep, and experiment 4, the matched budget.
+"""
+Experiment 3, the hyperparameter sweep, and experiment 4, the matched budget.
 
-The sweep runs a full factorial over max_same_samples, suffix_pool_len_max and
+The sweep runs every combination of max_same_samples, suffix_pool_len_max and
 alpha on every benchmark cell, for three seeds. Its grid starts at upstream's
-own benchmark settings and only goes up, so a cell that fails across all of it
-failed with at least the budget CAPAL's authors publish with.
+own benchmark settings and goes up along each axis.
 
 m stops at 240 because it is essentially the whole runtime cost (m=80 ~3s,
 m=240 ~19s, m=480 ~146s) and a preliminary m=480 sweep added no convergence.
+
+--matched-budget runs CAPAL with exactly the membership queries E-L* spent on
+the same cell, at eta=0.30. It is slow because it runs CAPAL with a large query budget,
+and so is not a sweep.
 
     python -m orthogonal_dfa.experiments.capal_comparison.run_wall_sweep
     python -m orthogonal_dfa.experiments.capal_comparison.run_wall_sweep --matched-budget
@@ -40,11 +44,6 @@ CONFIGS: List[Tuple[str, Dict[str, Any]]] = [
     for m, p, a in itertools.product(M_VALUES, POOL_VALUES, ALPHA_VALUES)
 ]
 
-#: Experiment 4: CAPAL given exactly the queries E-L* spent on the same cell.
-#: The knobs uncap suffix enumeration so it has somewhere to spend them, since
-#: at its shipped settings it stops after a few thousand. Every one is at or
-#: above the sweep's range, so failing here cannot be read as CAPAL being
-#: under-provisioned relative to experiment 3.
 MATCHED_BUDGET_CONFIGS: List[Tuple[str, Dict[str, Any]]] = [
     (
         "matched,enum=8,extra=16,pool=24,m=2000",
@@ -60,7 +59,8 @@ MATCHED_BUDGET_CONFIGS: List[Tuple[str, Dict[str, Any]]] = [
 
 
 def elstar_budgets() -> Dict[Tuple[str, float], int]:
-    """E-L*'s membership queries per (benchmark, eta), from experiment 2.
+    """
+    E-L*'s membership queries per (benchmark, eta), from experiment 2.
 
     Cells E-L* was not run on have no spend to match, and so carry no budget.
     """

--- a/orthogonal_dfa/experiments/capal_comparison/run_wall_sweep.py
+++ b/orthogonal_dfa/experiments/capal_comparison/run_wall_sweep.py
@@ -1,28 +1,16 @@
 #!/usr/bin/env python3
-"""Experiment 3: full CAPAL hyperparameter sweep across every benchmark cell.
+"""Experiment 3, the hyperparameter sweep, and experiment 4, the matched budget.
 
-A full factorial over CAPAL's three real knobs -- `max_same_samples` (evidence
-per pairwise test), `suffix_pool_len_max` (suffix pool length), and `alpha`
-(comparison significance) -- run on every benchmark cell (target x noise) for
-three seeds. For each cell this tells a *cell-specific structural wall* (fails
-at every config and seed) from a *default-config artifact* (some config or seed
-cracks it), and whether the modulo-9 wall is "one hard DFA at high noise" or
-"high noise is bad for everything".
+The sweep runs a full factorial over max_same_samples, suffix_pool_len_max and
+alpha on every benchmark cell, for three seeds. Its grid starts at upstream's
+own benchmark settings and only goes up, so a cell that fails across all of it
+failed with at least the budget CAPAL's authors publish with.
 
-The grid starts at upstream's own benchmark settings and only goes up, so its
-low corner is exactly the configuration experiments 1 and 2 measure. A cell that
-fails everywhere in this grid failed with at least the evidence, pool and search
-budget CAPAL's authors publish with, and more.
+m stops at 240 because it is essentially the whole runtime cost (m=80 ~3s,
+m=240 ~19s, m=480 ~146s) and a preliminary m=480 sweep added no convergence.
 
-`max_same_samples` is capped at 240: it is the entire runtime cost (m=80 ~3s,
-m=240 ~19s, m=480 ~146s with minutes-long outliers), and the preliminary m=480
-sweep showed larger m adds no convergence under persistent noise. `max_iters`
-stays at upstream's 200 rather than the 50 an earlier revision used, so
-convergence here means the same thing it does in sections 1-2.
-
-Example:
-    python -m orthogonal_dfa.experiments.capal_comparison.run_wall_sweep \
-        --etas 0.05 0.10 0.20 0.30 --seeds 0 1 2
+    python -m orthogonal_dfa.experiments.capal_comparison.run_wall_sweep
+    python -m orthogonal_dfa.experiments.capal_comparison.run_wall_sweep --matched-budget
 """
 
 from __future__ import annotations
@@ -40,8 +28,7 @@ from .sweep import capal_cell
 DEFAULT_ETAS = [0.05, 0.10, 0.20, 0.30]
 DEFAULT_SEEDS = [0, 1, 2]
 
-#: Full factorial over the three knobs that actually move CAPAL, anchored at
-#: upstream's benchmark settings (m=80, pool=10, alpha=1e-3) and sweeping up.
+#: Anchored at upstream's benchmark settings (m=80, pool=10, alpha=1e-3).
 M_VALUES = [80, 240]
 POOL_VALUES = [10, 24]
 ALPHA_VALUES = [1e-3, 0.05]
@@ -53,26 +40,11 @@ CONFIGS: List[Tuple[str, Dict[str, Any]]] = [
     for m, p, a in itertools.product(M_VALUES, POOL_VALUES, ALPHA_VALUES)
 ]
 
-#: The matched-budget probe: CAPAL given exactly the distinct membership
-#: queries E-L* spent on the same cell, then stopped and scored on whatever
-#: hypothesis it had reached.
-#:
-#: The knobs uncap suffix enumeration so that CAPAL has somewhere productive to
-#: spend the budget -- at its shipped settings it stops after a few thousand
-#: queries, far short of E-L*'s millions, and the comparison would be vacuous.
-#: `max_iters` is raised for the same reason: the run should end because the
-#: budget ran out, not because the iteration cap did. 500 is well clear of what
-#: a productive run needs -- the parity cells spend their whole budget in 6 to 8
-#: iterations -- and a stalled run gets no value from more: on
-#: regex_alt_111_or_000_3sym the distinct-query count and the learned automaton
-#: are identical at 50 iterations and at 10000, so the extra rounds only cost
-#: wall clock.
-#:
-#: Every knob here is at or above the sweep's range, so this cannot be read as
-#: CAPAL being under-provisioned on some axis relative to experiment 3:
-#: `suffix_pool_len_max` matches the sweep's 24, `max_same_samples` is 8x its
-#: top, and `enum_depth`/`extra_len_max` are above the defaults the sweep holds
-#: them at.
+#: Experiment 4: CAPAL given exactly the queries E-L* spent on the same cell.
+#: The knobs uncap suffix enumeration so it has somewhere to spend them, since
+#: at its shipped settings it stops after a few thousand. Every one is at or
+#: above the sweep's range, so failing here cannot be read as CAPAL being
+#: under-provisioned relative to experiment 3.
 MATCHED_BUDGET_CONFIGS: List[Tuple[str, Dict[str, Any]]] = [
     (
         "matched,enum=8,extra=16,pool=24,m=2000",
@@ -88,10 +60,9 @@ MATCHED_BUDGET_CONFIGS: List[Tuple[str, Dict[str, Any]]] = [
 
 
 def elstar_budgets() -> Dict[Tuple[str, float], int]:
-    """E-L*'s distinct membership queries per (benchmark, eta), from experiment 2.
+    """E-L*'s membership queries per (benchmark, eta), from experiment 2.
 
-    Only cells E-L* actually solved carry a budget: matching CAPAL against a
-    number E-L* did not itself achieve would not be a comparison.
+    Cells E-L* was not run on have no spend to match, and so carry no budget.
     """
     path = REPO_ROOT / "data" / "capal" / "our_benchmarks.json"
     if not path.exists():
@@ -130,8 +101,8 @@ def main() -> None:
     ap.add_argument(
         "--matched-budget",
         action="store_true",
-        help="Section-10 mode: uncap suffix enumeration to match E-L*'s query "
-        "budget (slow); defaults to eta=0.30 and its own output file.",
+        help="Experiment 4: give CAPAL E-L*'s query budget instead of sweeping "
+        "(slow); defaults to eta=0.30 and its own output file.",
     )
     ap.add_argument(
         "--configs",
@@ -169,14 +140,12 @@ def main() -> None:
     }
 
     description = (
-        "CAPAL at a matched query budget (uncapped suffix enumeration) on the "
-        "eta=0.30 wall cells: does hitting E-L*'s distinct-query count break "
-        "the wall?"
+        "CAPAL given exactly the membership queries E-L* spent on the same "
+        "cell, at eta=0.30."
         if args.matched_budget
         else (
-            "CAPAL hyperparameter sweep (max_same_samples x pool x alpha x seeds) "
-            "across every benchmark cell, to separate cell-specific structural "
-            "walls from default-config artifacts."
+            "CAPAL hyperparameter sweep (max_same_samples x pool x alpha x "
+            "seeds) across every benchmark cell."
         )
     )
 

--- a/orthogonal_dfa/experiments/capal_comparison/sweep.py
+++ b/orthogonal_dfa/experiments/capal_comparison/sweep.py
@@ -11,7 +11,7 @@ import itertools
 import json
 from dataclasses import asdict
 from pathlib import Path
-from typing import Callable, Dict, List, Sequence
+from typing import Any, Callable, Dict, List, Sequence
 
 from orthogonal_dfa.l_star.preconditions import PreconditionReport
 
@@ -34,6 +34,30 @@ SEEDS = [0]
 LEARNERS = [LEARNER_CAPAL, LEARNER_ELSTAR]
 
 
+def capal_cell(
+    b: Benchmark,
+    *,
+    eta: float,
+    seed: int,
+    words: Sequence[List[int]],
+    truth: Callable[[List[int]], bool],
+    **learner_kwargs: Any,
+) -> Cell:
+    """CAPAL on one benchmark cell. The single call site, so the sweep and the
+    head-to-head drivers cannot drift apart in how they invoke it."""
+    return run_capal_cell(
+        b.target,
+        benchmark=b.name,
+        family=b.family,
+        eta=eta,
+        seed=seed,
+        words=words,
+        truth=truth,
+        alphabet=b.alphabet,
+        **learner_kwargs,
+    )
+
+
 def run_cell(
     b: Benchmark,
     *,
@@ -50,16 +74,7 @@ def run_cell(
     everything; E-L* runs only where that report says it is in regime.
     """
     if learner == LEARNER_CAPAL:
-        return run_capal_cell(
-            b.target,
-            benchmark=b.name,
-            family=b.family,
-            eta=eta,
-            seed=seed,
-            words=words,
-            truth=truth,
-            alphabet=b.alphabet,
-        )
+        return capal_cell(b, eta=eta, seed=seed, words=words, truth=truth)
     if regime.satisfied:
         return run_elstar_cell(
             b.oracle_creator,


### PR DESCRIPTION
Split off `capal-comparison`. Code only — the results these produce come separately.

## Experiment 3: hyperparameter sweep

Sweeps CAPAL's three statistical knobs across every benchmark cell, noise level and seed (8 configs × 5 targets × 4 η × 3 seeds = 480 runs).

The grid is **anchored at upstream's own benchmark settings and only sweeps up**:

| knob | values | note |
| --- | --- | --- |
| `max_same_samples` | 80, 240 | 80 is upstream's |
| `suffix_pool_len_max` | 10, 24 | 10 is upstream's |
| `alpha` | 1e-3, 0.05 | 1e-3 is upstream's |
| `max_iters` | 200 | upstream's |

So the grid's low corner is exactly the configuration experiments 1 and 2 measure, and a cell that fails across the whole grid failed with at least the budget CAPAL's authors publish with. An earlier revision swept from `m=60, pool=8` with `max_iters=50` — below upstream on three knobs, which made "CAPAL fails here" much weaker than it sounded.

## Experiment 4: matched query budget

Gives CAPAL exactly the distinct membership queries E-L\* spent on the same cell, stops it there, and scores the hypothesis it had reached.

This is the part worth reviewing. Left to run, CAPAL's query count is an emergent property of its configuration, not a controlled quantity — on these targets it landed anywhere between **1% and 16×** of E-L\*'s spend, so nothing was matched to anything and the probe didn't test what its name claimed.

## What `core.py` gains

- **`**learner_kwargs`** forwarded to `make_learner`. The sweep exists to override them; the config is still read back off the learner afterwards, so the record says what CAPAL actually ran with rather than what we asked for.
- **`query_budget`**, enforced against the distinct-query cache, raising `BudgetExhausted`. It derives from `BaseException` for the same reason `CellTimeout` does: a stopping rule imposed from outside is not a learner failure, and the drivers' broad `except Exception` must not swallow it.
- **A `Stalled` outcome.** CAPAL can reach a fixed point where further iterations issue *no new queries at all* — on `regex_alt_111_or_000_3sym` the distinct count and learned automaton are identical at `max_iters=50` and at `max_iters=10000`. Such a cell can never bind its budget, so it is not a matched-budget measurement, and recording it separately stops it being averaged in as a low score at a budget it never approached.

A budgeted cell therefore ends one of four ways, and `error_type` says which: `None` (converged inside budget), `BudgetExhausted`, `Stalled`, `Timeout`.

## Verification

`pylint` 10.00, 18 tests pass. Smoke-tested end to end: the config grid resolves, `--configs` selects by label, budgets load from experiment 2's record, and a 100k budget on modulo at η=0.30 is consumed to exactly 100,000 with a scored hypothesis at 0.502.

Experiment 4 reads E-L\*'s spend from `data/capal/our_benchmarks.json` and exits with a clear message if it is absent, since the budget is defined by what E-L\* used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)