### PR TITLE
Add MemoizedOracle: memoized batched membership wrapper

### DIFF
--- a/orthogonal_dfa/l_star/memoized_oracle.py
+++ b/orthogonal_dfa/l_star/memoized_oracle.py
@@ -1,0 +1,30 @@
+"""
+A memoized, batched membership wrapper for arbitrary strings.
+
+The prefix-suffix grid (MaskTable) holds membership for (prefix, suffix) cells.
+A sift touches fresh strings the grid never holds -- one per tree node -- so
+those are memoized here instead, keeping the grid free of transient rows.  The
+oracle is deterministic per string, so a cached bit is exactly what a fresh
+query would return; misses are issued as one batched call.
+"""
+
+from typing import List
+
+
+class MemoizedOracle:
+    """Membership of arbitrary strings, memoized per string and batched."""
+
+    def __init__(self, oracle):
+        self._oracle = oracle
+        self._cache: dict = {}
+
+    def membership(self, strings) -> List[int]:
+        cache = self._cache
+        keys = [tuple(s) for s in strings]
+        misses = list(dict.fromkeys(k for k in keys if k not in cache))
+        if misses:
+            answers = self._oracle.membership_queries([list(k) for k in misses])
+            assert len(answers) == len(misses), "oracle dropped answers"
+            for key, bit in zip(misses, answers):
+                cache[key] = int(bit)
+        return [cache[k] for k in keys]

--- a/tests/test_batch_queries.py
+++ b/tests/test_batch_queries.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from orthogonal_dfa.l_star.lstar import _batch_before_possible_stop
 from orthogonal_dfa.l_star.mask_table import UNOBSERVED, MaskTable
+from orthogonal_dfa.l_star.memoized_oracle import MemoizedOracle
 from orthogonal_dfa.l_star.midfix_tree import MidfixTree, oracle_decider
 from orthogonal_dfa.l_star.statistics import binomial_side_of_boundary
 from orthogonal_dfa.l_star.structures import Oracle
@@ -194,6 +195,21 @@ class TestBatchBeforePossibleStop(unittest.TestCase):
         self.assertEqual(
             5, _batch_before_possible_stop(0, 0, self.boundary, self.min_valid, 5)
         )
+
+
+class TestMemoizedOracle(unittest.TestCase):
+    def test_caches_batches_and_dedupes(self):
+        oracle = HashOracle()
+        memo = MemoizedOracle(oracle)
+        strings = [[1, 0, 1], [0, 0], [1, 0, 1]]  # note the repeat
+        bits = memo.membership(strings)
+        self.assertEqual([oracle.membership_query(s) for s in strings], bits)
+        self.assertEqual([2], oracle.calls, "one batched call, deduped")
+
+        # A repeat costs nothing.
+        oracle.calls.clear()
+        self.assertEqual(bits, memo.membership(strings))
+        self.assertEqual([], oracle.calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A small standalone utility that memoizes membership of arbitrary strings per string and batches misses in one oracle call.

The prefix-suffix mask grid holds membership for (prefix, suffix) cells; off-grid strings a sift touches (one per tree node) are never on the grid, so they are memoized here instead — keeping the grid free of transient rows. The oracle is deterministic per string, so a cached bit is exactly what a fresh query would return.

First of a short series of extractions that move the direct-L* substrate onto main so the direct-lstar-random-walk branch shrinks to just the learner logic. No caller on main yet; it's the membership substrate a later PR (LeafPopulation + dropping the mask descent) builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)