### PR TITLE
Add LeafPopulation + MidfixTree path accessors

### DIFF
--- a/orthogonal_dfa/l_star/leaf_population.py
+++ b/orthogonal_dfa/l_star/leaf_population.py
@@ -1,0 +1,71 @@
+"""On-demand population of the discrimination tree's leaves.
+
+Each string rests at the deepest tree node it has so far been classified to, and
+is pulled further down only when a leaf below it is asked for more members than
+it already holds.  So the prefix pool is sifted lazily and incrementally -- a
+chunk at a time, toward the leaf being asked about -- rather than re-sifted from
+the root on every query.
+
+Keyed by *path*: the tuple of accept/reject branches from the root to a node.  A
+path is stable across splits (a split only appends two child paths below the
+split leaf), so this companion never has to be told the tree changed -- a former
+leaf simply becomes an internal node whose resting strings get flushed through it
+on the next pull.
+"""
+
+from typing import Callable, Dict, List, Optional, Tuple
+
+Path = Tuple[bool, ...]
+#: Classify a batch of strings against one node's midfix, decisions aligned with
+#: the input (``None`` = indecisive, dropped).
+Classify = Callable[[List[list], tuple], List[Optional[bool]]]
+
+
+class LeafPopulation:
+    """Strings resting at tree nodes, pulled toward a leaf on demand.
+
+    ``classify(strings, midfix)`` reads a node: it should batch the family queries
+    for ``strings`` at ``midfix`` and return one decision per string.
+    """
+
+    def __init__(self, tree, classify: Classify, *, chunk: int = 128):
+        self._tree = tree
+        self._classify = classify
+        self._chunk = chunk
+        # path -> strings currently resting at that node.
+        self._at: Dict[Path, List[tuple]] = {}
+
+    def add(self, string, at: Path = ()) -> None:
+        """Add ``string`` to the population resting at node ``at`` -- the root by
+        default (pooled, leaf unknown), or a leaf the caller has already sifted."""
+        self._at.setdefault(at, []).append(tuple(string))
+
+    def members(self, at: Path, count: int) -> List[list]:
+        """Up to ``count`` strings reaching leaf ``at``, pulling from ancestors as
+        needed and stopping as soon as ``count`` are in hand."""
+        self._fill(at, count)
+        return [list(s) for s in self._at.get(at, [])[:count]]
+
+    def _fill(self, at: Path, count: int) -> None:
+        """Pull strings down into ``at`` until it holds ``count`` or its ancestors
+        are exhausted."""
+        while len(self._at.get(at, ())) < count:
+            if not at:
+                return  # the root has no parent to pull from
+            parent = at[:-1]
+            if not self._at.get(parent):
+                self._fill(parent, self._chunk)  # get a chunk into the parent first
+                if not self._at.get(parent):
+                    return  # ancestors exhausted -- at holds all it ever will
+            self._push_chunk(parent)
+
+    def _push_chunk(self, parent: Path) -> None:
+        """Classify one chunk of ``parent``'s strings and drop each into its
+        child; indecisive strings fall out of the population."""
+        bucket = self._at[parent]
+        chunk, self._at[parent] = bucket[: self._chunk], bucket[self._chunk :]
+        midfix = self._tree.midfix_at(parent)
+        decisions = self._classify([list(s) for s in chunk], midfix)
+        for string, decision in zip(chunk, decisions):
+            if decision is not None:
+                self._at.setdefault(parent + (decision,), []).append(string)

--- a/orthogonal_dfa/l_star/midfix_tree.py
+++ b/orthogonal_dfa/l_star/midfix_tree.py
@@ -66,6 +66,31 @@ class MidfixTree:
     def leaves(self) -> Iterator[int]:
         return _leaves(self._root)
 
+    def path_of(self, state: int) -> Optional[Tuple[bool, ...]]:
+        """The branches from the root to leaf ``state`` (True = accept child).
+
+        A path names a node stably across splits, so a companion that tracks
+        strings by node keys off this rather than the rebuilt node objects."""
+
+        def find(node: Node, path: Tuple[bool, ...]) -> Optional[Tuple[bool, ...]]:
+            if isinstance(node, int):
+                return path if node == state else None
+            _, lookup = node
+            for branch, child in lookup.items():
+                found = find(child, path + (branch,))
+                if found is not None:
+                    return found
+            return None
+
+        return find(self._root, ())
+
+    def midfix_at(self, path: Tuple[bool, ...]) -> tuple:
+        """The midfix of the internal node reached by following ``path``."""
+        node = self._root
+        for branch in path:
+            node = node[1][branch]
+        return node[0]
+
     def accepting_leaves(self) -> set:
         """
         The leaves on the accept side of the root, i.e. the accepting states. Sound

--- a/tests/test_leaf_population.py
+++ b/tests/test_leaf_population.py
@@ -1,0 +1,89 @@
+import unittest
+
+from orthogonal_dfa.l_star.leaf_population import LeafPopulation
+
+
+class _StubTree:
+    """root splits on bit 0; its reject child splits on bit 1.
+
+    ()        -> bit 0 : True -> leaf (True,)
+    (False,)  -> bit 1 : True -> leaf (False, True), False -> (False, False)
+    """
+
+    _midfix = {(): (), (False,): ("m",)}
+
+    def midfix_at(self, path):
+        return self._midfix[path]
+
+
+def _classifier():
+    """A batched classifier that routes by a bit of the string, counting calls."""
+    calls = {"batches": 0, "strings": 0}
+
+    def classify(strings, midfix):
+        calls["batches"] += 1
+        calls["strings"] += len(strings)
+        idx = 0 if midfix == () else 1
+        return [bool(s[idx]) for s in strings]
+
+    return classify, calls
+
+
+class TestLeafPopulation(unittest.TestCase):
+    def test_pulls_matching_strings_to_each_leaf(self):
+        classify, _ = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        for s in ([1, 0], [1, 1], [0, 1], [0, 0]):
+            pop.add(s)
+        self.assertEqual(sorted(pop.members((True,), 10)), [[1, 0], [1, 1]])
+        self.assertEqual(pop.members((False, True), 10), [[0, 1]])
+        self.assertEqual(pop.members((False, False), 10), [[0, 0]])
+
+    def test_count_bounds_the_pull(self):
+        # 100 strings all route to leaf (True,); asking for 3 pulls one chunk, not all.
+        classify, calls = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        for i in range(100):
+            pop.add([1, i % 2])
+        got = pop.members((True,), 3)
+        self.assertEqual(len(got), 3)
+        self.assertLessEqual(calls["strings"], 16)
+
+    def test_sibling_strings_rest_and_are_reused(self):
+        # Querying one leaf drains the root once; querying the sibling must not
+        # reclassify the root -- the sibling's strings are already resting below it.
+        classify, calls = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=64)
+        for s in ([1, 0], [0, 1], [1, 1], [0, 0]):
+            pop.add(s)
+        pop.members((True,), 10)
+        self.assertEqual(pop.members((False, True), 10), [[0, 1]])
+        self.assertEqual(calls["batches"], 2)  # root once, then (False,) once
+
+    def test_add_at_a_known_leaf_skips_classification(self):
+        classify, calls = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        pop.add([7, 7], at=(True,))
+        self.assertEqual(pop.members((True,), 10), [[7, 7]])
+        self.assertEqual(calls["batches"], 0)
+
+    def test_cold_query_of_a_grandchild_cascades(self):
+        # Querying a grandchild with everything still at the root pulls root ->
+        # (False,) -> (False, True) in one call.
+        classify, _ = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        for s in ([1, 0], [0, 1], [1, 1], [0, 0], [0, 1]):
+            pop.add(s)
+        self.assertEqual(sorted(pop.members((False, True), 10)), [[0, 1], [0, 1]])
+
+    def test_exhausted_ancestors_return_what_is_there(self):
+        classify, _ = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        for s in ([1, 0], [1, 1]):
+            pop.add(s)
+        # Only two strings reach (True,); asking for more just returns those two.
+        self.assertEqual(sorted(pop.members((True,), 50)), [[1, 0], [1, 1]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A companion to the discrimination tree that tracks which strings rest at which node and pulls them toward a leaf on demand.

- `members(at, count)` walks to node `at`, and if it doesn't already hold `count` strings, pulls from the nearest ancestor in chunks — classifying each chunk at the ancestor's midfix and dropping strings into their child (feeding `at`, resting its sibling) — climbing further up only when a level is exhausted, and stopping as soon as `count` are in hand. So the pool is sifted lazily and incrementally toward the leaf asked about, rather than re-sifted from the root.
- Keyed by **path** (the tuple of accept/reject branches from the root), which is stable across splits: a split only appends child paths below the split leaf, so the companion never has to be told the tree changed.
- `MidfixTree` gains two read-only accessors it keys off — `path_of(state)` and `midfix_at(path)`. Both additive; no existing method changes.

Second extraction moving the direct-L* substrate onto main. No caller on main yet — a later PR wires it in as the replacement for the mask-based pool descent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)