### PR TITLE
Fill MaskTable's matrix through a shared MemoizedOracle

### DIFF
--- a/orthogonal_dfa/l_star/mask_table.py
+++ b/orthogonal_dfa/l_star/mask_table.py
@@ -20,6 +20,8 @@ from typing import List
 
 import numpy as np
 
+from .memoized_oracle import MemoizedOracle
+
 # Sentinel for a not-yet-queried cell.  Private to this module: callers ask about
 # observation through ``fully_observed`` / ``observed_masks`` and never see it.
 UNOBSERVED = np.int8(-1)
@@ -28,7 +30,11 @@ UNOBSERVED = np.int8(-1)
 class MaskTable:
     def __init__(self, oracle, prefixes: List[List[int]], representative: List[bool]):
         assert len(prefixes) == len(representative)
-        self._oracle = oracle
+        # Memoize membership per string.  The matrix already dedups by (prefix,
+        # suffix) cell; this additionally dedups across cells that spell the same
+        # string, and -- once other readers share it -- across the whole learner.
+        self.memo = MemoizedOracle(oracle)
+        self._oracle = self.memo
         self._prefixes = [list(p) for p in prefixes]
         self._prefix_keys = {tuple(p) for p in self._prefixes}
         self._representative = list(representative)

--- a/orthogonal_dfa/l_star/mask_table.py
+++ b/orthogonal_dfa/l_star/mask_table.py
@@ -32,7 +32,7 @@ class MaskTable:
         assert len(prefixes) == len(representative)
         # Memoize membership per string.  The matrix already dedups by (prefix,
         # suffix) cell; this additionally dedups across cells that spell the same
-        # string, and -- once other readers share it -- across the whole learner.
+        # string, and allows us to remove the matrix caching in future.
         self.memo = MemoizedOracle(oracle)
         self._oracle = self.memo
         self._prefixes = [list(p) for p in prefixes]

--- a/orthogonal_dfa/l_star/memoized_oracle.py
+++ b/orthogonal_dfa/l_star/memoized_oracle.py
@@ -1,13 +1,3 @@
-"""
-A memoized, batched membership wrapper for arbitrary strings.
-
-Wraps an oracle and is one itself, so it drops in wherever a raw oracle is used
--- but a string is queried at most once no matter how many callers (or how many
-prefix/suffix cells) reference it.  The oracle is deterministic per string, so a
-cached bit is exactly what a fresh query would return; misses go out as one
-batched call.
-"""
-
 from typing import List
 
 from .structures import Oracle

--- a/orthogonal_dfa/l_star/memoized_oracle.py
+++ b/orthogonal_dfa/l_star/memoized_oracle.py
@@ -1,25 +1,30 @@
 """
 A memoized, batched membership wrapper for arbitrary strings.
 
-Wraps an oracle transparently -- the ``membership_queries`` interface is
-unchanged, so it drops in wherever a raw oracle is used -- but a string is
-queried at most once no matter how many callers (or how many prefix/suffix
-cells) reference it.  The oracle is deterministic per string, so a cached bit is
-exactly what a fresh query would return; misses are issued as one batched call.
+Wraps an oracle and is one itself, so it drops in wherever a raw oracle is used
+-- but a string is queried at most once no matter how many callers (or how many
+prefix/suffix cells) reference it.  The oracle is deterministic per string, so a
+cached bit is exactly what a fresh query would return; misses go out as one
+batched call.
 """
 
 from typing import List
 
+from .structures import Oracle
 
-class MemoizedOracle:
+
+class MemoizedOracle(Oracle):
     """Membership of arbitrary strings, memoized per string and batched."""
 
     def __init__(self, oracle):
         self._oracle = oracle
-        self.alphabet_size = oracle.alphabet_size
         self._cache: dict = {}
 
-    def membership(self, strings) -> List[int]:
+    @property
+    def alphabet_size(self) -> int:
+        return self._oracle.alphabet_size
+
+    def membership_queries(self, strings: List[List[int]]) -> List[int]:
         cache = self._cache
         keys = [tuple(s) for s in strings]
         misses = list(dict.fromkeys(k for k in keys if k not in cache))
@@ -30,5 +35,5 @@ class MemoizedOracle:
                 cache[key] = int(bit)
         return [cache[k] for k in keys]
 
-    # Oracle drop-in: same signature as the wrapped oracle's batched query.
-    membership_queries = membership
+    def membership_query(self, string: List[int]) -> bool:
+        return bool(self.membership_queries([string])[0])

--- a/orthogonal_dfa/l_star/memoized_oracle.py
+++ b/orthogonal_dfa/l_star/memoized_oracle.py
@@ -1,0 +1,34 @@
+"""
+A memoized, batched membership wrapper for arbitrary strings.
+
+Wraps an oracle transparently -- the ``membership_queries`` interface is
+unchanged, so it drops in wherever a raw oracle is used -- but a string is
+queried at most once no matter how many callers (or how many prefix/suffix
+cells) reference it.  The oracle is deterministic per string, so a cached bit is
+exactly what a fresh query would return; misses are issued as one batched call.
+"""
+
+from typing import List
+
+
+class MemoizedOracle:
+    """Membership of arbitrary strings, memoized per string and batched."""
+
+    def __init__(self, oracle):
+        self._oracle = oracle
+        self.alphabet_size = oracle.alphabet_size
+        self._cache: dict = {}
+
+    def membership(self, strings) -> List[int]:
+        cache = self._cache
+        keys = [tuple(s) for s in strings]
+        misses = list(dict.fromkeys(k for k in keys if k not in cache))
+        if misses:
+            answers = self._oracle.membership_queries([list(k) for k in misses])
+            assert len(answers) == len(misses), "oracle dropped answers"
+            for key, bit in zip(misses, answers):
+                cache[key] = int(bit)
+        return [cache[k] for k in keys]
+
+    # Oracle drop-in: same signature as the wrapped oracle's batched query.
+    membership_queries = membership

--- a/tests/test_batch_queries.py
+++ b/tests/test_batch_queries.py
@@ -202,12 +202,18 @@ class TestMemoizedOracle(unittest.TestCase):
         oracle = HashOracle()
         memo = MemoizedOracle(oracle)
         strings = [[1, 0, 1], [0, 0], [1, 0, 1]]  # note the repeat
-        bits = memo.membership(strings)
+        bits = memo.membership_queries(strings)
         self.assertEqual([oracle.membership_query(s) for s in strings], bits)
         self.assertEqual([2], oracle.calls, "one batched call, deduped")
         oracle.calls.clear()
-        self.assertEqual(bits, memo.membership(strings))
+        self.assertEqual(bits, memo.membership_queries(strings))
         self.assertEqual([], oracle.calls)
+        # the single-string query rides the same cache
+        oracle.calls.clear()
+        self.assertEqual(
+            oracle.membership_query([1, 0, 1]), memo.membership_query([1, 0, 1])
+        )
+        self.assertEqual([], oracle.calls, "cached, no new call")
 
 
 if __name__ == "__main__":

--- a/tests/test_batch_queries.py
+++ b/tests/test_batch_queries.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from orthogonal_dfa.l_star.lstar import _batch_before_possible_stop
 from orthogonal_dfa.l_star.mask_table import UNOBSERVED, MaskTable
+from orthogonal_dfa.l_star.memoized_oracle import MemoizedOracle
 from orthogonal_dfa.l_star.midfix_tree import MidfixTree, oracle_decider
 from orthogonal_dfa.l_star.statistics import binomial_side_of_boundary
 from orthogonal_dfa.l_star.structures import Oracle
@@ -194,6 +195,19 @@ class TestBatchBeforePossibleStop(unittest.TestCase):
         self.assertEqual(
             5, _batch_before_possible_stop(0, 0, self.boundary, self.min_valid, 5)
         )
+
+
+class TestMemoizedOracle(unittest.TestCase):
+    def test_caches_batches_and_dedupes(self):
+        oracle = HashOracle()
+        memo = MemoizedOracle(oracle)
+        strings = [[1, 0, 1], [0, 0], [1, 0, 1]]  # note the repeat
+        bits = memo.membership(strings)
+        self.assertEqual([oracle.membership_query(s) for s in strings], bits)
+        self.assertEqual([2], oracle.calls, "one batched call, deduped")
+        oracle.calls.clear()
+        self.assertEqual(bits, memo.membership(strings))
+        self.assertEqual([], oracle.calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
First step of migrating main's population/membership onto the direct-L* substrate, one benchmarked change at a time.

MaskTable now queries membership through a `MemoizedOracle` instead of the raw oracle. Behaviour-identical (the oracle is deterministic per string), and the memo is exposed as `MaskTable.memo` so the next reader — the leaf population that replaces the `classify_pool` descent — can share the same cache, which is what keeps that swap query-neutral.

`count_queries` (main vs this), fast tasks:

| task | queries main | queries pr | ratio | acc |
|---|---|---|---|---|
| modulo | 457,202 | 451,102 | 0.99x | 1.000 |
| subseq | 796,913 | 788,078 | 0.99x | 1.000 |
| two_subseq | 796,527 | 781,419 | 0.98x | 1.000 |
| poor_case | 838,695 | 827,453 | 0.99x | 1.000 |

No regressions — slightly fewer queries, from deduping cells that spell the same string. Supersedes #168 (that module, plus an actual caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `pr-mask-via-memoized-oracle` vs `main`

|   | task | queries `main` | queries `pr-mask-via-memoized-oracle` | ratio | acc `main` | acc `pr-mask-via-memoized-oracle` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 457,202 | 451,102 | 0.99x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 796,913 | 788,078 | 0.99x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 796,527 | 781,419 | 0.98x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 838,695 | 827,453 | 0.99x | 1.000 | 1.000 | 10 |
| ⚪ | modulo_hard | 1,251,782 | 1,236,882 | 0.99x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 2,764,865 | 2,738,365 | 0.99x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **0.99x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

### Forward passes — `pr-mask-via-memoized-oracle` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 14,401 → 14,216 (0.99x, 99% packed) | 3,726 → 3,677 (0.99x, 96% packed) | 622 → 618 (0.99x, 71% packed) |
| subseq | 28,339 → 28,061 (0.99x, 88% packed) | 10,981 → 10,912 (0.99x, 56% packed) | 6,153 → 6,146 (1.00x, 13% packed) |
| two_subseq | 27,499 → 27,028 (0.98x, 90% packed) | 9,922 → 9,801 (0.99x, 62% packed) | 5,112 → 5,100 (1.00x, 15% packed) |
| poor_case | 30,255 → 29,896 (0.99x, 86% packed) | 12,240 → 12,151 (0.99x, 53% packed) | 7,372 → 7,361 (1.00x, 11% packed) |
| modulo_hard | 39,224 → 38,759 (0.99x, 100% packed) | 9,939 → 9,828 (0.99x, 98% packed) | 1,424 → 1,411 (0.99x, 86% packed) |
| modulo_asym | 86,518 → 85,688 (0.99x, 100% packed) | 21,771 → 21,561 (0.99x, 99% packed) | 2,884 → 2,857 (0.99x, 94% packed) |
