### PR TITLE
Resolve transitions over a LeafPopulation instead of the mask

### DIFF
--- a/orthogonal_dfa/l_star/leaf_population.py
+++ b/orthogonal_dfa/l_star/leaf_population.py
@@ -1,16 +1,13 @@
 """On-demand population of the discrimination tree's leaves.
 
-Each string rests at the deepest tree node it has so far been classified to, and
-is pulled further down only when a leaf below it is asked for more members than
-it already holds.  So the prefix pool is sifted lazily and incrementally -- a
-chunk at a time, toward the leaf being asked about -- rather than re-sifted from
-the root on every query.
+Each string rests at the deepest node it has been classified to, and is pulled
+further down only when a leaf below it is asked for more members than it holds --
+so the pool is sifted lazily, a chunk at a time, not re-sifted from the root.
 
-Keyed by *path*: the tuple of accept/reject branches from the root to a node.  A
-path is stable across splits (a split only appends two child paths below the
-split leaf), so this companion never has to be told the tree changed -- a former
-leaf simply becomes an internal node whose resting strings get flushed through it
-on the next pull.
+Keyed by *path*, the accept/reject branches from the root to a node.  A path is
+stable across splits (a split only appends child paths below the split leaf), so
+this companion never has to be told the tree changed: a former leaf becomes an
+internal node whose resting strings flush through it on the next pull.
 """
 
 from typing import Callable, Dict, List, Optional, Tuple

--- a/orthogonal_dfa/l_star/leaf_population.py
+++ b/orthogonal_dfa/l_star/leaf_population.py
@@ -1,0 +1,71 @@
+"""On-demand population of the discrimination tree's leaves.
+
+Each string rests at the deepest tree node it has so far been classified to, and
+is pulled further down only when a leaf below it is asked for more members than
+it already holds.  So the prefix pool is sifted lazily and incrementally -- a
+chunk at a time, toward the leaf being asked about -- rather than re-sifted from
+the root on every query.
+
+Keyed by *path*: the tuple of accept/reject branches from the root to a node.  A
+path is stable across splits (a split only appends two child paths below the
+split leaf), so this companion never has to be told the tree changed -- a former
+leaf simply becomes an internal node whose resting strings get flushed through it
+on the next pull.
+"""
+
+from typing import Callable, Dict, List, Optional, Tuple
+
+Path = Tuple[bool, ...]
+#: Classify a batch of strings against one node's midfix, decisions aligned with
+#: the input (``None`` = indecisive, dropped).
+Classify = Callable[[List[list], tuple], List[Optional[bool]]]
+
+
+class LeafPopulation:
+    """Strings resting at tree nodes, pulled toward a leaf on demand.
+
+    ``classify(strings, midfix)`` reads a node: it should batch the family queries
+    for ``strings`` at ``midfix`` and return one decision per string.
+    """
+
+    def __init__(self, tree, classify: Classify, *, chunk: int = 128):
+        self._tree = tree
+        self._classify = classify
+        self._chunk = chunk
+        # path -> strings currently resting at that node.
+        self._at: Dict[Path, List[tuple]] = {}
+
+    def add(self, string, at: Path = ()) -> None:
+        """Add ``string`` to the population resting at node ``at`` -- the root by
+        default (pooled, leaf unknown), or a leaf the caller has already sifted."""
+        self._at.setdefault(at, []).append(tuple(string))
+
+    def members(self, at: Path, count: int) -> List[list]:
+        """Up to ``count`` strings reaching leaf ``at``, pulling from ancestors as
+        needed and stopping as soon as ``count`` are in hand."""
+        self._fill(at, count)
+        return [list(s) for s in self._at.get(at, [])[:count]]
+
+    def _fill(self, at: Path, count: int) -> None:
+        """Pull strings down into ``at`` until it holds ``count`` or its ancestors
+        are exhausted."""
+        while len(self._at.get(at, ())) < count:
+            if not at:
+                return  # the root has no parent to pull from
+            parent = at[:-1]
+            if not self._at.get(parent):
+                self._fill(parent, self._chunk)  # get a chunk into the parent first
+                if not self._at.get(parent):
+                    return  # ancestors exhausted -- at holds all it ever will
+            self._push_chunk(parent)
+
+    def _push_chunk(self, parent: Path) -> None:
+        """Classify one chunk of ``parent``'s strings and drop each into its
+        child; indecisive strings fall out of the population."""
+        bucket = self._at[parent]
+        chunk, self._at[parent] = bucket[: self._chunk], bucket[self._chunk :]
+        midfix = self._tree.midfix_at(parent)
+        decisions = self._classify([list(s) for s in chunk], midfix)
+        for string, decision in zip(chunk, decisions):
+            if decision is not None:
+                self._at.setdefault(parent + (decision,), []).append(string)

--- a/orthogonal_dfa/l_star/midfix_tree.py
+++ b/orthogonal_dfa/l_star/midfix_tree.py
@@ -66,6 +66,31 @@ class MidfixTree:
     def leaves(self) -> Iterator[int]:
         return _leaves(self._root)
 
+    def path_of(self, state: int) -> Optional[Tuple[bool, ...]]:
+        """The branches from the root to leaf ``state`` (True = accept child).
+
+        A path names a node stably across splits, so a companion that tracks
+        strings by node keys off this rather than the rebuilt node objects."""
+
+        def find(node: Node, path: Tuple[bool, ...]) -> Optional[Tuple[bool, ...]]:
+            if isinstance(node, int):
+                return path if node == state else None
+            _, lookup = node
+            for branch, child in lookup.items():
+                found = find(child, path + (branch,))
+                if found is not None:
+                    return found
+            return None
+
+        return find(self._root, ())
+
+    def midfix_at(self, path: Tuple[bool, ...]) -> tuple:
+        """The midfix of the internal node reached by following ``path``."""
+        node = self._root
+        for branch in path:
+            node = node[1][branch]
+        return node[0]
+
     def accepting_leaves(self) -> set:
         """
         The leaves on the accept side of the root, i.e. the accepting states. Sound

--- a/orthogonal_dfa/l_star/midfix_tree.py
+++ b/orthogonal_dfa/l_star/midfix_tree.py
@@ -67,10 +67,8 @@ class MidfixTree:
         return _leaves(self._root)
 
     def path_of(self, state: int) -> Optional[Tuple[bool, ...]]:
-        """The branches from the root to leaf ``state`` (True = accept child).
-
-        A path names a node stably across splits, so a companion that tracks
-        strings by node keys off this rather than the rebuilt node objects."""
+        """The branches from the root to leaf ``state`` (True = accept child); a
+        stable node key, unlike the node objects a split rebuilds."""
 
         def find(node: Node, path: Tuple[bool, ...]) -> Optional[Tuple[bool, ...]]:
             if isinstance(node, int):

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -19,9 +19,8 @@ This only directly affects state s, so all we need to do at this point is
 to re-enqueue all (s, c') for all symbols c' in the alphabet, as well as every
 edge (s', c') -> s, which needs to be reclassified into one of the newly split states.
 
-Each state's prefixes are the pool prefixes that sift to its leaf; they live in a
-:class:`~orthogonal_dfa.l_star.leaf_population.LeafPopulation` that rests them at
-tree nodes and pulls them toward a leaf on demand, reading membership through the
+Each state's prefixes -- the pool prefixes that sift to its leaf -- live in a
+:class:`~orthogonal_dfa.l_star.leaf_population.LeafPopulation`, read through the
 mask's shared MemoizedOracle so a cell the mask already holds costs no new query.
 
 The split keeps the accept side of the divergence as s itself and gives the reject
@@ -58,17 +57,16 @@ class TransitionResolver:
     def __init__(self, pst):
         self.pst = pst
         self.tree = None
-        self.population = None  # LeafPopulation: pool prefixes resting at each leaf
+        self.population = None  # pool prefixes, per leaf
         self.trans = {}  # (state_id, symbol) -> target state_id
-        self.incoming = {}  # state_id -> set of (state_id, symbol) pointing at it
+        self.incoming = {}  # state_id -> set of edges pointing at it
         self.queue = deque()
 
     # -- membership / population -------------------------------------------
 
     def _means(self, strings, distinguisher):
-        """Mean family membership of each string past ``distinguisher`` -- the
-        mean over ``string + distinguisher + v`` for base suffixes ``v``, through
-        the mask's shared memo (matching compute_decision's observed_masks.mean(0))."""
+        """Mean membership of each string past ``distinguisher``, read through the
+        mask's shared memo so cells the mask already holds cost no new query."""
         base = self.tree.base_family
         queries, spans = [], []
         for s in strings:
@@ -81,9 +79,8 @@ class TransitionResolver:
         return np.array([answers[lo:hi].mean() for lo, hi in spans])
 
     def _classify(self, strings, midfix):
-        """The leaf-population's decide: which side of ``midfix`` each string sits
-        on, thresholded like the split (accept_thresh / reject_thresh; the band
-        between is indecisive and drops out of the population)."""
+        """Which side of ``midfix`` each string sits on; the indecisive band
+        between the thresholds returns None and drops out of the population."""
         pst = self.pst
         means = self._means(strings, midfix)
         return [
@@ -131,8 +128,6 @@ class TransitionResolver:
         node = self.tree.root
         while not isinstance(node, int):
             midfix, lookup = node
-            # Resolving (state, c) reads the family one symbol deeper: c, then this
-            # node's own midfix, then each base suffix.
             prepended = [c] + list(midfix)
             decision = self._means(members, prepended)
             with np.errstate(invalid="ignore"):
@@ -145,8 +140,7 @@ class TransitionResolver:
         self._set_transition(state_id, c, node)
 
     def _split(self, state_id, midfix):
-        # The tree split re-partitions state_id's prefixes; the population re-sifts
-        # them on the next members() call, so nothing to fix up here.
+        # The population re-sifts state_id's prefixes on the next members() call.
         new_id = self.tree.split(state_id, midfix)
         self._reopen_edges(state_id)
         self._open_state(new_id)
@@ -159,8 +153,6 @@ class TransitionResolver:
         vs, boundary = sample_suffix_family(pst, v_idx)
         pst.decision_boundary = boundary
         self.tree = MidfixTree([pst.table.suffix(i) for i in vs])
-        # The pool prefixes rest in the tree and are sifted lazily through the
-        # shared memo -- the per-leaf partition self.masks used to hold explicitly.
         self.population = LeafPopulation(self.tree, self._classify)
         for p in pst.table.prefixes:
             self.population.add(list(p))

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -2,15 +2,14 @@
 
 Builds the discrimination tree (states) and the transition function together:
 
-The tree starts as the initial distinguisher family v_eps which partitions
-prefix pool into two sets s_acc / s_rej.  The leaves of the tree are the
-states of the DFA. We also separately maintain a transition function, which maps
+The tree starts as the initial distinguisher family v_eps which partitions the
+prefix pool into two sets s_acc / s_rej.  The leaves of the tree are the states
+of the DFA. We also separately maintain a transition function, which maps
 (state, symbol) pairs to target states.
 
-We work a queue of unresolved (state, symbol) pairs.  Resolving (s, c)
-classifies every prefix of s extended by c. Doing so involves querying
-the current tree for the prefixes of s except with every distinguisher
-family prepended by c.
+We work a queue of unresolved (state, symbol) pairs.  Resolving (s, c) classifies
+every prefix of s extended by c. Doing so involves querying the current tree for
+the prefixes of s except with every distinguisher family prepended by c.
 This has two possibilities:
   1. They all land on one leaf t. In this case we record the transition (s, c) -> t and move on.
   2. They diverge: s is really more than one state. We split it in two at the
@@ -20,17 +19,14 @@ This only directly affects state s, so all we need to do at this point is
 to re-enqueue all (s, c') for all symbols c' in the alphabet, as well as every
 edge (s', c') -> s, which needs to be reclassified into one of the newly split states.
 
-Evaluating a distinguisher [c]+w while resolving (s, c) only requires
-executing on the prefixes of s, which is a potentially small subset of
-the prefix pool.
+Each state's prefixes are the pool prefixes that sift to its leaf; they live in a
+:class:`~orthogonal_dfa.l_star.leaf_population.LeafPopulation` that rests them at
+tree nodes and pulls them toward a leaf on demand, reading membership through the
+mask's shared MemoizedOracle so a cell the mask already holds costs no new query.
 
 The split keeps the accept side of the divergence as s itself and gives the reject
 side a fresh id (see MidfixTree.split), so state ids stay a dense range(num_states)
 and never need remapping on export.
-
-One source of redundant work remains:
-  [2] If it's only going to be all one state it's possible this is easy to tell early
-  and bail on the rest of the queries, but we don't do that yet.
 """
 
 from collections import deque
@@ -40,6 +36,7 @@ import scipy.stats
 from automata.fa.dfa import DFA
 
 from .cluster import sample_suffix_family
+from .leaf_population import LeafPopulation
 from .midfix_tree import MidfixTree, oracle_decider
 
 
@@ -61,15 +58,48 @@ class TransitionResolver:
     def __init__(self, pst):
         self.pst = pst
         self.tree = None
-        self.masks = {}  # state_id -> bool mask over the prefix pool
+        self.population = None  # LeafPopulation: pool prefixes resting at each leaf
         self.trans = {}  # (state_id, symbol) -> target state_id
         self.incoming = {}  # state_id -> set of (state_id, symbol) pointing at it
         self.queue = deque()
 
+    # -- membership / population -------------------------------------------
+
+    def _means(self, strings, distinguisher):
+        """Mean family membership of each string past ``distinguisher`` -- the
+        mean over ``string + distinguisher + v`` for base suffixes ``v``, through
+        the mask's shared memo (matching compute_decision's observed_masks.mean(0))."""
+        base = self.tree.base_family
+        queries, spans = [], []
+        for s in strings:
+            lo = len(queries)
+            queries.extend(list(s) + list(distinguisher) + v for v in base)
+            spans.append((lo, len(queries)))
+        if not queries:
+            return np.zeros(len(strings))
+        answers = np.asarray(self.pst.table.memo.membership_queries(queries))
+        return np.array([answers[lo:hi].mean() for lo, hi in spans])
+
+    def _classify(self, strings, midfix):
+        """The leaf-population's decide: which side of ``midfix`` each string sits
+        on, thresholded like the split (accept_thresh / reject_thresh; the band
+        between is indecisive and drops out of the population)."""
+        pst = self.pst
+        means = self._means(strings, midfix)
+        return [
+            True if m >= pst.accept_thresh else False if m < pst.reject_thresh else None
+            for m in means
+        ]
+
+    def _members(self, state_id):
+        """The pool prefixes that sift to leaf ``state_id``."""
+        return self.population.members(
+            self.tree.path_of(state_id), self.pst.num_prefixes
+        )
+
     # -- bookkeeping --------------------------------------------------------
 
-    def _open_state(self, state_id, mask):
-        self.masks[state_id] = mask
+    def _open_state(self, state_id):
         self.incoming[state_id] = set()
         for c in range(self.pst.alphabet_size):
             self.queue.append((state_id, c))
@@ -81,8 +111,8 @@ class TransitionResolver:
 
     def _reopen_edges(self, state_id):
         # A split shrank state_id's membership, so both its outgoing edges (computed
-        # under the old, larger mask) and every edge into it (which may now belong to
-        # either side) must be re-resolved.
+        # under the old, larger population) and every edge into it (which may now
+        # belong to either side) must be re-resolved.
         for c in range(self.pst.alphabet_size):
             target = self.trans.pop((state_id, c), None)
             if target is not None:
@@ -97,38 +127,29 @@ class TransitionResolver:
 
     def _resolve(self, state_id, c):
         pst = self.pst
-        s_mask = self.masks[state_id]
+        members = self._members(state_id)
         node = self.tree.root
         while not isinstance(node, int):
             midfix, lookup = node
-            # Resolving edge (state, c) reads the family one symbol deeper: c, then
-            # this node's own midfix, then each base suffix.
+            # Resolving (state, c) reads the family one symbol deeper: c, then this
+            # node's own midfix, then each base suffix.
             prepended = [c] + list(midfix)
-            vs = self.tree.suffixes(prepended)
+            decision = self._means(members, prepended)
             with np.errstate(invalid="ignore"):
-                decision = pst.compute_decision_from_strings(vs, s_mask)
-                acc = decision >= pst.accept_thresh
-                rej = decision < pst.reject_thresh
-            n_acc, n_rej = int(acc.sum()), int(rej.sum())
+                n_acc = int((decision >= pst.accept_thresh).sum())
+                n_rej = int((decision < pst.reject_thresh).sum())
             if _splits(pst, n_acc, n_rej):
-                self._split(state_id, prepended, acc, rej)
+                self._split(state_id, prepended)
                 return
             node = lookup[True] if n_acc >= n_rej else lookup[False]
         self._set_transition(state_id, c, node)
 
-    def _split(self, state_id, midfix, acc, rej):
-        # acc/rej are the split family's accept/reject calls over this state's
-        # prefixes (the s_mask subset); scatter them back to full-pool masks.
-        pst = self.pst
-        s_mask = self.masks[state_id]
-        acc_mask = np.zeros(pst.num_prefixes, dtype=bool)
-        rej_mask = np.zeros(pst.num_prefixes, dtype=bool)
-        acc_mask[s_mask] = acc
-        rej_mask[s_mask] = rej
-        new_id = self.tree.split(state_id, midfix)  # True (accept) keeps state_id
-        self.masks[state_id] = acc_mask
+    def _split(self, state_id, midfix):
+        # The tree split re-partitions state_id's prefixes; the population re-sifts
+        # them on the next members() call, so nothing to fix up here.
+        new_id = self.tree.split(state_id, midfix)
         self._reopen_edges(state_id)
-        self._open_state(new_id, rej_mask)
+        self._open_state(new_id)
 
     # -- driver -------------------------------------------------------------
 
@@ -138,14 +159,14 @@ class TransitionResolver:
         vs, boundary = sample_suffix_family(pst, v_idx)
         pst.decision_boundary = boundary
         self.tree = MidfixTree([pst.table.suffix(i) for i in vs])
-        all_prefixes = np.ones(pst.num_prefixes, dtype=bool)
-        decision = pst.compute_decision(vs, all_prefixes)
-        with np.errstate(invalid="ignore"):
-            acc = decision >= pst.accept_thresh
-            rej = decision < pst.reject_thresh
+        # The pool prefixes rest in the tree and are sifted lazily through the
+        # shared memo -- the per-leaf partition self.masks used to hold explicitly.
+        self.population = LeafPopulation(self.tree, self._classify)
+        for p in pst.table.prefixes:
+            self.population.add(list(p))
         # Root ids match MidfixTree: 0 = accept (True side), 1 = reject (False side).
-        self._open_state(0, all_prefixes & acc)
-        self._open_state(1, all_prefixes & rej)
+        self._open_state(0)
+        self._open_state(1)
 
         while self.queue:
             state_id, c = self.queue.popleft()

--- a/tests/test_leaf_population.py
+++ b/tests/test_leaf_population.py
@@ -1,0 +1,89 @@
+import unittest
+
+from orthogonal_dfa.l_star.leaf_population import LeafPopulation
+
+
+class _StubTree:
+    """root splits on bit 0; its reject child splits on bit 1.
+
+    ()        -> bit 0 : True -> leaf (True,)
+    (False,)  -> bit 1 : True -> leaf (False, True), False -> (False, False)
+    """
+
+    _midfix = {(): (), (False,): ("m",)}
+
+    def midfix_at(self, path):
+        return self._midfix[path]
+
+
+def _classifier():
+    """A batched classifier that routes by a bit of the string, counting calls."""
+    calls = {"batches": 0, "strings": 0}
+
+    def classify(strings, midfix):
+        calls["batches"] += 1
+        calls["strings"] += len(strings)
+        idx = 0 if midfix == () else 1
+        return [bool(s[idx]) for s in strings]
+
+    return classify, calls
+
+
+class TestLeafPopulation(unittest.TestCase):
+    def test_pulls_matching_strings_to_each_leaf(self):
+        classify, _ = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        for s in ([1, 0], [1, 1], [0, 1], [0, 0]):
+            pop.add(s)
+        self.assertEqual(sorted(pop.members((True,), 10)), [[1, 0], [1, 1]])
+        self.assertEqual(pop.members((False, True), 10), [[0, 1]])
+        self.assertEqual(pop.members((False, False), 10), [[0, 0]])
+
+    def test_count_bounds_the_pull(self):
+        # 100 strings all route to leaf (True,); asking for 3 pulls one chunk, not all.
+        classify, calls = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        for i in range(100):
+            pop.add([1, i % 2])
+        got = pop.members((True,), 3)
+        self.assertEqual(len(got), 3)
+        self.assertLessEqual(calls["strings"], 16)
+
+    def test_sibling_strings_rest_and_are_reused(self):
+        # Querying one leaf drains the root once; querying the sibling must not
+        # reclassify the root -- the sibling's strings are already resting below it.
+        classify, calls = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=64)
+        for s in ([1, 0], [0, 1], [1, 1], [0, 0]):
+            pop.add(s)
+        pop.members((True,), 10)
+        self.assertEqual(pop.members((False, True), 10), [[0, 1]])
+        self.assertEqual(calls["batches"], 2)  # root once, then (False,) once
+
+    def test_add_at_a_known_leaf_skips_classification(self):
+        classify, calls = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        pop.add([7, 7], at=(True,))
+        self.assertEqual(pop.members((True,), 10), [[7, 7]])
+        self.assertEqual(calls["batches"], 0)
+
+    def test_cold_query_of_a_grandchild_cascades(self):
+        # Querying a grandchild with everything still at the root pulls root ->
+        # (False,) -> (False, True) in one call.
+        classify, _ = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        for s in ([1, 0], [0, 1], [1, 1], [0, 0], [0, 1]):
+            pop.add(s)
+        self.assertEqual(sorted(pop.members((False, True), 10)), [[0, 1], [0, 1]])
+
+    def test_exhausted_ancestors_return_what_is_there(self):
+        classify, _ = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        for s in ([1, 0], [1, 1]):
+            pop.add(s)
+        # Only two strings reach (True,); asking for more just returns those two.
+        self.assertEqual(sorted(pop.members((True,), 50)), [[1, 0], [1, 1]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The core migration step: main's transition resolver stops holding its per-state population as bool masks over the pool and reading membership off the mask matrix, and instead uses a `LeafPopulation` that rests the pool prefixes at tree nodes and pulls them toward a leaf on demand, reading membership through the mask's shared `MemoizedOracle` (from #170).

- `self.masks[state]` (which pool prefixes sift to that leaf) → `LeafPopulation.members(state)`;
- the split's accept/reject counts come from querying membership through the shared memo, not `compute_decision_from_strings` off the mask matrix;
- `_split` no longer scatters masks — the population re-sifts itself, since it's keyed by path and split-agnostic;
- **same thresholds, same binomial `_splits`, so the DFA is identical.** The mask keeps only its clustering/FNR role.

Gives `LeafPopulation` its first real caller on main, so this **supersedes #169**.

Local correctness: modulo learns 9 states, subseq 8 states, both at accuracy 1.0000 — unchanged. `count_queries` is the gate (should be flat: the population's sift reuses the same cells the mask/edge-resolution already queried, through the shared memo).

Next step after this: swap the binomial `_splits` for `SplitEvidence` over this same population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `migrate-resolver-to-population` vs `main`

|   | task | queries `main` | queries `migrate-resolver-to-population` | ratio | acc `main` | acc `migrate-resolver-to-population` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 451,102 | 451,102 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 788,078 | 788,078 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 781,419 | 781,419 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 827,453 | 827,453 | 1.00x | 1.000 | 1.000 | 10 |
| ⚪ | modulo_hard | 1,236,882 | 1,236,882 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 2,738,365 | 2,738,365 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **1.00x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

### Forward passes — `migrate-resolver-to-population` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 14,216 → 14,216 (1.00x, 99% packed) | 3,677 → 3,677 (1.00x, 96% packed) | 618 → 618 (1.00x, 71% packed) |
| subseq | 28,061 → 28,061 (1.00x, 88% packed) | 10,912 → 10,912 (1.00x, 56% packed) | 6,146 → 6,146 (1.00x, 13% packed) |
| two_subseq | 27,028 → 27,028 (1.00x, 90% packed) | 9,801 → 9,801 (1.00x, 62% packed) | 5,100 → 5,100 (1.00x, 15% packed) |
| poor_case | 29,896 → 29,896 (1.00x, 86% packed) | 12,151 → 12,151 (1.00x, 53% packed) | 7,361 → 7,361 (1.00x, 11% packed) |
| modulo_hard | 38,759 → 38,759 (1.00x, 100% packed) | 9,828 → 9,828 (1.00x, 98% packed) | 1,411 → 1,411 (1.00x, 86% packed) |
| modulo_asym | 85,688 → 85,688 (1.00x, 100% packed) | 21,561 → 21,561 (1.00x, 99% packed) | 2,857 → 2,857 (1.00x, 94% packed) |
