### PR TITLE
Split the resolver's edge-target and split-detection descents apart

### DIFF
--- a/orthogonal_dfa/l_star/suffix_family.py
+++ b/orthogonal_dfa/l_star/suffix_family.py
@@ -1,0 +1,57 @@
+"""The suffix family a classification round reads against.
+
+A noisy oracle cannot classify a string with one query, so the learner averages
+membership over a *family* of distinguishing suffixes and only answers when the
+mean lands decisively past a threshold. This owns that family: the suffix rows
+and the memo of the means computed from them.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+
+class SuffixFamily:
+    """The round's suffixes ``vs`` (rows into ``pst.table``), and confident
+    classification of a string against a midfix node through their mean."""
+
+    def __init__(self, pst, vs: List[int]):
+        self.pst = pst
+        self.vs = list(vs)
+        self._means: Dict[Tuple[tuple, tuple], float] = {}
+
+    def bits(self, base) -> List[int]:
+        """Membership of ``base`` under each family suffix, through the table's
+        shared memo so cells the mask already holds cost no new query."""
+        table = self.pst.table
+        return table.memo.membership_queries(
+            [list(base) + table.suffix(v) for v in self.vs]
+        )
+
+    def prefill(self, bases) -> None:
+        """Observe the whole family for every base at once, so a population costs
+        one oracle call rather than one per member."""
+        table = self.pst.table
+        table.memo.membership_queries(
+            [list(b) + table.suffix(v) for b in bases for v in self.vs]
+        )
+
+    def mean(self, seq, midfix) -> float:
+        """Mean family membership of ``seq`` under the distinguishers
+        ``midfix + v``."""
+        key = (tuple(seq), tuple(midfix))
+        cached = self._means.get(key)
+        if cached is not None:
+            return cached
+        value = sum(self.bits(list(seq) + list(midfix))) / len(self.vs)
+        self._means[key] = value
+        return value
+
+    def is_accept(self, seq, midfix) -> Optional[bool]:
+        """Confidently classify ``seq`` at ``midfix``: ``True`` / ``False`` when
+        the family mean lands past ``accept_thresh`` / ``reject_thresh``, and
+        ``None`` in the indecisive band between them."""
+        mean = self.mean(seq, midfix)
+        if mean >= self.pst.accept_thresh:
+            return True
+        if mean < self.pst.reject_thresh:
+            return False
+        return None

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -106,21 +106,44 @@ class TransitionResolver:
     # -- the resolution step ------------------------------------------------
 
     def _resolve(self, state_id, c):
-        pst = self.pst
         members = self._members(state_id)
+        distinguisher = self._divergence(c, members)
+        if distinguisher is not None:
+            self._split(state_id, distinguisher)
+            return
+        self._set_transition(state_id, c, self._edge_target(c, members))
+
+    def _tally(self, members, distinguisher):
+        """Accept/reject counts of ``members`` classified against ``distinguisher``.
+        Means are memoized, so the split-detection and edge-target descents that
+        both call this share every read."""
+        self.family.prefill([list(m) + distinguisher for m in members])
+        votes = [self.family.is_accept(m, distinguisher) for m in members]
+        return sum(v is True for v in votes), sum(v is False for v in votes)
+
+    def _divergence(self, c, members):
+        """The distinguisher ``[c] + midfix`` at the first node where ``members``
+        split under one more symbol -- meaning their leaf is really two states --
+        or ``None`` if they agree all the way to a leaf."""
         node = self.tree.root
         while not isinstance(node, int):
             midfix, lookup = node
-            prepended = [c] + list(midfix)
-            self.family.prefill([list(m) + prepended for m in members])
-            votes = [self.family.is_accept(m, prepended) for m in members]
-            n_acc = sum(v is True for v in votes)
-            n_rej = sum(v is False for v in votes)
-            if _splits(pst, n_acc, n_rej):
-                self._split(state_id, prepended)
-                return
+            distinguisher = [c] + list(midfix)
+            n_acc, n_rej = self._tally(members, distinguisher)
+            if _splits(self.pst, n_acc, n_rej):
+                return distinguisher
             node = lookup[True] if n_acc >= n_rej else lookup[False]
-        self._set_transition(state_id, c, node)
+        return None
+
+    def _edge_target(self, c, members):
+        """The leaf ``members`` extended by ``c`` reach, following the majority at
+        each node."""
+        node = self.tree.root
+        while not isinstance(node, int):
+            midfix, lookup = node
+            n_acc, n_rej = self._tally(members, [c] + list(midfix))
+            node = lookup[True] if n_acc >= n_rej else lookup[False]
+        return node
 
     def _split(self, state_id, midfix):
         # The population re-sifts state_id's prefixes on the next members() call.

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -30,13 +30,13 @@ and never need remapping on export.
 
 from collections import deque
 
-import numpy as np
 import scipy.stats
 from automata.fa.dfa import DFA
 
 from .cluster import sample_suffix_family
 from .leaf_population import LeafPopulation
 from .midfix_tree import MidfixTree, oracle_decider
+from .suffix_family import SuffixFamily
 
 
 def _splits(pst, n_acc, n_rej):
@@ -57,6 +57,7 @@ class TransitionResolver:
     def __init__(self, pst):
         self.pst = pst
         self.tree = None
+        self.family = None
         self.population = None  # pool prefixes, per leaf
         self.trans = {}  # (state_id, symbol) -> target state_id
         self.incoming = {}  # state_id -> set of edges pointing at it
@@ -64,29 +65,11 @@ class TransitionResolver:
 
     # -- membership / population -------------------------------------------
 
-    def _means(self, strings, distinguisher):
-        """Mean membership of each string past ``distinguisher``, read through the
-        mask's shared memo so cells the mask already holds cost no new query."""
-        base = self.tree.base_family
-        queries, spans = [], []
-        for s in strings:
-            lo = len(queries)
-            queries.extend(list(s) + list(distinguisher) + v for v in base)
-            spans.append((lo, len(queries)))
-        if not queries:
-            return np.zeros(len(strings))
-        answers = np.asarray(self.pst.table.memo.membership_queries(queries))
-        return np.array([answers[lo:hi].mean() for lo, hi in spans])
-
     def _classify(self, strings, midfix):
         """Which side of ``midfix`` each string sits on; the indecisive band
         between the thresholds returns None and drops out of the population."""
-        pst = self.pst
-        means = self._means(strings, midfix)
-        return [
-            True if m >= pst.accept_thresh else False if m < pst.reject_thresh else None
-            for m in means
-        ]
+        self.family.prefill([list(s) + list(midfix) for s in strings])
+        return [self.family.is_accept(s, midfix) for s in strings]
 
     def _members(self, state_id):
         """The pool prefixes that sift to leaf ``state_id``."""
@@ -129,10 +112,10 @@ class TransitionResolver:
         while not isinstance(node, int):
             midfix, lookup = node
             prepended = [c] + list(midfix)
-            decision = self._means(members, prepended)
-            with np.errstate(invalid="ignore"):
-                n_acc = int((decision >= pst.accept_thresh).sum())
-                n_rej = int((decision < pst.reject_thresh).sum())
+            self.family.prefill([list(m) + prepended for m in members])
+            votes = [self.family.is_accept(m, prepended) for m in members]
+            n_acc = sum(v is True for v in votes)
+            n_rej = sum(v is False for v in votes)
             if _splits(pst, n_acc, n_rej):
                 self._split(state_id, prepended)
                 return
@@ -152,6 +135,7 @@ class TransitionResolver:
         v_idx = pst.table.intern_suffix([])
         vs, boundary = sample_suffix_family(pst, v_idx)
         pst.decision_boundary = boundary
+        self.family = SuffixFamily(pst, vs)
         self.tree = MidfixTree([pst.table.suffix(i) for i in vs])
         self.population = LeafPopulation(self.tree, self._classify)
         for p in pst.table.prefixes:


### PR DESCRIPTION
Stacked on #172.

`_resolve` fused two jobs into one descent over the leaf's members: (1) detecting the members are really two states and splitting, and (2) finding where the `(state, c)` edge points. This separates them into `_divergence` (returns the split distinguisher `[c]+midfix`, or `None`) and `_edge_target` (the leaf the members reach), with a shared `_tally`.

**Query-neutral, behavior-identical.** `SuffixFamily` memoizes the family means, so `_edge_target` re-walking the nodes `_divergence` already tallied costs no new oracle queries; both follow the same majority path to the same split point / leaf as the old fused loop. `test_modulo` and `test_specific_subsequence` pass unchanged.

Sets up two independent later steps: resolve edges from a single member's sift (EdgeResolver), and swap the binomial split for the two-test SplitEvidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `pr-decouple-split-edge` vs `main`

|   | task | queries `main` | queries `pr-decouple-split-edge` | ratio | acc `main` | acc `pr-decouple-split-edge` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 451,102 | 451,102 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 788,078 | 788,078 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 781,419 | 781,419 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 827,453 | 827,453 | 1.00x | 1.000 | 1.000 | 10 |
| ⚪ | modulo_hard | 1,236,882 | 1,236,882 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 2,738,365 | 2,738,365 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **1.00x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

### Forward passes — `pr-decouple-split-edge` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 14,216 → 14,216 (1.00x, 99% packed) | 3,677 → 3,677 (1.00x, 96% packed) | 618 → 618 (1.00x, 71% packed) |
| subseq | 28,061 → 28,061 (1.00x, 88% packed) | 10,912 → 10,912 (1.00x, 56% packed) | 6,146 → 6,146 (1.00x, 13% packed) |
| two_subseq | 27,028 → 27,028 (1.00x, 90% packed) | 9,801 → 9,801 (1.00x, 62% packed) | 5,100 → 5,100 (1.00x, 15% packed) |
| poor_case | 29,896 → 29,896 (1.00x, 86% packed) | 12,151 → 12,151 (1.00x, 53% packed) | 7,361 → 7,361 (1.00x, 11% packed) |
| modulo_hard | 38,759 → 38,759 (1.00x, 100% packed) | 9,828 → 9,828 (1.00x, 98% packed) | 1,411 → 1,411 (1.00x, 86% packed) |
| modulo_asym | 85,688 → 85,688 (1.00x, 100% packed) | 21,561 → 21,561 (1.00x, 99% packed) | 2,857 → 2,857 (1.00x, 94% packed) |
