### PR TITLE
Extract the resolver's edge bookkeeping into PartialDFA

### DIFF
--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -1,26 +1,24 @@
-"""The partial transition function the resolver builds alongside its tree.
+"""
+The partial transition function the resolver builds alongside its tree.
 
-It owns the edges resolved so far, the set of edges pointing at each state, and
-the queue of edges still to resolve.  Keeping this here lets a split invalidate
-*precisely* the edges it made ambiguous -- the leaf's own outgoing edges and
-every edge into it -- instead of rebuilding the hypothesis: an edge that never
-touched the split leaf keeps its resolved target.
+This model owns
+    - edges resolved so far
+    - queue of edges still to resolve
+
+The edges pointing at a state are not indexed; a split needs them only ~once per
+state, so they are scanned out of ``transitions`` on demand instead of being kept
+in sync on every ``set_edge``.
 """
 
 from collections import deque
-from typing import Dict, Optional, Set, Tuple
+from typing import Dict, List, Optional, Tuple
 
 
 class PartialDFA:
     def __init__(self, alphabet_size: int, *, num_states: int):
         self.alphabet_size = alphabet_size
-        #: ``transitions[s][c]`` -- the resolved target of edge ``(s, c)``.
+        #: transitions[s][c] = s'
         self.transitions: Dict[int, Dict[int, int]] = {s: {} for s in range(num_states)}
-        #: ``incoming[s]`` -- the edges whose target is ``s``, so a split can
-        #: re-open exactly those.
-        self.incoming: Dict[int, Set[Tuple[int, int]]] = {
-            s: set() for s in range(num_states)
-        }
         self.worklist: "deque[Tuple[int, int]]" = deque()
 
     def target(self, state: int, c: int) -> Optional[int]:
@@ -30,16 +28,7 @@ class PartialDFA:
         return c in self.transitions[state]
 
     def set_edge(self, state: int, c: int, target: int) -> None:
-        previous = self.transitions[state].get(c)
-        if previous is not None:
-            self.incoming[previous].discard((state, c))
         self.transitions[state][c] = target
-        self.incoming[target].add((state, c))
-
-    def clear_edge(self, state: int, c: int) -> None:
-        target = self.transitions[state].pop(c, None)
-        if target is not None:
-            self.incoming[target].discard((state, c))
 
     def reopen(self, state: int, c: int) -> None:
         self.worklist.append((state, c))
@@ -49,6 +38,16 @@ class PartialDFA:
             for c in range(self.alphabet_size):
                 self.reopen(state, c)
 
+    def edges_into(self, state: int) -> List[Tuple[int, int]]:
+        """The edges whose current target is ``state``, scanned from
+        ``transitions`` rather than a maintained reverse index."""
+        return [
+            (s, c)
+            for s, edges in self.transitions.items()
+            for c, t in edges.items()
+            if t == state
+        ]
+
     def split_state(self, state: int, new_state: int) -> None:
         """Account for ``state`` bifurcating into ``state`` and ``new_state``.
 
@@ -57,14 +56,12 @@ class PartialDFA:
         re-queued; then the new leaf's edges are opened.
         """
         self.transitions[new_state] = {}
-        self.incoming[new_state] = set()
         for c in range(self.alphabet_size):
-            self.clear_edge(state, c)
+            self.transitions[state].pop(c, None)
             self.reopen(state, c)
-        for src, c in list(self.incoming[state]):
-            self.clear_edge(src, c)
+        for src, c in self.edges_into(state):
+            self.transitions[src].pop(c, None)
             self.reopen(src, c)
-        self.incoming[state] = set()
         self.open_every_edge((new_state,))
 
     def drain(self, resolve) -> None:

--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -40,11 +40,10 @@ class PartialDFA:
         return None
 
     def split_state(self, state: int, new_state: int) -> None:
-        """Account for ``state`` bifurcating into ``state`` and ``new_state``.
+        """
+        Account for state bifurcating into (state, new_state).
 
-        Both its outgoing edges (computed under the old, larger leaf) and every
-        edge into it (which may now belong to either side) are dropped; they and
-        the new leaf's edges then read as unresolved and get re-resolved.
+        All relevant edges are removed, both outgoing from and incoming to state.
         """
         self.transitions[new_state] = {}
         for c in range(self.alphabet_size):
@@ -53,8 +52,11 @@ class PartialDFA:
             self.transitions[src].pop(c, None)
 
     def drain(self, resolve) -> None:
-        """Resolve edges via ``resolve(state, symbol)`` until every one is filled.
-        ``resolve`` may split -- clearing edges, which the next scan picks back
-        up -- so this loops until no edge is missing."""
+        """
+        Resolve edges via resolve(state, symbol) until every one is filled.
+
+        resolve() is allowed to call split_state() on this, which adds more work,
+        so this is not guaranteed to terminate unless resolve() is well-behaved.
+        """
         while (edge := self._next_unresolved()) is not None:
             resolve(*edge)

--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -1,0 +1,80 @@
+"""The partial transition function the resolver builds alongside its tree.
+
+It owns the edges resolved so far, the set of edges pointing at each state, and
+the queue of edges still to resolve.  Keeping this here lets a split invalidate
+*precisely* the edges it made ambiguous -- the leaf's own outgoing edges and
+every edge into it -- instead of rebuilding the hypothesis: an edge that never
+touched the split leaf keeps its resolved target.
+"""
+
+from collections import deque
+from typing import Dict, Optional, Set, Tuple
+
+
+class PartialDFA:
+    def __init__(self, alphabet_size: int, *, num_states: int):
+        self.alphabet_size = alphabet_size
+        #: ``transitions[s][c]`` -- the resolved target of edge ``(s, c)``.
+        self.transitions: Dict[int, Dict[int, int]] = {
+            s: {} for s in range(num_states)
+        }
+        #: ``incoming[s]`` -- the edges whose target is ``s``, so a split can
+        #: re-open exactly those.
+        self.incoming: Dict[int, Set[Tuple[int, int]]] = {
+            s: set() for s in range(num_states)
+        }
+        self.worklist: "deque[Tuple[int, int]]" = deque()
+
+    def target(self, state: int, c: int) -> Optional[int]:
+        return self.transitions[state].get(c)
+
+    def has_edge(self, state: int, c: int) -> bool:
+        return c in self.transitions[state]
+
+    def set_edge(self, state: int, c: int, target: int) -> None:
+        previous = self.transitions[state].get(c)
+        if previous is not None:
+            self.incoming[previous].discard((state, c))
+        self.transitions[state][c] = target
+        self.incoming[target].add((state, c))
+
+    def clear_edge(self, state: int, c: int) -> None:
+        target = self.transitions[state].pop(c, None)
+        if target is not None:
+            self.incoming[target].discard((state, c))
+
+    def reopen(self, state: int, c: int) -> None:
+        self.worklist.append((state, c))
+
+    def open_every_edge(self, states) -> None:
+        for state in states:
+            for c in range(self.alphabet_size):
+                self.reopen(state, c)
+
+    def split_state(self, state: int, new_state: int) -> None:
+        """Account for ``state`` bifurcating into ``state`` and ``new_state``.
+
+        Both its outgoing edges (computed under the old, larger leaf) and every
+        edge into it (which may now belong to either side) are dropped and
+        re-queued; then the new leaf's edges are opened.
+        """
+        self.transitions[new_state] = {}
+        self.incoming[new_state] = set()
+        for c in range(self.alphabet_size):
+            self.clear_edge(state, c)
+            self.reopen(state, c)
+        for src, c in list(self.incoming[state]):
+            self.clear_edge(src, c)
+            self.reopen(src, c)
+        self.incoming[state] = set()
+        self.open_every_edge((new_state,))
+
+    def drain(self, resolve) -> None:
+        """Resolve queued edges via ``resolve(state, symbol)`` until the
+        hypothesis is closed.  A split reuses the old id, so ids stay dense and the
+        only dedup is skipping edges a later step already resolved."""
+        while self.worklist:
+            state, c = self.worklist.popleft()
+            if self.has_edge(state, c):
+                continue
+            resolve(state, c)

--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -1,16 +1,9 @@
 """
 The partial transition function the resolver builds alongside its tree.
 
-This model owns
-    - edges resolved so far
-    - queue of edges still to resolve
-
-The edges pointing at a state are not indexed; a split needs them only ~once per
-state, so they are scanned out of ``transitions`` on demand instead of being kept
-in sync on every ``set_edge``.
+Also contains methods for splitting states and a loop for resolving unresolved edges.
 """
 
-from collections import deque
 from typing import Dict, List, Optional, Tuple
 
 
@@ -19,7 +12,6 @@ class PartialDFA:
         self.alphabet_size = alphabet_size
         #: transitions[s][c] = s'
         self.transitions: Dict[int, Dict[int, int]] = {s: {} for s in range(num_states)}
-        self.worklist: "deque[Tuple[int, int]]" = deque()
 
     def target(self, state: int, c: int) -> Optional[int]:
         return self.transitions[state].get(c)
@@ -29,14 +21,6 @@ class PartialDFA:
 
     def set_edge(self, state: int, c: int, target: int) -> None:
         self.transitions[state][c] = target
-
-    def reopen(self, state: int, c: int) -> None:
-        self.worklist.append((state, c))
-
-    def open_every_edge(self, states) -> None:
-        for state in states:
-            for c in range(self.alphabet_size):
-                self.reopen(state, c)
 
     def edges_into(self, state: int) -> List[Tuple[int, int]]:
         """The edges whose current target is ``state``, scanned from
@@ -48,28 +32,29 @@ class PartialDFA:
             if t == state
         ]
 
+    def _next_unresolved(self) -> Optional[Tuple[int, int]]:
+        for state, edges in self.transitions.items():
+            for c in range(self.alphabet_size):
+                if c not in edges:
+                    return (state, c)
+        return None
+
     def split_state(self, state: int, new_state: int) -> None:
         """Account for ``state`` bifurcating into ``state`` and ``new_state``.
 
         Both its outgoing edges (computed under the old, larger leaf) and every
-        edge into it (which may now belong to either side) are dropped and
-        re-queued; then the new leaf's edges are opened.
+        edge into it (which may now belong to either side) are dropped; they and
+        the new leaf's edges then read as unresolved and get re-resolved.
         """
         self.transitions[new_state] = {}
         for c in range(self.alphabet_size):
             self.transitions[state].pop(c, None)
-            self.reopen(state, c)
         for src, c in self.edges_into(state):
             self.transitions[src].pop(c, None)
-            self.reopen(src, c)
-        self.open_every_edge((new_state,))
 
     def drain(self, resolve) -> None:
-        """Resolve queued edges via ``resolve(state, symbol)`` until the
-        hypothesis is closed.  A split reuses the old id, so ids stay dense and the
-        only dedup is skipping edges a later step already resolved."""
-        while self.worklist:
-            state, c = self.worklist.popleft()
-            if self.has_edge(state, c):
-                continue
-            resolve(state, c)
+        """Resolve edges via ``resolve(state, symbol)`` until every one is filled.
+        ``resolve`` may split -- clearing edges, which the next scan picks back
+        up -- so this loops until no edge is missing."""
+        while (edge := self._next_unresolved()) is not None:
+            resolve(*edge)

--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -15,9 +15,7 @@ class PartialDFA:
     def __init__(self, alphabet_size: int, *, num_states: int):
         self.alphabet_size = alphabet_size
         #: ``transitions[s][c]`` -- the resolved target of edge ``(s, c)``.
-        self.transitions: Dict[int, Dict[int, int]] = {
-            s: {} for s in range(num_states)
-        }
+        self.transitions: Dict[int, Dict[int, int]] = {s: {} for s in range(num_states)}
         #: ``incoming[s]`` -- the edges whose target is ``s``, so a split can
         #: re-open exactly those.
         self.incoming: Dict[int, Set[Tuple[int, int]]] = {

--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -20,6 +20,7 @@ class PartialDFA:
         return c in self.transitions[state]
 
     def set_edge(self, state: int, c: int, target: int) -> None:
+        assert c not in self.transitions[state]
         self.transitions[state][c] = target
 
     def edges_into(self, state: int) -> List[Tuple[int, int]]:

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -134,8 +134,6 @@ class TransitionResolver:
             tree=self.tree,
         )
         self.dfa = PartialDFA(pst.alphabet_size, num_states=self.tree.num_states)
-        # Root ids match MidfixTree: 0 = accept (True side), 1 = reject (False side).
-        self.dfa.open_every_edge(range(self.tree.num_states))
         self.dfa.drain(self._resolve)
 
         return self._to_dfa_and_tree()

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -28,13 +28,12 @@ side a fresh id (see MidfixTree.split), so state ids stay a dense range(num_stat
 and never need remapping on export.
 """
 
-from collections import deque
-
 from automata.fa.dfa import DFA
 
 from .cluster import sample_suffix_family
 from .leaf_population import LeafPopulation
 from .midfix_tree import MidfixTree, oracle_decider
+from .partial_dfa import PartialDFA
 from .split_evidence import SPLIT, SplitEvidence
 from .suffix_family import SuffixFamily
 
@@ -46,9 +45,7 @@ class TransitionResolver:
         self.family = None
         self.splits = None
         self.population = None  # pool prefixes, per leaf
-        self.trans = {}  # (state_id, symbol) -> target state_id
-        self.incoming = {}  # state_id -> set of edges pointing at it
-        self.queue = deque()
+        self.dfa = None  # the partial transition function + its worklist
 
     # -- membership / population -------------------------------------------
 
@@ -64,32 +61,6 @@ class TransitionResolver:
             self.tree.path_of(state_id), self.pst.num_prefixes
         )
 
-    # -- bookkeeping --------------------------------------------------------
-
-    def _open_state(self, state_id):
-        self.incoming[state_id] = set()
-        for c in range(self.pst.alphabet_size):
-            self.queue.append((state_id, c))
-
-    def _set_transition(self, state_id, c, target):
-        assert (state_id, c) not in self.trans
-        self.trans[(state_id, c)] = target
-        self.incoming[target].add((state_id, c))
-
-    def _reopen_edges(self, state_id):
-        # A split shrank state_id's membership, so both its outgoing edges (computed
-        # under the old, larger population) and every edge into it (which may now
-        # belong to either side) must be re-resolved.
-        for c in range(self.pst.alphabet_size):
-            target = self.trans.pop((state_id, c), None)
-            if target is not None:
-                self.incoming[target].discard((state_id, c))
-            self.queue.append((state_id, c))
-        for src, c in list(self.incoming[state_id]):
-            self.trans.pop((src, c), None)
-            self.queue.append((src, c))
-        self.incoming[state_id] = set()
-
     # -- the resolution step ------------------------------------------------
 
     def _resolve(self, state_id, c):
@@ -98,7 +69,7 @@ class TransitionResolver:
         if distinguisher is not None:
             self._split(state_id, distinguisher)
             return
-        self._set_transition(state_id, c, self._edge_target(c, members))
+        self.dfa.set_edge(state_id, c, self._edge_target(c, members))
 
     def _tally(self, members, distinguisher):
         """Accept/reject counts of ``members`` classified against ``distinguisher``.
@@ -142,8 +113,7 @@ class TransitionResolver:
     def _split(self, state_id, midfix):
         # The population re-sifts state_id's prefixes on the next members() call.
         new_id = self.tree.split(state_id, midfix)
-        self._reopen_edges(state_id)
-        self._open_state(new_id)
+        self.dfa.split_state(state_id, new_id)
 
     # -- driver -------------------------------------------------------------
 
@@ -163,18 +133,10 @@ class TransitionResolver:
             population=self.population,
             tree=self.tree,
         )
+        self.dfa = PartialDFA(pst.alphabet_size, num_states=self.tree.num_states)
         # Root ids match MidfixTree: 0 = accept (True side), 1 = reject (False side).
-        self._open_state(0)
-        self._open_state(1)
-
-        while self.queue:
-            state_id, c = self.queue.popleft()
-            # A stable-id split reuses state_id and re-opens its edges, so the same
-            # (state, c) can sit in the queue twice; skip one already resolved (a
-            # later split pops it from trans when it must be redone).
-            if (state_id, c) in self.trans:
-                continue
-            self._resolve(state_id, c)
+        self.dfa.open_every_edge(range(self.tree.num_states))
+        self.dfa.drain(self._resolve)
 
         return self._to_dfa_and_tree()
 
@@ -184,9 +146,7 @@ class TransitionResolver:
         pst = self.pst
         n = self.tree.num_states
 
-        transitions = {i: {} for i in range(n)}
-        for (sid, c), target in self.trans.items():
-            transitions[sid][c] = target
+        transitions = {i: dict(self.dfa.transitions[i]) for i in range(n)}
 
         accepting = self.tree.accepting_leaves()
 

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -7,7 +7,8 @@ prefix pool into two sets s_acc / s_rej.  The leaves of the tree are the states
 of the DFA. We also separately maintain a transition function, which maps
 (state, symbol) pairs to target states.
 
-We work a queue of unresolved (state, symbol) pairs.  Resolving (s, c) classifies
+We resolve the unresolved (state, symbol) edges -- each just one missing from the
+partial transition function -- until none remain.  Resolving (s, c) classifies
 every prefix of s extended by c. Doing so involves querying the current tree for
 the prefixes of s except with every distinguisher family prepended by c.
 This has two possibilities:
@@ -15,9 +16,9 @@ This has two possibilities:
   2. They diverge: s is really more than one state. We split it in two at the
   first decision tree node (from the root) where its prefixes disagree about where c leads
 
-This only directly affects state s, so all we need to do at this point is
-to re-enqueue all (s, c') for all symbols c' in the alphabet, as well as every
-edge (s', c') -> s, which needs to be reclassified into one of the newly split states.
+This only directly affects state s, so we drop its outgoing edges and every
+edge (s', c') -> s into it; both then read as unresolved and are re-resolved into
+one of the newly split states.
 
 Each state's prefixes -- the pool prefixes that sift to its leaf -- live in a
 :class:`~orthogonal_dfa.l_star.leaf_population.LeafPopulation`, read through the

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -46,7 +46,7 @@ class TransitionResolver:
         self.family = None
         self.splits = None
         self.population = None  # pool prefixes, per leaf
-        self.dfa = None  # the partial transition function + its worklist
+        self.dfa = None  # the partial transition function
 
     # -- membership / population -------------------------------------------
 


### PR DESCRIPTION
The transition function, the incoming-edge sets, and the worklist — with `_set_transition` / `_reopen_edges` / `_open_state` and the drain loop — move out of `TransitionResolver` into a `PartialDFA` object: the same one the direct-L* learner builds its hypothesis on. The resolver now calls `set_edge` / `split_state` / `open_every_edge` / `drain` and reads `dfa.transitions` on export.

**Query-neutral and result-identical.** `PartialDFA.split_state` re-queues edges in the same order the old `_reopen_edges` + `_open_state` did, so the edge-resolution order that drives E-L*'s splits is unchanged. Measured on `.*1010101.*` (seed 0): identical calls (297), queries (460,409), and states (8); `test_modulo` and `test_specific_subsequence` pass.

First piece of the direct-L* driver landed against the *live* resolver — the `PartialDFA` here is a subset of the branch's (no witnesses / `pending_probes` / `totalise` yet, since the queue-driver has no caller for those); those arrive with the random-walk driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `pr-partial-dfa` vs `main`

|   | task | queries `main` | queries `pr-partial-dfa` | ratio | acc `main` | acc `pr-partial-dfa` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 451,102 | 451,102 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 460,409 | 460,409 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 781,419 | 781,419 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 827,453 | 827,453 | 1.00x | 1.000 | 1.000 | 10 |
| ⚪ | modulo_hard | 1,236,882 | 1,236,882 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 2,738,365 | 2,738,365 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **1.00x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

### Forward passes — `pr-partial-dfa` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 14,216 → 14,216 (1.00x, 99% packed) | 3,677 → 3,677 (1.00x, 96% packed) | 618 → 618 (1.00x, 71% packed) |
| subseq | 14,514 → 14,514 (1.00x, 99% packed) | 3,749 → 3,749 (1.00x, 96% packed) | 608 → 608 (1.00x, 74% packed) |
| two_subseq | 27,028 → 27,028 (1.00x, 90% packed) | 9,801 → 9,801 (1.00x, 62% packed) | 5,100 → 5,100 (1.00x, 15% packed) |
| poor_case | 29,896 → 29,898 (1.00x, 86% packed) | 12,151 → 12,151 (1.00x, 53% packed) | 7,361 → 7,363 (1.00x, 11% packed) |
| modulo_hard | 38,759 → 38,759 (1.00x, 100% packed) | 9,828 → 9,828 (1.00x, 98% packed) | 1,411 → 1,411 (1.00x, 86% packed) |
| modulo_asym | 85,688 → 85,688 (1.00x, 100% packed) | 21,561 → 21,561 (1.00x, 99% packed) | 2,857 → 2,857 (1.00x, 94% packed) |
