### PR TITLE
Discover states in place from counterexamples; resolve edges from a member

### DIFF
--- a/orthogonal_dfa/l_star/counterexample_synthesis.py
+++ b/orthogonal_dfa/l_star/counterexample_synthesis.py
@@ -26,7 +26,12 @@ COUNTEREXAMPLE_PROBES = 4000
 def _default_patience(acc_threshold: float) -> int:
     """Consecutive clean probes that end a counterexample pass: seeing this many
     in a row is a ``<= 0.05`` event if the disagreement rate were still at the
-    tolerated ``1 - acc_threshold``."""
+    tolerated ``1 - acc_threshold``.
+
+    A perfect-accuracy target tolerates no disagreement, so no finite clean run
+    rules it out -- never early-stop, run the whole probe budget."""
+    if acc_threshold >= 1:
+        return COUNTEREXAMPLE_PROBES
     return math.ceil(math.log(0.05) / math.log(acc_threshold))
 
 
@@ -41,14 +46,6 @@ def classify_pool(pst, tree, *, accept, reject):
         return decision >= accept, decision < reject
 
     return tree.classify_pool(pst.num_prefixes, decide_columns)
-
-
-#: Draws allowed per counterexample search, per prefix asked for.
-SAMPLES_PER_COUNTEREXAMPLE = 50
-
-
-def counterexample_sample_budget(count: int) -> int:
-    return SAMPLES_PER_COUNTEREXAMPLE * count
 
 
 def enrich_underrepresented_leaves(pst, tree, *, count):
@@ -166,9 +163,7 @@ def counterexample_driven_synthesis(
         )
         dfa, dt = resolver.export()
         print(f"Resolved DFA with {dt.num_states} states")
-        if dt.num_states <= 1:
-            pst.sample_more_prefixes()
-            continue
+        assert dt.num_states >= 2
         print(dfa)
         true_acc = estimate_agreement_rate(
             pst,

--- a/orthogonal_dfa/l_star/counterexample_synthesis.py
+++ b/orthogonal_dfa/l_star/counterexample_synthesis.py
@@ -1,15 +1,15 @@
 """
 Counterexample-driven synthesis: the E-L* learner loop.
 
-Resolves a DFA from the current prefix pool (``resolve_dfa``), estimates its
-accuracy, and when it falls short generates counterexample prefixes and enriches
-under-represented leaves before resolving again -- until the estimate clears the
-threshold or the search dries up.  The classification and accuracy primitives it
-uses live in ``lstar``.
+Each round the resolver builds a DFA from the current prefix pool and splits it
+in place on DFA-vs-tree disagreements (its counterexample pass); when the
+estimated accuracy still falls short, under-represented leaves are enriched and
+the round repeats -- until the estimate clears the threshold or enrichment dries
+up.  The classification and accuracy primitives it uses live in ``lstar``.
 """
 
 import copy
-import warnings
+import math
 
 import numpy as np
 import tqdm.auto as tqdm
@@ -19,10 +19,19 @@ from .lstar import (
     _oracle_classify,
     denoise_accept_labels,
     estimate_agreement_rate,
-    locate_incorrect_point,
 )
-from .statistics import binomial_side_of_boundary, counterexample_search_exhausted
-from .transition_resolver import resolve_dfa
+from .statistics import binomial_side_of_boundary
+from .transition_resolver import TransitionResolver
+
+#: Probes drawn per counterexample pass.
+COUNTEREXAMPLE_PROBES = 4000
+
+
+def _default_patience(acc_threshold: float) -> int:
+    """Consecutive clean probes that end a counterexample pass: seeing this many
+    in a row is a ``<= 0.05`` event if the disagreement rate were still at the
+    tolerated ``1 - acc_threshold``."""
+    return math.ceil(math.log(0.05) / math.log(acc_threshold))
 
 
 def classify_pool(pst, tree, *, accept, reject):
@@ -38,93 +47,12 @@ def classify_pool(pst, tree, *, accept, reject):
     return tree.classify_pool(pst.num_prefixes, decide_columns)
 
 
-def add_counterexample_prefixes(pst, dt, dfa, count):
-    results = generate_counterexamples(
-        pst,
-        pst.sampler,
-        pst.oracle,
-        dt,
-        dfa,
-        count=count,
-    )
-    if results:
-        pst.table.add_prefixes(results)
-    return results
-
-
 #: Draws allowed per counterexample search, per prefix asked for.
 SAMPLES_PER_COUNTEREXAMPLE = 50
 
 
 def counterexample_sample_budget(count: int) -> int:
     return SAMPLES_PER_COUNTEREXAMPLE * count
-
-
-def generate_counterexamples(pst, us, oracle, tree, dfa, *, count):
-    boundary = pst.decision_boundary
-    # The counterexample pipeline classifies strings many times: ~log2(string_len)
-    # binary search steps + 2 decisive checks, each traversing the full tree.  A
-    # false positive just adds an uninformative prefix (harmless), so we can
-    # tolerate a much higher overall error rate than state discovery (which uses
-    # split_pval).  We use 0.2 as the whole-pipeline budget and union-bound
-    # over all node-level decisions.
-    from .statistics import compute_suffix_size_counterexample_gen as _compute_sfx
-
-    counterexample_fpr = 0.2
-    string_len = pst.sampler.length
-    num_classifications = 2 + int(np.ceil(np.log2(string_len)))
-    num_node_decisions = num_classifications * tree.depth
-    effective_p = 0.5 + pst.config.min_signal_strength
-    per_node_budget = counterexample_fpr / max(num_node_decisions, 1)
-    scaled_suffix_size = _compute_sfx(per_node_budget, effective_p)
-    # Both are decisive, reduced is more efficient
-    reduced, _ = _oracle_classify(
-        tree, oracle, accept=boundary, reject=boundary, suffix_limit=scaled_suffix_size
-    )
-    decisive, _ = _oracle_classify(tree, oracle, accept=boundary, reject=boundary)
-    pbar = tqdm.tqdm(total=count)
-    additional_prefixes = []
-    num_samples = 0
-    max_samples = counterexample_sample_budget(count)
-    while True:
-        num_samples += 1
-        x = us.sample(pst.rng, pst.alphabet_size)
-        y = us.sample(pst.rng, pst.alphabet_size)
-        s0 = reduced(x)
-        prefix, sym = locate_incorrect_point(
-            reduced,
-            dfa,
-            x,
-            y,
-            s0=s0,
-            # Skip the endpoint classification when x itself is unclassifiable --
-            # locate_incorrect_point returns on s0 without reading s_end.
-            s_end=(reduced(x + y) if s0 is not None else None),
-        )
-        if counterexample_search_exhausted(
-            len(additional_prefixes), num_samples, count, max_samples
-        ):
-            warnings.warn(
-                f"Counterexample search yielded {len(additional_prefixes)}/{count}"
-                f" prefixes in {num_samples} samples; the decision tree and the"
-                f" DFA disagree too rarely to reach {count} within"
-                f" {max_samples} samples"
-            )
-            pbar.close()
-            return additional_prefixes
-        if prefix is None:
-            continue
-        if prefix in additional_prefixes or pst.table.contains_prefix(prefix):
-            continue
-        state_1 = decisive(prefix)
-        state_2 = dfa.transitions[state_1][sym]
-        if state_2 == decisive(prefix + [sym]):
-            continue
-        additional_prefixes.append(prefix)
-        pbar.update()
-        if len(additional_prefixes) >= count:
-            pbar.close()
-            return additional_prefixes
 
 
 def enrich_underrepresented_leaves(pst, tree, *, count):
@@ -232,14 +160,19 @@ def uncoverable_access_strings(pst, tree):
 def counterexample_driven_synthesis(
     pst, *, additional_counterexamples: int, acc_threshold: float
 ):
+    patience = _default_patience(acc_threshold)
     while True:
         print(f"Starting synthesis iteration with {pst.num_prefixes} prefixes")
-        while True:
-            dfa, dt = resolve_dfa(pst)
-            print(f"Resolved DFA with {dt.num_states} states")
-            if dt.num_states > 1:
-                break
+        resolver = TransitionResolver(pst)
+        resolver.build()
+        resolver.counterexample_pass(
+            max_probes=COUNTEREXAMPLE_PROBES, patience=patience
+        )
+        dfa, dt = resolver.export()
+        print(f"Resolved DFA with {dt.num_states} states")
+        if dt.num_states <= 1:
             pst.sample_more_prefixes()
+            continue
         print(dfa)
         true_acc = estimate_agreement_rate(
             pst,
@@ -268,15 +201,11 @@ def counterexample_driven_synthesis(
             )
             yield dfa, dt, None
             return
-        ce = add_counterexample_prefixes(pst, dt, dfa, additional_counterexamples)
         enriched = enrich_underrepresented_leaves(
             pst, dt, count=additional_counterexamples
         )
-        if not ce and not enriched:
-            print(
-                "Neither counterexample search nor leaf enrichment found"
-                " new prefixes; stopping synthesis"
-            )
+        if not enriched:
+            print("Leaf enrichment found no new prefixes; stopping synthesis")
             yield dfa, dt, None
             return
         yield dfa, dt, copy.deepcopy(pst)

--- a/orthogonal_dfa/l_star/counterexample_synthesis.py
+++ b/orthogonal_dfa/l_star/counterexample_synthesis.py
@@ -15,11 +15,7 @@ import numpy as np
 import tqdm.auto as tqdm
 from automata.fa.dfa import DFA
 
-from .lstar import (
-    _oracle_classify,
-    denoise_accept_labels,
-    estimate_agreement_rate,
-)
+from .lstar import _oracle_classify, denoise_accept_labels, estimate_agreement_rate
 from .statistics import binomial_side_of_boundary
 from .transition_resolver import TransitionResolver
 

--- a/orthogonal_dfa/l_star/midfix_tree.py
+++ b/orthogonal_dfa/l_star/midfix_tree.py
@@ -135,6 +135,28 @@ class MidfixTree:
             node = lookup[decision]
         return node
 
+    def first_disagreement(self, s, sprime, decide: Decide, prefix) -> Optional[tuple]:
+        """
+        The midfix separating s and sprime, or None.
+
+        s and sprime currently sift to the same leaf, but s + prefix and
+        sprime + prefix are known to reach different leaves. Walk down the branch
+        where they still agree; the first node where they disagree yields the
+        separating midfix prefix + node midfix. None when a needed classification
+        is indecisive, or when they agree all the way to a leaf.
+        """
+        node = self._root
+        while not isinstance(node, int):
+            midfix, lookup = node
+            full = (*prefix, *midfix)
+            d, dprime = decide(s, full), decide(sprime, full)
+            if d is None or dprime is None:
+                return None
+            if d != dprime:
+                return full
+            node = lookup[d]
+        return None
+
     def classify_many(self, seqs, decide_level) -> List[Optional[int]]:
         """
         Like [classify(s) for s in seqs] but with the reads batched one level at a

--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -12,16 +12,23 @@ class PartialDFA:
         self.alphabet_size = alphabet_size
         #: transitions[s][c] = s'
         self.transitions: Dict[int, Dict[int, int]] = {s: {} for s in range(num_states)}
+        #: A prefix reaching s whose extension by c reaches transitions[s][c] --
+        #: the member that resolved the edge, kept so a split can separate on it.
+        self.witnesses: Dict[Tuple[int, int], List[int]] = {}
 
     def target(self, state: int, c: int) -> Optional[int]:
         return self.transitions[state].get(c)
 
+    def witness(self, state: int, c: int) -> Optional[List[int]]:
+        return self.witnesses.get((state, c))
+
     def has_edge(self, state: int, c: int) -> bool:
         return c in self.transitions[state]
 
-    def set_edge(self, state: int, c: int, target: int) -> None:
+    def set_edge(self, state: int, c: int, target: int, witness) -> None:
         assert c not in self.transitions[state]
         self.transitions[state][c] = target
+        self.witnesses[state, c] = list(witness)
 
     def edges_into(self, state: int) -> List[Tuple[int, int]]:
         """The edges whose current target is ``state``, scanned from
@@ -49,8 +56,10 @@ class PartialDFA:
         self.transitions[new_state] = {}
         for c in range(self.alphabet_size):
             self.transitions[state].pop(c, None)
+            self.witnesses.pop((state, c), None)
         for src, c in self.edges_into(state):
             self.transitions[src].pop(c, None)
+            self.witnesses.pop((src, c), None)
 
     def drain(self, resolve) -> None:
         """

--- a/orthogonal_dfa/l_star/statistics.py
+++ b/orthogonal_dfa/l_star/statistics.py
@@ -135,16 +135,6 @@ def compute_suffix_size_counterexample_gen(acceptable_misclassification, noise_l
     raise ValueError("not reachable")
 
 
-def counterexample_search_exhausted(
-    num_found, num_samples, count, max_samples, *, failure_prob=1e-5
-):
-    """Whether the hits so far are too far below ``count / max_samples``, the
-    rate the search has to sustain to reach ``count``."""
-    needed_rate = count / max_samples
-    pval = scipy.stats.binom.cdf(num_found, num_samples, needed_rate)
-    return pval < failure_prob
-
-
 def binomial_side_of_boundary(num_accepts, num_samples, boundary, *, failure_prob=1e-5):
     """Binomial test of num_accepts/num_samples against accept rate ``boundary``.
 

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -1,32 +1,26 @@
 """Incremental, transition-driven DFA discovery.
 
-Builds the discrimination tree (states) and the transition function together:
+Builds the discrimination tree (states) and the transition function together.
 
-The tree starts as the initial distinguisher family v_eps which partitions the
-prefix pool into two sets s_acc / s_rej.  The leaves of the tree are the states
-of the DFA. We also separately maintain a transition function, which maps
-(state, symbol) pairs to target states.
+The tree starts as the initial distinguisher family v_eps, partitioning the
+prefix pool into accept / reject -- two leaves, the initial two states.  Each
+(state, symbol) edge is then resolved by sifting a member of the state extended
+by the symbol: the leaf it lands on is the target, and the member is kept as the
+edge's witness (the tree is consistent, so any member resolves it the same way).
 
-We resolve the unresolved (state, symbol) edges -- each just one missing from the
-partial transition function -- until none remain.  Resolving (s, c) classifies
-every prefix of s extended by c. Doing so involves querying the current tree for
-the prefixes of s except with every distinguisher family prepended by c.
-This has two possibilities:
-  1. They all land on one leaf t. In this case we record the transition (s, c) -> t and move on.
-  2. They diverge: s is really more than one state. We split it in two at the
-  first decision tree node (from the root) where its prefixes disagree about where c leads
-
-This only directly affects state s, so we drop its outgoing edges and every
-edge (s', c') -> s into it; both then read as unresolved and are re-resolved into
-one of the newly split states.
+States beyond the initial two are found by the counterexample pass: random probe
+strings are walked through the resolved transition function and re-sifted, and
+where the walk and the sift disagree the probe has exhibited two prefixes that
+reach one leaf yet behave differently under one more symbol -- a Myhill-Nerode
+counterexample -- so that leaf is split (see SplitEvidence).  A split drops the
+edges it made ambiguous; both they and the new leaf's edges then read as
+unresolved and are refilled on the next resolve pass.
 
 Each state's prefixes -- the pool prefixes that sift to its leaf -- live in a
-:class:`~orthogonal_dfa.l_star.leaf_population.LeafPopulation`, read through the
-mask's shared MemoizedOracle so a cell the mask already holds costs no new query.
-
-The split keeps the accept side of the divergence as s itself and gives the reject
-side a fresh id (see MidfixTree.split), so state ids stay a dense range(num_states)
-and never need remapping on export.
+:class:`~orthogonal_dfa.l_star.leaf_population.LeafPopulation`.  The split keeps
+the accept side as s itself and gives the reject side a fresh id (see
+MidfixTree.split), so state ids stay a dense range(num_states) and need no
+remapping on export.
 """
 
 from automata.fa.dfa import DFA
@@ -35,8 +29,16 @@ from .cluster import sample_suffix_family
 from .leaf_population import LeafPopulation
 from .midfix_tree import MidfixTree, oracle_decider
 from .partial_dfa import PartialDFA
-from .split_evidence import SPLIT, SplitEvidence
+from .split_evidence import NO_SPLIT, SPLIT, SplitEvidence
 from .suffix_family import SuffixFamily
+
+# Outcome of processing one probe (see TransitionResolver.counterexample_pass).
+_RESOLVED = 0  # clean probe, or the leaf is a single state at this distinguisher
+_SPLIT = 1  # the leaf bifurcated decisively; a split was applied
+_UNDECIDED = 2  # evidence not yet conclusive -- keep sifting to accumulate members
+
+#: Probes sifted per batched pass.
+_PROBE_BLOCK = 16
 
 
 class TransitionResolver:
@@ -62,15 +64,16 @@ class TransitionResolver:
             self.tree.path_of(state_id), self.pst.num_prefixes
         )
 
+    def _sift(self, seq):
+        """The leaf ``seq`` sifts to, or ``None`` when a node cannot place it."""
+        return self.tree.classify(list(seq), self.family.is_accept)
+
     # -- the resolution step ------------------------------------------------
 
     def _resolve(self, state_id, c):
         members = self._members(state_id)
-        distinguisher = self._divergence(state_id, c, members)
-        if distinguisher is not None:
-            self._split(state_id, distinguisher)
-            return
-        self.dfa.set_edge(state_id, c, self._edge_target(c, members))
+        target, witness = self._edge_target(c, members)
+        self.dfa.set_edge(state_id, c, target, witness)
 
     def _tally(self, members, distinguisher):
         """Accept/reject counts of ``members`` classified against ``distinguisher``.
@@ -80,41 +83,128 @@ class TransitionResolver:
         votes = [self.family.is_accept(m, distinguisher) for m in members]
         return sum(v is True for v in votes), sum(v is False for v in votes)
 
-    def _divergence(self, state_id, c, members):
-        """
-        The distinguisher [c] + midfix at the first node down the descent where
-        SplitEvidence confirms state_id's members are really two states, or None
-        if none does.
-
-        The held-out train/test test is the sole decision -- a real second state
-        reproduces across the disjoint halves where scattered noise does not -- so
-        no cheap pre-filter is needed to propose candidates first.
-        """
-        node = self.tree.root
-        while not isinstance(node, int):
-            midfix, lookup = node
-            distinguisher = [c] + list(midfix)
-            if self.splits.verdict(state_id, tuple(distinguisher)) == SPLIT:
-                return distinguisher
-            n_acc, n_rej = self._tally(members, distinguisher)
-            node = lookup[True] if n_acc >= n_rej else lookup[False]
-        return None
-
     def _edge_target(self, c, members):
-        """The leaf ``members`` extended by ``c`` reach, following the majority at
-        each node -- the same descent ``_divergence`` just took, so its tallies are
-        already memoized."""
+        """Where the ``(leaf, c)`` edge points and the member that witnesses it:
+        the first decisive member's ``c``-successor, or the whole-population
+        majority (witnessed by any member) when every member is indecisive."""
+        for m in members:
+            target = self._sift(list(m) + [c])
+            if target is not None:
+                return target, list(m)
         node = self.tree.root
         while not isinstance(node, int):
             midfix, lookup = node
             n_acc, n_rej = self._tally(members, [c] + list(midfix))
             node = lookup[True] if n_acc >= n_rej else lookup[False]
-        return node
+        return node, (list(members[0]) if members else [])
 
     def _split(self, state_id, midfix):
         # The population re-sifts state_id's prefixes on the next members() call.
         new_id = self.tree.split(state_id, midfix)
         self.dfa.split_state(state_id, new_id)
+
+    # -- counterexamples ----------------------------------------------------
+
+    def counterexample_pass(self, *, max_probes, patience):
+        """Split in place on DFA-vs-tree disagreements until they dry up.
+
+        Each probe is walked through the resolved delta and re-sifted; where they
+        disagree, the probe has exhibited two prefixes reaching one leaf that
+        behave differently under one more symbol, so the leaf is split -- the same
+        counterexample the outer loop used to defer by adding a prefix and
+        rebuilding. Stops after ``patience`` consecutive clean probes."""
+        splits = 0
+        since_split = 0
+        for w in self._probe_blocks(max_probes):
+            status = self._process(w)
+            if status == _SPLIT:
+                splits += 1
+                since_split = 0
+                self.dfa.drain(self._resolve)  # the split dropped edges; refill
+            elif status == _UNDECIDED:
+                since_split = 0
+            else:
+                since_split += 1
+            if since_split >= patience:
+                break
+        return splits
+
+    def _probe_blocks(self, max_probes):
+        drawn = 0
+        while drawn < max_probes:
+            block = [
+                self.pst.sampler.sample(self.pst.rng, self.pst.alphabet_size)
+                for _ in range(min(_PROBE_BLOCK, max_probes - drawn))
+            ]
+            drawn += len(block)
+            self.family.prefill(block)
+            yield from block
+
+    def _process(self, w):
+        """Anchor at the shortest prefix the tree places, follow the resolved
+        delta, then act on where the walk and a fresh sift disagree."""
+        w = list(w)
+        state = None
+        start = 0
+        while start < len(w):
+            state = self._sift(w[:start])
+            if state is not None:
+                break
+            start += 1
+        if state is None:
+            return _RESOLVED
+        self.population.add(w[:start], at=self.tree.path_of(state))
+        states = [None] * start + [state]
+        for c in w[start:]:
+            state = self.dfa.target(state, c)
+            states.append(state)
+        return self._act_on_disagreement(w, states, start)
+
+    def _act_on_disagreement(self, w, states, agree_point):
+        state = states[-1]
+        actual = self._sift(w)
+        if actual is None or state is None or actual == state:
+            return _RESOLVED
+        fd = self._first_disagreement(w, states, agree_point, len(w))
+        if fd is None:
+            return _RESOLVED
+        s1, c, s2 = states[fd - 1], w[fd - 1], states[fd]
+        if s1 is None or s2 is None or self.dfa.target(s1, c) != s2:
+            return _RESOLVED
+        sprime = w[: fd - 1]
+        witness = self.dfa.witness(s1, c)
+        if witness is None or self._sift(sprime) != s1 or self._sift(witness) != s1:
+            return _RESOLVED
+        distinguisher = self.tree.first_disagreement(
+            witness, sprime, self.family.is_accept, [c]
+        )
+        if distinguisher is None:
+            return _RESOLVED
+        verdict = self.splits.verdict(s1, tuple(distinguisher))
+        if verdict == SPLIT:
+            self._apply_split(s1, list(distinguisher), witness, sprime)
+            return _SPLIT
+        return _RESOLVED if verdict == NO_SPLIT else _UNDECIDED
+
+    def _first_disagreement(self, w, states, lo, hi):
+        """Binary-search the first index where the followed state diverges from a
+        fresh sift of ``w[:i]``; ``None`` on an indecisive sift."""
+        if lo + 1 == hi:
+            return hi
+        mid = (lo + hi) // 2
+        actual = self._sift(w[:mid])
+        if actual is None or states[mid] is None:
+            return None
+        if actual == states[mid]:
+            return self._first_disagreement(w, states, mid, hi)
+        return self._first_disagreement(w, states, lo, mid)
+
+    def _apply_split(self, s1, distinguisher, witness, sprime):
+        self._split(s1, distinguisher)
+        for p in (witness, sprime):
+            st = self._sift(p)
+            if st is not None:
+                self.population.add(list(p), at=self.tree.path_of(st))
 
     # -- driver -------------------------------------------------------------
 
@@ -137,11 +227,9 @@ class TransitionResolver:
         self.dfa = PartialDFA(pst.alphabet_size, num_states=self.tree.num_states)
         self.dfa.drain(self._resolve)
 
-        return self._to_dfa_and_tree()
-
     # -- output -------------------------------------------------------------
 
-    def _to_dfa_and_tree(self):
+    def export(self):
         pst = self.pst
         n = self.tree.num_states
 
@@ -172,4 +260,6 @@ def resolve_dfa(pst):
     """
     Build the (DFA, MidfixTree) for the current prefix pool via the resolver.
     """
-    return TransitionResolver(pst).build()
+    resolver = TransitionResolver(pst)
+    resolver.build()
+    return resolver.export()

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -113,12 +113,10 @@ class TransitionResolver:
         behave differently under one more symbol, so the leaf is split -- the same
         counterexample the outer loop used to defer by adding a prefix and
         rebuilding. Stops after ``patience`` consecutive clean probes."""
-        splits = 0
         since_split = 0
         for w in self._probe_blocks(max_probes):
             status = self._process(w)
             if status == _SPLIT:
-                splits += 1
                 since_split = 0
                 self.dfa.drain(self._resolve)  # the split dropped edges; refill
             elif status == _UNDECIDED:
@@ -127,7 +125,6 @@ class TransitionResolver:
                 since_split += 1
             if since_split >= patience:
                 break
-        return splits
 
     def _probe_blocks(self, max_probes):
         drawn = 0

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -161,6 +161,10 @@ class TransitionResolver:
             start += 1
         if state is None:
             return _RESOLVED
+        # Seed the anchor leaf's population. The prefix pool is length-L, so it
+        # only reaches deep leaves; short anchor prefixes are what give the shallow
+        # leaves enough members for the one-state test to settle them.
+        self.population.add(w[:start], at=self.tree.path_of(state))
         states = [None] * start + [state]
         for c in w[start:]:
             state = self.dfa.target(state, c)

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -161,7 +161,6 @@ class TransitionResolver:
             start += 1
         if state is None:
             return _RESOLVED
-        self.population.add(w[:start], at=self.tree.path_of(state))
         states = [None] * start + [state]
         for c in w[start:]:
             state = self.dfa.target(state, c)

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -134,8 +134,19 @@ class TransitionResolver:
                 for _ in range(min(_PROBE_BLOCK, max_probes - drawn))
             ]
             drawn += len(block)
-            self.family.prefill(block)
+            self._prefill_sifts(block)
             yield from block
+
+    def _prefill_sifts(self, seqs):
+        """Warm the whole block's sifts one tree level at a time -- one batched
+        family read per level over every probe still descending, rather than one
+        per node per probe -- so :meth:`_process` then re-reads a warm cache."""
+
+        def decide_level(pairs):
+            self.family.prefill([list(s) + list(m) for s, m in pairs])
+            return [self.family.is_accept(s, m) for s, m in pairs]
+
+        self.tree.classify_many(seqs, decide_level)
 
     def _process(self, w):
         """Anchor at the shortest prefix the tree places, follow the resolved

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -161,19 +161,20 @@ class TransitionResolver:
         return self._act_on_disagreement(w, states, start)
 
     def _act_on_disagreement(self, w, states, agree_point):
-        state = states[-1]
         actual = self._sift(w)
-        if actual is None or state is None or actual == state:
+        if actual is None or actual == states[-1]:
             return _RESOLVED
-        fd = self._first_disagreement(w, states, agree_point, len(w))
+        fd = self._first_bad_edge(w, states, agree_point, len(w))
         if fd is None:
             return _RESOLVED
-        s1, c, s2 = states[fd - 1], w[fd - 1], states[fd]
-        if s1 is None or s2 is None or self.dfa.target(s1, c) != s2:
-            return _RESOLVED
+        # The walk follows resolved edges over a total delta, so s1, its
+        # c-successor and the edge's witness are all present, and sprime reaches s1
+        # (the sift agrees up to fd - 1). Only a majority-fallback witness (from an
+        # empty-membered leaf) can miss s1, which the sift below screens out.
+        s1, c = states[fd - 1], w[fd - 1]
         sprime = w[: fd - 1]
         witness = self.dfa.witness(s1, c)
-        if witness is None or self._sift(sprime) != s1 or self._sift(witness) != s1:
+        if self._sift(witness) != s1:
             return _RESOLVED
         distinguisher = self.tree.first_disagreement(
             witness, sprime, self.family.is_accept, [c]
@@ -186,18 +187,19 @@ class TransitionResolver:
             return _SPLIT
         return _RESOLVED if verdict == NO_SPLIT else _UNDECIDED
 
-    def _first_disagreement(self, w, states, lo, hi):
+    def _first_bad_edge(self, w, states, lo, hi):
         """Binary-search the first index where the followed state diverges from a
-        fresh sift of ``w[:i]``; ``None`` on an indecisive sift."""
+        fresh sift of ``w[:i]``; ``None`` on an indecisive sift.  Invariant: the
+        sift agrees at ``lo`` and disagrees at ``hi``."""
         if lo + 1 == hi:
             return hi
         mid = (lo + hi) // 2
         actual = self._sift(w[:mid])
-        if actual is None or states[mid] is None:
+        if actual is None:
             return None
         if actual == states[mid]:
-            return self._first_disagreement(w, states, mid, hi)
-        return self._first_disagreement(w, states, lo, mid)
+            return self._first_bad_edge(w, states, mid, hi)
+        return self._first_bad_edge(w, states, lo, mid)
 
     def _apply_split(self, s1, distinguisher, witness, sprime):
         self._split(s1, distinguisher)

--- a/scripts/profile_query_origins.py
+++ b/scripts/profile_query_origins.py
@@ -74,13 +74,14 @@ BENCHMARKS = {
 COL_SITES = ("_query", "intern_suffix", "_ensure", "observed_masks", "column")
 
 # For a tree classify, the enclosing high-level phase (searched outward, first match
-# wins). "build" catches the resolver's initial-state classify in _to_dfa_and_tree,
-# which otherwise falls to "other".
+# wins). "export" catches the resolver's initial-state classify, which otherwise
+# falls to "other".
 CLASSIFY_PHASES = [
     "estimate_agreement_rate",
-    "generate_counterexamples",
+    "counterexample_pass",
     "enrich_underrepresented_leaves",
     "build",
+    "export",
 ]
 
 # For a new-suffix column, the method that needed the suffix (searched outward,
@@ -104,7 +105,6 @@ SUFFIX_TRIGGERS = [
 
 # For a new-prefix row (add_prefixes), what added the prefixes.
 ROW_TRIGGERS = [
-    "add_counterexample_prefixes",
     "enrich_underrepresented_leaves",
     "sample_more_prefixes",
 ]

--- a/tests/test_lstar.py
+++ b/tests/test_lstar.py
@@ -4,7 +4,6 @@ import numpy as np
 from automata.fa.dfa import DFA
 from parameterized import parameterized
 
-from orthogonal_dfa.l_star.counterexample_synthesis import counterexample_sample_budget
 from orthogonal_dfa.l_star.examples.benchmark_generator import (
     DFAOracle,
     sample_balanced_benchmark,
@@ -16,7 +15,6 @@ from orthogonal_dfa.l_star.examples.bernoulli_parity import (
 )
 from orthogonal_dfa.l_star.learn import learn_dfa
 from orthogonal_dfa.l_star.sampler import UniformSampler
-from orthogonal_dfa.l_star.statistics import counterexample_search_exhausted
 from orthogonal_dfa.l_star.structures import AsymmetricBernoulli, SymmetricBernoulli
 
 us = UniformSampler(40)
@@ -583,40 +581,3 @@ class TestLStarIndistinguishablePair(unittest.TestCase):
         oracle_creator = lambda nm, s, _d=outer: DFAOracle(nm, s, _d)
         learned = learn_dfa(oracle_creator, min_signal_strength=0.3, seed=0)
         assertDFA(self, learned, oracle_creator)
-
-
-class TestCounterexampleSearchExhausted(unittest.TestCase):
-    COUNT = 200
-    BUDGET = counterexample_sample_budget(COUNT)
-
-    def test_does_not_fire_on_a_search_that_is_still_productive(self):
-        # 2 found in 8 draws is what used to trigger the old abort.
-        self.assertFalse(counterexample_search_exhausted(2, 8, self.COUNT, self.BUDGET))
-        self.assertFalse(
-            counterexample_search_exhausted(30, 400, self.COUNT, self.BUDGET)
-        )
-
-    def test_does_not_fire_on_a_search_running_to_pace(self):
-        self.assertFalse(
-            counterexample_search_exhausted(
-                self.COUNT, self.BUDGET - 1, self.COUNT, self.BUDGET
-            )
-        )
-
-    def test_fires_on_a_dry_search_long_before_the_budget(self):
-        self.assertTrue(
-            counterexample_search_exhausted(0, 600, self.COUNT, self.BUDGET)
-        )
-        self.assertFalse(
-            counterexample_search_exhausted(0, 100, self.COUNT, self.BUDGET)
-        )
-
-    def test_fires_on_a_yield_too_far_below_the_needed_rate(self):
-        # Half the needed rate, established...
-        self.assertTrue(
-            counterexample_search_exhausted(40, 4000, self.COUNT, self.BUDGET)
-        )
-        # ...and the same shortfall, too early to tell.
-        self.assertFalse(
-            counterexample_search_exhausted(4, 400, self.COUNT, self.BUDGET)
-        )


### PR DESCRIPTION
The keystone of the E-L* → direct-L* driver morph: state discovery moves from **deferred** (add a counterexample prefix → rebuild → split next round) to **in place** (split during a probe pass).

**Two coupled moves, one PR:**
- **Edges from a member.** `_edge_target` sifts one `member + symbol` (the tree is consistent, so any member resolves the edge the same way) and keeps that member as the edge's **witness** in `PartialDFA`. The whole-population majority descent and the `_divergence` split test are gone.
- **Splits in place.** `counterexample_pass` walks random probes through the resolved delta, re-sifts, and where the walk and the sift disagree runs `MidfixTree.first_disagreement` + `SplitEvidence` on the exposed leaf, splitting immediately. This is E-L*'s `locate_incorrect_point` counterexample, acted on directly instead of appended to the pool.

The outer loop now drives a persistent resolver (`build → counterexample_pass → export`) instead of `resolve_dfa` + `add_counterexample_prefixes`; the E-L* counterexample search (`generate_counterexamples` / `add_counterexample_prefixes`) is removed. Leaf enrichment stays.

**Why one PR:** the probe pass *alone* — with the population descent still resolving edges — regresses queries (the two mechanisms find states redundantly, and the descent is expensive). Paired with member-based edges (which drop the descent) it's a net win. The efficiency is emergent from the combination.

**Measured (seed 0), net-positive:**

| target | main | this PR | Δ |
|---|---|---|---|
| modulo-9 | 451,102 | 380,098 | **−16%** |
| `.*1010101.*` | 460,409 | 422,775 | **−8%** |

Same state counts. `test_modulo` / `test_specific_subsequence` pass locally; the full (slower) suite runs on CI.

Next in the stack: FNR feeding replaces enrichment, then delete the remaining dead E-L* mask machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `pr-split-on-counterexample` vs `main`

|   | task | queries `main` | queries `pr-split-on-counterexample` | ratio | acc `main` | acc `pr-split-on-counterexample` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| 🟢 | modulo | 451,102 | 380,342 | 0.84x | 1.000 | 1.000 | 9 |
| 🟢 | subseq | 460,409 | 424,300 | 0.92x | 1.000 | 1.000 | 8 |
| 🟢 | two_subseq | 781,419 | 442,244 | 0.57x | 1.000 | 1.000 | 9 |
| 🔴 | poor_case | 827,453 | 968,934 | 1.17x | 1.000 | 1.000 | 10 |
| 🟢 | modulo_hard | 1,236,882 | 1,072,934 | 0.87x | 1.000 | 1.000 | 9 |
| 🟢 | modulo_asym | 2,738,365 | 2,275,354 | 0.83x | 1.000 | 1.000 | 9 |
| 🟢 | **geomean** |  |  | **0.85x** |  |  |  |

**❌ REGRESSION** (queries up or accuracy/states broke on ≥1 task)

### Forward passes — `pr-split-on-counterexample` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 14,216 → 12,026 (0.85x, 99% packed) | 3,677 → 3,208 (0.87x, 93% packed) | 618 → 676 (1.09x, 55% packed) |
| subseq | 14,514 → 13,438 (0.93x, 99% packed) | 3,749 → 3,658 (0.98x, 91% packed) | 608 → 872 (1.43x, 48% packed) |
| two_subseq | 27,028 → 14,058 (0.52x, 98% packed) | 9,801 → 4,029 (0.41x, 86% packed) | 5,100 → 1,351 (0.26x, 32% packed) |
| poor_case | 29,898 → 30,791 (1.03x, 98% packed) | 12,151 → 9,467 (0.78x, 80% packed) | 7,363 → 4,267 (0.58x, 22% packed) |
| modulo_hard | 38,759 → 33,708 (0.87x, 99% packed) | 9,828 → 8,683 (0.88x, 97% packed) | 1,411 → 1,399 (0.99x, 75% packed) |
| modulo_asym | 85,688 → 71,333 (0.83x, 100% packed) | 21,561 → 18,099 (0.84x, 98% packed) | 2,857 → 2,531 (0.89x, 88% packed) |
