### PR TITLE
Dedup leaf-targeted seeds in LeafPopulation.add

### DIFF
--- a/orthogonal_dfa/l_star/leaf_population.py
+++ b/orthogonal_dfa/l_star/leaf_population.py
@@ -34,8 +34,17 @@ class LeafPopulation:
 
     def add(self, string, at: Path = ()) -> None:
         """Add ``string`` to the population resting at node ``at`` -- the root by
-        default (pooled, leaf unknown), or a leaf the caller has already sifted."""
-        self._at.setdefault(at, []).append(tuple(string))
+        default (pooled, leaf unknown), or a leaf the caller has already sifted.
+
+        A leaf-targeted add is deduped: seeding the same string at one leaf twice
+        does no work, so a repeatedly re-anchored prefix cannot flood it with
+        copies that the split test would then miscount as independent members.
+        The root pool keeps every add, so a prefix's multiplicity is preserved."""
+        bucket = self._at.setdefault(at, [])
+        entry = tuple(string)
+        if at and entry in bucket:
+            return
+        bucket.append(entry)
 
     def members(self, at: Path, count: int) -> List[list]:
         """Up to ``count`` strings reaching leaf ``at``, pulling from ancestors as


### PR DESCRIPTION
## What

`LeafPopulation.add` now dedups **leaf-targeted** seeds: seeding the same string at one leaf twice is a no-op. The root pool (`at=()`) still keeps every add, so prefix multiplicity is preserved.

## Why

The counterexample pass re-anchors every probe at its shortest decisive prefix and seeds that prefix into the anchor leaf (`transition_resolver.py` `_process`). When `[]` is decisive — the common case (measured **158/158** anchored probes on modulo, **265/265** on subseq) — this piled hundreds of identical `[]` onto one leaf.

`SplitEvidence` weighs a leaf's members as independent samples, so those duplicates inflate one side of the split test. In a weak-signal regime (Bayes factor stuck below threshold), `_agrees_as_one_state` can be driven to `NO_SPLIT` by duplicate count alone, dragging a genuine ≥10% minority below the `_MIN_DETECTABLE_SPLIT` floor. The **seed** is load-bearing (dropping the anchor add entirely hangs pool-starved shallow leaves), but the **duplicate count** is inert.

## Validation

Deduping to one copy per leaf is behavior-preserving on every target checked — same DFA and same oracle-query count:

| target | before | after |
|---|---|---|
| subseq (`.*1010101.*`) | calls=660, states=8 | calls=660, states=8 |
| modulo (mod 9, {3,6}) | calls=487, states=9 | calls=487, states=9 |
| regex_asymmetric | 8 states, identical round trajectory | bit-identical |

`test_leaf_population.py` and `test_lstar.py::TestLStar::test_modulo` pass; lint clean (pylint 10.00/10, isort, black).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `dedup-anchor-seed` vs `main`

|   | task | queries `main` | queries `dedup-anchor-seed` | ratio | acc `main` | acc `dedup-anchor-seed` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 380,342 | 380,342 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 424,300 | 424,300 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 442,244 | 442,244 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 968,934 | 968,934 | 1.00x | 1.000 | 1.000 | 10 |
| ⚪ | modulo_hard | 1,072,934 | 1,072,934 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 2,275,354 | 2,275,354 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **1.00x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

### Forward passes — `dedup-anchor-seed` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 12,026 → 12,026 (1.00x, 99% packed) | 3,208 → 3,208 (1.00x, 93% packed) | 676 → 676 (1.00x, 55% packed) |
| subseq | 13,438 → 13,438 (1.00x, 99% packed) | 3,658 → 3,658 (1.00x, 91% packed) | 872 → 872 (1.00x, 48% packed) |
| two_subseq | 14,058 → 14,058 (1.00x, 98% packed) | 4,029 → 4,029 (1.00x, 86% packed) | 1,351 → 1,351 (1.00x, 32% packed) |
| poor_case | 30,791 → 30,791 (1.00x, 98% packed) | 9,467 → 9,467 (1.00x, 80% packed) | 4,267 → 4,267 (1.00x, 22% packed) |
| modulo_hard | 33,708 → 33,708 (1.00x, 99% packed) | 8,683 → 8,683 (1.00x, 97% packed) | 1,399 → 1,399 (1.00x, 75% packed) |
| modulo_asym | 71,333 → 71,333 (1.00x, 100% packed) | 18,099 → 18,099 (1.00x, 98% packed) | 2,531 → 2,531 (1.00x, 88% packed) |
