### PR TITLE
Feed boundary strings into the representative pool (FNR feeding)

### DIFF
--- a/orthogonal_dfa/l_star/counterexample_synthesis.py
+++ b/orthogonal_dfa/l_star/counterexample_synthesis.py
@@ -156,16 +156,21 @@ def feed_boundary_strings(pst, boundaries, *, limit: int) -> int:
     adding it makes the next round's ``sample_suffix_family`` see a high FNR over
     it and re-cluster to a family that places it decisively.  Capped at the same
     per-round budget as enrichment so one round cannot flood the pool.  Returns
-    how many were added."""
+    how many were added.
+
+    ``boundaries`` is a set, so sort it to a canonical order and then shuffle it
+    with a fixed rng: the cap picks the same unbiased sample every run, rather
+    than one biased by sort order or dependent on set iteration order."""
+    ordered = sorted(tuple(b) for b in boundaries)
+    np.random.default_rng(0).shuffle(ordered)
     fresh, seen = [], set()
-    for b in boundaries:
+    for key in ordered:
         if len(fresh) >= limit:
             break
-        key = tuple(b)
-        if key in seen or pst.table.contains_prefix(list(b)):
+        if key in seen or pst.table.contains_prefix(list(key)):
             continue
         seen.add(key)
-        fresh.append(list(b))
+        fresh.append(list(key))
     if fresh:
         pst.table.add_prefixes(fresh)
     return len(fresh)

--- a/orthogonal_dfa/l_star/counterexample_synthesis.py
+++ b/orthogonal_dfa/l_star/counterexample_synthesis.py
@@ -150,13 +150,13 @@ def uncoverable_access_strings(pst, tree):
     return flagged
 
 
-def feed_boundary_strings(pst, boundaries) -> int:
-    """Add up to a capped share of the round's boundary strings to the
-    representative pool.  A boundary string is one the family straddled
-    (``sift -> None``); adding it makes the next round's ``sample_suffix_family``
-    see a high FNR over it and re-cluster to a family that places it decisively.
-    Returns how many were added."""
-    limit = max(int(0.1 * pst.num_prefixes), 200)
+def feed_boundary_strings(pst, boundaries, *, limit: int) -> int:
+    """Add up to ``limit`` of the round's boundary strings to the representative
+    pool.  A boundary string is one the family straddled (``sift -> None``);
+    adding it makes the next round's ``sample_suffix_family`` see a high FNR over
+    it and re-cluster to a family that places it decisively.  Capped at the same
+    per-round budget as enrichment so one round cannot flood the pool.  Returns
+    how many were added."""
     fresh, seen = [], set()
     for b in boundaries:
         if len(fresh) >= limit:
@@ -216,7 +216,9 @@ def counterexample_driven_synthesis(
         enriched = enrich_underrepresented_leaves(
             pst, dt, count=additional_counterexamples
         )
-        fed = feed_boundary_strings(pst, resolver.indecisive)
+        fed = feed_boundary_strings(
+            pst, resolver.indecisive, limit=additional_counterexamples
+        )
         if fed:
             print(f"Fed {fed} boundary strings into the representative pool")
         if not enriched and not fed:

--- a/orthogonal_dfa/l_star/counterexample_synthesis.py
+++ b/orthogonal_dfa/l_star/counterexample_synthesis.py
@@ -150,6 +150,27 @@ def uncoverable_access_strings(pst, tree):
     return flagged
 
 
+def feed_boundary_strings(pst, boundaries) -> int:
+    """Add up to a capped share of the round's boundary strings to the
+    representative pool.  A boundary string is one the family straddled
+    (``sift -> None``); adding it makes the next round's ``sample_suffix_family``
+    see a high FNR over it and re-cluster to a family that places it decisively.
+    Returns how many were added."""
+    limit = max(int(0.1 * pst.num_prefixes), 200)
+    fresh, seen = [], set()
+    for b in boundaries:
+        if len(fresh) >= limit:
+            break
+        key = tuple(b)
+        if key in seen or pst.table.contains_prefix(list(b)):
+            continue
+        seen.add(key)
+        fresh.append(list(b))
+    if fresh:
+        pst.table.add_prefixes(fresh)
+    return len(fresh)
+
+
 def counterexample_driven_synthesis(
     pst, *, additional_counterexamples: int, acc_threshold: float
 ):
@@ -195,8 +216,11 @@ def counterexample_driven_synthesis(
         enriched = enrich_underrepresented_leaves(
             pst, dt, count=additional_counterexamples
         )
-        if not enriched:
-            print("Leaf enrichment found no new prefixes; stopping synthesis")
+        fed = feed_boundary_strings(pst, resolver.indecisive)
+        if fed:
+            print(f"Fed {fed} boundary strings into the representative pool")
+        if not enriched and not fed:
+            print("No new prefixes from enrichment or boundary feed; stopping")
             yield dfa, dt, None
             return
         yield dfa, dt, copy.deepcopy(pst)

--- a/orthogonal_dfa/l_star/midfix_tree.py
+++ b/orthogonal_dfa/l_star/midfix_tree.py
@@ -122,18 +122,29 @@ class MidfixTree:
 
     # -- classification -----------------------------------------------------
 
-    def classify(self, seq, decide: Decide) -> Optional[int]:
+    def sift(self, seq, decide: Decide) -> Tuple[Optional[int], Optional[tuple]]:
         """
-        Route seq to a leaf, or None when a node's decide callback abstains.
+        Route seq to a leaf: (state, None) when it lands decisively, or
+        (None, boundary) when some node cannot place it.
+
+        The boundary is seq + midfix, not seq: the indecision is over
+        seq + midfix + v, so it is seq + midfix that the family failed on and
+        that a caller can force the next family to resolve.
         """
         node = self._root
         while not isinstance(node, int):
             midfix, lookup = node
             decision = decide(seq, midfix)
             if decision is None:
-                return None
+                return None, tuple(seq) + tuple(midfix)
             node = lookup[decision]
-        return node
+        return node, None
+
+    def classify(self, seq, decide: Decide) -> Optional[int]:
+        """
+        Route seq to a leaf, or None when a node's decide callback abstains.
+        """
+        return self.sift(seq, decide)[0]
 
     def first_disagreement(self, s, sprime, decide: Decide, prefix) -> Optional[tuple]:
         """

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -49,6 +49,7 @@ class TransitionResolver:
         self.splits = None
         self.population = None  # pool prefixes, per leaf
         self.dfa = None  # the partial transition function
+        self.indecisive = set()  # boundary strings the family could not place
 
     # -- membership / population -------------------------------------------
 
@@ -65,8 +66,15 @@ class TransitionResolver:
         )
 
     def _sift(self, seq):
-        """The leaf ``seq`` sifts to, or ``None`` when a node cannot place it."""
-        return self.tree.classify(list(seq), self.family.is_accept)
+        """The leaf ``seq`` sifts to, or ``None`` when a node cannot place it.
+
+        Every string the tree cannot place is harvested into ``indecisive``: it is
+        a boundary string the current family straddles, and the driver feeds these
+        back so the next family is forced to resolve them."""
+        leaf, boundary = self.tree.sift(list(seq), self.family.is_accept)
+        if leaf is None:
+            self.indecisive.add(boundary)
+        return leaf
 
     # -- the resolution step ------------------------------------------------
 


### PR DESCRIPTION
## What

The first piece of direct-L\*'s convergence, brought to the E-L\* driver. Between rounds, E-L\* only **enriched under-represented leaves**. This additionally **harvests the boundary strings** the family straddles (`sift → None`) and feeds a capped share of them into the representative pool, so the next round's `sample_suffix_family` sees a high FNR over them and re-clusters to a family that places them decisively.

The machinery it drives already existed on main — the FNR gate in `sample_suffix_family` (clusters over `pst.table.representative` against `fnr_limit`) and the path sampler. This change just feeds it.

- `midfix_tree.sift` now returns `(leaf, boundary)`; `classify` delegates to it (behavior unchanged).
- The resolver harvests every abstaining sift into `indecisive` (centralised in `_sift`).
- The driver feeds the boundary strings into the representative pool via `add_prefixes`, alongside the existing enrichment, capped at `additional_counterexamples` (the same per-round budget enrichment uses).
- The feed is deterministic: the `indecisive` set is sorted to a canonical order and then shuffled with a fixed `default_rng(0)`, so the capped sample is reproducible and unbiased regardless of set iteration order.

Merged up to current `main` (includes #178), so this benchmarks the combined dedup + feed behavior.

## Why this shape

Post-#177 the inner resolver already discovers states in place like direct-L\*; the only remaining gap is the outer loop's feedback. This is the crux of that gap — feeding boundaries is what lets a round hand the next one exactly the states it could not resolve, converging the chain a state at a time instead of relying on leaf-rebalancing alone.

## Benchmarks (count_queries — oracle calls / forward passes)

Baseline = `origin/main` (with #178); branch = main + #178 + this change.

| target | rounds (main → branch) | main | branch | Δ |
|---|---|---|---|---|
| subseq `.*1010101.*` | 1 → 1 | 660 | 660 | identical (feed never fires) |
| modulo (mod 9, {3,6}) | 1 → 1 | 487 | 487 | identical |
| poor_case 1 | 2 → 2 | 5091 | 5092 | +1 (neutral) |
| poor_case 2 | multi | 3728 | **1384** | **−63%** |
| regex_asymmetric | **22 → 3** | 10462 | **9585** | **−8.4%** |

Single-round targets are byte-identical (the feed only runs when a round falls short of the accuracy threshold). Multi-round targets converge in far fewer rounds — regex_asymmetric collapses from 22 rounds to 3 — with the same correct DFAs (8 and 10 states) and fewer oracle queries. Lint clean (pylint 10.00/10, isort+black).

(regex_asymmetric figure predates the deterministic-feed commit; the cap never binds on these targets so it is unaffected, but the authoritative numbers will come from the maintainer's benchmark run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `fnr-boundary-feeding` vs `main`

|   | task | queries `main` | queries `fnr-boundary-feeding` | ratio | acc `main` | acc `fnr-boundary-feeding` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 380,342 | 380,342 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 424,300 | 424,300 | 1.00x | 1.000 | 1.000 | 8 |
| 🔴 | two_subseq | 442,244 | 477,526 | 1.08x | 1.000 | 1.000 | 9 |
| 🟢 | poor_case | 968,934 | 634,782 | 0.66x | 1.000 | 1.000 | 10 |
| ⚪ | modulo_hard | 1,072,934 | 1,072,934 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 2,275,354 | 2,275,354 | 1.00x | 1.000 | 1.000 | 9 |
| 🟢 | **geomean** |  |  | **0.94x** |  |  |  |

**❌ REGRESSION** (queries up or accuracy/states broke on ≥1 task)

### Forward passes — `fnr-boundary-feeding` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 12,026 → 12,026 (1.00x, 99% packed) | 3,208 → 3,208 (1.00x, 93% packed) | 676 → 676 (1.00x, 55% packed) |
| subseq | 13,438 → 13,438 (1.00x, 99% packed) | 3,658 → 3,658 (1.00x, 91% packed) | 872 → 872 (1.00x, 48% packed) |
| two_subseq | 14,058 → 15,174 (1.08x, 98% packed) | 4,029 → 4,306 (1.07x, 87% packed) | 1,351 → 1,401 (1.04x, 33% packed) |
| poor_case | 30,791 → 20,110 (0.65x, 99% packed) | 9,467 → 5,611 (0.59x, 88% packed) | 4,267 → 1,723 (0.40x, 36% packed) |
| modulo_hard | 33,708 → 33,708 (1.00x, 99% packed) | 8,683 → 8,683 (1.00x, 97% packed) | 1,399 → 1,399 (1.00x, 75% packed) |
| modulo_asym | 71,333 → 71,333 (1.00x, 100% packed) | 18,099 → 18,099 (1.00x, 98% packed) | 2,531 → 2,531 (1.00x, 88% packed) |
