### PR TITLE
Extract the sift glue into a Sifter

### DIFF
--- a/orthogonal_dfa/l_star/sifting.py
+++ b/orthogonal_dfa/l_star/sifting.py
@@ -1,0 +1,49 @@
+"""Classifying strings against the current discrimination tree.
+
+The tree knows which midfix cuts where; the family knows how to answer a midfix.
+Putting them together is what "sift" means, and both the probe loop and the edge
+resolver need it, so it lives here rather than in either of them.
+"""
+
+from typing import Optional, Tuple
+
+
+class Sifter:
+    """Routes strings through ``tree``, classifying with ``family``."""
+
+    def __init__(self, tree, family):
+        self.tree = tree
+        self.family = family
+
+    def sift_and_boundary(self, seq) -> Tuple[Optional[int], Optional[tuple]]:
+        """Route ``seq`` to a leaf: ``(state, None)``, or ``(None, boundary)``
+        when some node cannot place it."""
+        return self.tree.sift(seq, self.family.is_accept)
+
+    def sift(self, seq) -> Optional[int]:
+        leaf, _ = self.sift_and_boundary(seq)
+        return leaf
+
+    def prefill(self, seqs) -> None:
+        """Warm the cache for sifting all of ``seqs``, one batched call per tree
+        level rather than one per node visited.
+
+        Uses ``classify_many`` purely for its per-level walk: each level's
+        ``decide`` first warms the whole level's family cells in one batched call,
+        then reads them back (now cached) to descend.  The returned leaves are
+        discarded -- only the warmed cache matters."""
+
+        def warm(pairs):
+            self.family.prefill([list(s) + list(m) for s, m in pairs])
+            return [self.family.is_accept(s, m) for s, m in pairs]
+
+        self.tree.classify_many(seqs, warm)
+
+    def disagreement(self, s, sprime, prefix) -> Optional[tuple]:
+        """A midfix separating ``s`` and ``sprime`` (see
+        :meth:`MidfixTree.first_disagreement`), or ``None``.
+
+        This only *proposes* a distinguisher; whether the split fires is decided
+        by the population evidence, so the pair need only clear the ordinary
+        decisive band, not a wide split margin."""
+        return self.tree.first_disagreement(s, sprime, self.family.is_accept, prefix)

--- a/orthogonal_dfa/l_star/sifting.py
+++ b/orthogonal_dfa/l_star/sifting.py
@@ -20,10 +20,6 @@ class Sifter:
         when some node cannot place it."""
         return self.tree.sift(seq, self.family.is_accept)
 
-    def sift(self, seq) -> Optional[int]:
-        leaf, _ = self.sift_and_boundary(seq)
-        return leaf
-
     def prefill(self, seqs) -> None:
         """Warm the cache for sifting all of ``seqs``, one batched call per tree
         level rather than one per node visited.

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -29,6 +29,7 @@ from .cluster import sample_suffix_family
 from .leaf_population import LeafPopulation
 from .midfix_tree import MidfixTree, oracle_decider
 from .partial_dfa import PartialDFA
+from .sifting import Sifter
 from .split_evidence import NO_SPLIT, SPLIT, SplitEvidence
 from .suffix_family import SuffixFamily
 
@@ -46,6 +47,7 @@ class TransitionResolver:
         self.pst = pst
         self.tree = None
         self.family = None
+        self.sifter = None
         self.splits = None
         self.population = None  # pool prefixes, per leaf
         self.dfa = None  # the partial transition function
@@ -71,7 +73,7 @@ class TransitionResolver:
         Every string the tree cannot place is harvested into ``indecisive``: it is
         a boundary string the current family straddles, and the driver feeds these
         back so the next family is forced to resolve them."""
-        leaf, boundary = self.tree.sift(list(seq), self.family.is_accept)
+        leaf, boundary = self.sifter.sift_and_boundary(list(seq))
         if leaf is None:
             self.indecisive.add(boundary)
         return leaf
@@ -142,19 +144,8 @@ class TransitionResolver:
                 for _ in range(min(_PROBE_BLOCK, max_probes - drawn))
             ]
             drawn += len(block)
-            self._prefill_sifts(block)
+            self.sifter.prefill(block)
             yield from block
-
-    def _prefill_sifts(self, seqs):
-        """Warm the whole block's sifts one tree level at a time -- one batched
-        family read per level over every probe still descending, rather than one
-        per node per probe -- so :meth:`_process` then re-reads a warm cache."""
-
-        def decide_level(pairs):
-            self.family.prefill([list(s) + list(m) for s, m in pairs])
-            return [self.family.is_accept(s, m) for s, m in pairs]
-
-        self.tree.classify_many(seqs, decide_level)
 
     def _process(self, w):
         """Anchor at the shortest prefix the tree places, follow the resolved
@@ -195,9 +186,7 @@ class TransitionResolver:
         witness = self.dfa.witness(s1, c)
         if self._sift(witness) != s1:
             return _RESOLVED
-        distinguisher = self.tree.first_disagreement(
-            witness, sprime, self.family.is_accept, [c]
-        )
+        distinguisher = self.sifter.disagreement(witness, sprime, [c])
         if distinguisher is None:
             return _RESOLVED
         verdict = self.splits.verdict(s1, tuple(distinguisher))
@@ -236,6 +225,7 @@ class TransitionResolver:
         pst.decision_boundary = boundary
         self.family = SuffixFamily(pst, vs)
         self.tree = MidfixTree([pst.table.suffix(i) for i in vs])
+        self.sifter = Sifter(self.tree, self.family)
         self.population = LeafPopulation(self.tree, self._classify)
         for p in pst.table.prefixes:
             self.population.add(list(p))


### PR DESCRIPTION
## What

Pulls the resolver's tree+family classification glue — `_sift`, the per-block prefill, and the `first_disagreement` call — into a `Sifter(tree, family)` object in a new `sifting.py`. The resolver's `_sift` stays a thin wrapper that harvests the boundary and delegates to `sifter.sift_and_boundary`.

This is the same module direct-L\* already factors this into, so `main` and the capstone now share it.

## Why

Pure reorganization to shrink the capstone (#134) diff. `sifting.py` currently lands there as a whole new +71 file; after this it's just the `leaves_of`/`SCAN_BLOCK` delta (which is itself dead code even on the branch — `leaves_of` has no callers — and can be dropped there separately). `transition_resolver.py` also shrinks.

The extracted `Sifter` intentionally omits `leaves_of` (unused everywhere) so main carries no dead code.

## Validation

Pure refactor — behavior byte-identical:

| target | oracle calls | states |
|---|---|---|
| subseq | 660 (=main) | 8 |
| modulo | 487 (=main) | 9 |
| poor_case 2 | 1384 (=main) | 10 |

Lint clean (isort+black via `uv`, pylint 10.00/10); `test_modulo` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `extract-sifter` vs `main`

|   | task | queries `main` | queries `extract-sifter` | ratio | acc `main` | acc `extract-sifter` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 380,342 | 380,342 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 424,300 | 424,300 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 477,526 | 477,526 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 634,782 | 634,782 | 1.00x | 1.000 | 1.000 | 10 |
| ⚪ | modulo_hard | 1,072,934 | 1,072,934 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 2,275,354 | 2,275,354 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **1.00x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

### Forward passes — `extract-sifter` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 12,026 → 12,026 (1.00x, 99% packed) | 3,208 → 3,208 (1.00x, 93% packed) | 676 → 676 (1.00x, 55% packed) |
| subseq | 13,438 → 13,438 (1.00x, 99% packed) | 3,658 → 3,658 (1.00x, 91% packed) | 872 → 872 (1.00x, 48% packed) |
| two_subseq | 15,174 → 15,174 (1.00x, 98% packed) | 4,306 → 4,306 (1.00x, 87% packed) | 1,401 → 1,401 (1.00x, 33% packed) |
| poor_case | 20,110 → 20,110 (1.00x, 99% packed) | 5,611 → 5,611 (1.00x, 88% packed) | 1,723 → 1,723 (1.00x, 36% packed) |
| modulo_hard | 33,708 → 33,708 (1.00x, 99% packed) | 8,683 → 8,683 (1.00x, 97% packed) | 1,399 → 1,399 (1.00x, 75% packed) |
| modulo_asym | 71,333 → 71,333 (1.00x, 100% packed) | 18,099 → 18,099 (1.00x, 98% packed) | 2,531 → 2,531 (1.00x, 88% packed) |
