### PR TITLE
Return the best hypothesis across rounds, not the last

### DIFF
--- a/orthogonal_dfa/l_star/counterexample_synthesis.py
+++ b/orthogonal_dfa/l_star/counterexample_synthesis.py
@@ -8,7 +8,6 @@ the round repeats -- until the estimate clears the threshold or enrichment dries
 up.  The classification and accuracy primitives it uses live in ``lstar``.
 """
 
-import copy
 import math
 
 import numpy as np
@@ -203,7 +202,7 @@ def counterexample_driven_synthesis(
         print(f"Estimated DFA accuracy on fresh samples: {true_acc:.4f}")
         if true_acc >= acc_threshold:
             print(f"Achieved desired accuracy of {acc_threshold}; stopping synthesis")
-            yield dfa, dt, None
+            yield dfa, dt, true_acc, pst.decision_boundary
             return
         uncoverable = uncoverable_access_strings(pst, dt)
         if uncoverable:
@@ -216,7 +215,7 @@ def counterexample_driven_synthesis(
                 f"{pst.sampler.length} (e.g. {examples}); the target is not "
                 f"learnable with this prefix sampler."
             )
-            yield dfa, dt, None
+            yield dfa, dt, true_acc, pst.decision_boundary
             return
         enriched = enrich_underrepresented_leaves(
             pst, dt, count=additional_counterexamples
@@ -228,21 +227,27 @@ def counterexample_driven_synthesis(
             print(f"Fed {fed} boundary strings into the representative pool")
         if not enriched and not fed:
             print("No new prefixes from enrichment or boundary feed; stopping")
-            yield dfa, dt, None
+            yield dfa, dt, true_acc, pst.decision_boundary
             return
-        yield dfa, dt, copy.deepcopy(pst)
+        yield dfa, dt, true_acc, pst.decision_boundary
 
 
 def do_counterexample_driven_synthesis(
     pst, *, additional_counterexamples: int, acc_threshold: float
 ) -> DFA:
-    dfa = dt = None
-    for dfa, dt, _ in counterexample_driven_synthesis(
+    # Rounds are not monotone -- feeding re-clusters, so a later family can
+    # classify worse -- so keep the most accurate hypothesis, not the last. The
+    # boundary is kept with it because denoising reads the tree against it.
+    best_acc, best_dfa, best_dt, best_boundary = -1.0, None, None, None
+    for dfa, dt, true_acc, boundary in counterexample_driven_synthesis(
         pst,
         additional_counterexamples=additional_counterexamples,
         acc_threshold=acc_threshold,
     ):
-        pass
+        if true_acc > best_acc:
+            best_acc, best_dfa, best_dt, best_boundary = true_acc, dfa, dt, boundary
+    dfa, dt = best_dfa, best_dt
     if dfa is not None:
+        pst.decision_boundary = best_boundary
         dfa = denoise_accept_labels(pst, dfa)
     return dfa, dt


### PR DESCRIPTION
## What

The synthesis loop returned whatever the **last** round produced. But since #179, feeding re-clusters the suffix family each round, so rounds are no longer monotone — a later family can classify *worse* than an earlier one. This tracks the most accurate hypothesis seen across rounds and returns that, carrying its decision boundary alongside it (denoising reads the tree against the boundary).

No stall detector — we agreed the principled `uncoverable_access_strings` + enrich/feed-dry stops already cover what it would, and the heuristic isn't justified.

Also drops a dead per-round `copy.deepcopy(pst)` that the last-round consumer never read.

## Why it's safe

On a **converging** target the last round is the one that clears the accuracy threshold, so it's already the best — nothing changes:

| target | oracle calls | states |
|---|---|---|
| subseq | 660 (=main) | 8 |
| modulo | 487 (=main) | 9 |
| poor_case 2 | 1384 (=main) | 10 |

The change only bites when a run stops **without** converging (uncoverable states, or enrichment and feeding both dry), where it now returns the best round rather than a possibly-worse last one. `test_transient_states_terminate` still terminates; `test_boundary_near_zero` still `xfails` (best-tracking doesn't accidentally flip it).

Lint clean (isort+black via `uv`, pylint 10.00/10).

## Sequencing

This lands before the EdgeResolver / leave-open change so that when indecisive edges start self-looping at export, a worse final round can't be what gets returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)