### PR TITLE
Resolve edges through an EdgeResolver, leaving open what no member places

### DIFF
--- a/orthogonal_dfa/l_star/edge_resolver.py
+++ b/orthogonal_dfa/l_star/edge_resolver.py
@@ -1,15 +1,16 @@
-"""Deciding where the partial DFA's open edges point.
+"""
+Deciding where the partial DFA's open edges point.
 
-:class:`PartialDFA` owns the edges and the witnesses.  It cannot decide where an
-edge *goes*, because that needs the oracle.  This does: it sifts
-``member + symbol`` for the members the source leaf already has and takes the
-first successor the family can place.
+PartialDFA owns the edges and the witnesses, but cannot decide where an
+edge *goes*, because that needs the oracle.
 
-Any member will do -- the tree is consistent, so every member of a leaf resolves
-the same edge.  When no member's continuation can be placed the edge is left
-open; the export totalises it, and every ``member + symbol`` the family could not
-place is harvested into ``indecisive``, which the driver feeds back so the next
-round's family resolves it.
+We pick an arbitrary member of a source state, and ask the oracle
+where its successor under the edge's character goes.
+
+    - If the family can place that successor, we point the edge there and
+      record the member as the witness.
+    - If the family cannot place that successor, we harvest it as a boundary
+      string and leave the edge open.
 """
 
 from typing import List, Optional, Tuple
@@ -32,9 +33,6 @@ class EdgeResolver:
     def decisive_target(
         self, state: int, c: int
     ) -> Tuple[Optional[int], Optional[List[int]]]:
-        """The first member of ``state`` whose ``c``-successor the family can
-        place, and that member; ``(None, None)`` when none can.  Each successor the
-        family cannot place is harvested as a boundary string."""
         for member in self.leaf_members(state):
             target, boundary = self.sifter.sift_and_boundary(list(member) + [c])
             if target is not None:
@@ -43,15 +41,17 @@ class EdgeResolver:
         return None, None
 
     def resolve(self, state: int, c: int) -> None:
-        """Point one edge at a decisive successor, or leave it open."""
         target, witness = self.decisive_target(state, c)
         if target is not None:
             self.dfa.set_edge(state, c, target, witness)
 
     def close(self) -> int:
-        """Resolve every open edge once, returning how many are now closed.  Edge
-        resolution never splits, so one pass resolves all it can; the rest stay
-        open for the export to totalise."""
+        """
+        Resolve every open edge once, returning how many are now closed.
+
+        Edge resolution never splits, so one pass resolves all it can; the rest stay
+        open for the export to totalise.
+        """
         edges = self.dfa.unresolved_edges()
         for state, c in edges:
             self.resolve(state, c)

--- a/orthogonal_dfa/l_star/edge_resolver.py
+++ b/orthogonal_dfa/l_star/edge_resolver.py
@@ -1,0 +1,58 @@
+"""Deciding where the partial DFA's open edges point.
+
+:class:`PartialDFA` owns the edges and the witnesses.  It cannot decide where an
+edge *goes*, because that needs the oracle.  This does: it sifts
+``member + symbol`` for the members the source leaf already has and takes the
+first successor the family can place.
+
+Any member will do -- the tree is consistent, so every member of a leaf resolves
+the same edge.  When no member's continuation can be placed the edge is left
+open; the export totalises it, and every ``member + symbol`` the family could not
+place is harvested into ``indecisive``, which the driver feeds back so the next
+round's family resolves it.
+"""
+
+from typing import List, Optional, Tuple
+
+from .split_evidence import _MEMBER_LIMIT
+
+
+class EdgeResolver:
+    """Closes the hypothesis: see the module docstring."""
+
+    def __init__(self, partial, sifter, indecisive, *, population):
+        self.dfa = partial
+        self.sifter = sifter
+        self.indecisive = indecisive
+        self._population = population
+
+    def leaf_members(self, state: int) -> List[List[int]]:
+        return self._population.members(self.sifter.tree.path_of(state), _MEMBER_LIMIT)
+
+    def decisive_target(
+        self, state: int, c: int
+    ) -> Tuple[Optional[int], Optional[List[int]]]:
+        """The first member of ``state`` whose ``c``-successor the family can
+        place, and that member; ``(None, None)`` when none can.  Each successor the
+        family cannot place is harvested as a boundary string."""
+        for member in self.leaf_members(state):
+            target, boundary = self.sifter.sift_and_boundary(list(member) + [c])
+            if target is not None:
+                return target, list(member)
+            self.indecisive.add(boundary)
+        return None, None
+
+    def resolve(self, state: int, c: int) -> None:
+        """Point one edge at a decisive successor, or leave it open."""
+        target, witness = self.decisive_target(state, c)
+        if target is not None:
+            self.dfa.set_edge(state, c, target, witness)
+
+    def close(self) -> int:
+        """Resolve every open edge once, returning how many are now closed.  Edge
+        resolution never splits, so one pass resolves all it can; the rest stay
+        open for the export to totalise."""
+        edges = self.dfa.unresolved_edges()
+        for state, c in edges:
+            self.resolve(state, c)
+        return sum(1 for state, c in edges if self.dfa.has_edge(state, c))

--- a/orthogonal_dfa/l_star/leaf_population.py
+++ b/orthogonal_dfa/l_star/leaf_population.py
@@ -52,6 +52,13 @@ class LeafPopulation:
         self._fill(at, count)
         return [list(s) for s in self._at.get(at, [])[:count]]
 
+    def representative(self, at: Path, count: int) -> Optional[list]:
+        """The canonical member reaching leaf ``at`` -- the shortest, ties broken
+        lexicographically -- or ``None`` if none do. ``count`` bounds how many
+        members are pulled to choose among."""
+        members = self.members(at, count)
+        return min(members, key=lambda m: (len(m), m)) if members else None
+
     def _fill(self, at: Path, count: int) -> None:
         """Pull strings down into ``at`` until it holds ``count`` or its ancestors
         are exhausted."""

--- a/orthogonal_dfa/l_star/leaf_population.py
+++ b/orthogonal_dfa/l_star/leaf_population.py
@@ -53,9 +53,13 @@ class LeafPopulation:
         return [list(s) for s in self._at.get(at, [])[:count]]
 
     def representative(self, at: Path, count: int) -> Optional[list]:
-        """The canonical member reaching leaf ``at`` -- the shortest, ties broken
-        lexicographically -- or ``None`` if none do. ``count`` bounds how many
-        members are pulled to choose among."""
+        """
+        The canonical member reaching leaf at: the shortest, ties broken
+        lexicographically. None if no such member exists.
+
+        count is the number of elements to ensure we have before selecting this
+        representative.
+        """
         members = self.members(at, count)
         return min(members, key=lambda m: (len(m), m)) if members else None
 

--- a/orthogonal_dfa/l_star/leaf_population.py
+++ b/orthogonal_dfa/l_star/leaf_population.py
@@ -52,17 +52,6 @@ class LeafPopulation:
         self._fill(at, count)
         return [list(s) for s in self._at.get(at, [])[:count]]
 
-    def representative(self, at: Path, count: int) -> Optional[list]:
-        """
-        The canonical member reaching leaf at: the shortest, ties broken
-        lexicographically. None if no such member exists.
-
-        count is the number of elements to ensure we have before selecting this
-        representative.
-        """
-        members = self.members(at, count)
-        return min(members, key=lambda m: (len(m), m)) if members else None
-
     def _fill(self, at: Path, count: int) -> None:
         """Pull strings down into ``at`` until it holds ``count`` or its ancestors
         are exhausted."""

--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -1,34 +1,52 @@
-"""
-The partial transition function the resolver builds alongside its tree.
+"""The partial transition function the resolver builds alongside its tree.
 
-Also contains methods for splitting states and a loop for resolving unresolved edges.
+``delta`` under construction: the edges resolved so far and the witness prefix
+that justified each one.  Keeping it here is what lets a split invalidate
+*precisely* the edges it made ambiguous instead of rebuilding the hypothesis: an
+edge that does not touch the split leaf keeps a valid witness, because its sift
+path never passed through that leaf.
+
+The object owns bookkeeping only.  *Deciding* where an edge points needs the
+oracle, so the caller supplies ``resolve(state, symbol)`` when draining and
+``decisive_target(state, symbol)`` when totalising.  Neither the edges pointing at
+a state nor the edges still to resolve are indexed: a split needs the former only
+~once per state, and an unresolved edge is just one missing from ``transitions``
+-- both are scanned on demand.
 """
 
 from typing import Dict, List, Optional, Tuple
 
 
 class PartialDFA:
+    """See the module docstring."""
+
     def __init__(self, alphabet_size: int, *, num_states: int):
         self.alphabet_size = alphabet_size
-        #: transitions[s][c] = s'
+        #: ``transitions[s][c]`` -- the current best guess for ``delta(s, c)``.
         self.transitions: Dict[int, Dict[int, int]] = {s: {} for s in range(num_states)}
-        #: A prefix reaching s whose extension by c reaches transitions[s][c] --
-        #: the member that resolved the edge, kept so a split can separate on it.
+        #: A prefix that provably reaches ``s`` and whose one-symbol extension by
+        #: ``c`` reaches ``transitions[s][c]``.
         self.witnesses: Dict[Tuple[int, int], List[int]] = {}
+
+    # -- edges --------------------------------------------------------------
 
     def target(self, state: int, c: int) -> Optional[int]:
         return self.transitions[state].get(c)
 
-    def witness(self, state: int, c: int) -> Optional[List[int]]:
-        return self.witnesses.get((state, c))
-
     def has_edge(self, state: int, c: int) -> bool:
         return c in self.transitions[state]
+
+    def witness(self, state: int, c: int) -> Optional[List[int]]:
+        return self.witnesses.get((state, c))
 
     def set_edge(self, state: int, c: int, target: int, witness) -> None:
         assert c not in self.transitions[state]
         self.transitions[state][c] = target
         self.witnesses[state, c] = list(witness)
+
+    def clear_edge(self, state: int, c: int) -> None:
+        self.transitions[state].pop(c, None)
+        self.witnesses.pop((state, c), None)
 
     def edges_into(self, state: int) -> List[Tuple[int, int]]:
         """The edges whose current target is ``state``, scanned from
@@ -40,6 +58,15 @@ class PartialDFA:
             if t == state
         ]
 
+    def unresolved_edges(self) -> List[Tuple[int, int]]:
+        """Every edge still missing from ``transitions``."""
+        return [
+            (s, c)
+            for s, edges in self.transitions.items()
+            for c in range(self.alphabet_size)
+            if c not in edges
+        ]
+
     def _next_unresolved(self) -> Optional[Tuple[int, int]]:
         for state, edges in self.transitions.items():
             for c in range(self.alphabet_size):
@@ -47,26 +74,66 @@ class PartialDFA:
                     return (state, c)
         return None
 
-    def split_state(self, state: int, new_state: int) -> None:
-        """
-        Account for state bifurcating into (state, new_state).
+    # -- resolving ----------------------------------------------------------
 
-        All relevant edges are removed, both outgoing from and incoming to state.
-        """
-        self.transitions[new_state] = {}
-        for c in range(self.alphabet_size):
-            self.transitions[state].pop(c, None)
-            self.witnesses.pop((state, c), None)
-        for src, c in self.edges_into(state):
-            self.transitions[src].pop(c, None)
-            self.witnesses.pop((src, c), None)
+    def pending_probes(self, representative) -> List[List[int]]:
+        """``representative(s) + [c]`` for every unresolved edge -- the strings the
+        next :meth:`drain` will sift, so a caller can warm them in one batch."""
+        probes = []
+        for s, c in self.unresolved_edges():
+            rep = representative(s)
+            if rep is not None:
+                probes.append(list(rep) + [c])
+        return probes
 
-    def drain(self, resolve) -> None:
-        """
-        Resolve edges via resolve(state, symbol) until every one is filled.
+    def drain(self, resolve) -> int:
+        """Resolve edges via ``resolve(state, symbol)`` until every one is filled;
+        returns the number resolved.
 
-        resolve() is allowed to call split_state() on this, which adds more work,
-        so this is not guaranteed to terminate unless resolve() is well-behaved.
+        ``resolve`` is allowed to call :meth:`split_state`, which clears edges the
+        next scan picks back up, so this loops until no edge is missing rather than
+        iterating a fixed list.
         """
+        resolved = 0
         while (edge := self._next_unresolved()) is not None:
             resolve(*edge)
+            resolved += 1
+        return resolved
+
+    # -- splitting ----------------------------------------------------------
+
+    def split_state(self, state: int, new_state: int) -> None:
+        """Account for ``state`` having bifurcated into ``state`` and ``new_state``.
+
+        Only edges incident to the old leaf become ambiguous: its outgoing edges
+        vanish (the source is now two states) and every edge into it must be
+        re-classified.  Both sets are dropped; they and the new leaf's edges then
+        read as unresolved and get re-resolved."""
+        self.transitions[new_state] = {}
+        for c in range(self.alphabet_size):
+            self.clear_edge(state, c)
+        for src, c in self.edges_into(state):
+            self.clear_edge(src, c)
+
+    # -- export -------------------------------------------------------------
+
+    def totalise(self, states, decisive_target):
+        """A total copy of ``delta``.  An edge resolution left open is filled from
+        ``decisive_target(state, symbol)``; where that fails too the edge
+        self-loops and is reported in the second return value.
+
+        Does not mutate ``transitions`` -- unresolved edges stay open so a later
+        round can still close them."""
+        complete: Dict[int, Dict[int, int]] = {}
+        unresolved: List[Tuple[int, int]] = []
+        for state in states:
+            complete[state] = dict(self.transitions[state])
+            for c in range(self.alphabet_size):
+                if c in complete[state]:
+                    continue
+                target = decisive_target(state, c)
+                if target is None:
+                    unresolved.append((state, c))
+                    target = state
+                complete[state][c] = target
+        return complete, unresolved

--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -59,16 +59,6 @@ class PartialDFA:
                     return (state, c)
         return None
 
-    def pending_probes(self, representative) -> List[List[int]]:
-        """representative(s) + [c] for every unresolved edge -- the strings a drain
-        will sift, exposed so a caller can warm them in one batch."""
-        probes = []
-        for s, c in self.unresolved_edges():
-            rep = representative(s)
-            if rep is not None:
-                probes.append(list(rep) + [c])
-        return probes
-
     def drain(self, resolve) -> int:
         """
         Resolve edges via resolve(state, symbol) until every one is filled; return

--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -1,7 +1,8 @@
 """
 The partial transition function the resolver builds alongside its tree.
 
-Also contains methods for splitting states and a loop for resolving unresolved edges.
+Also contains methods for splitting a state and for totalising the partial delta
+into a complete transition function for export.
 """
 
 from typing import Dict, List, Optional, Tuple
@@ -51,27 +52,6 @@ class PartialDFA:
             for c in range(self.alphabet_size)
             if c not in edges
         ]
-
-    def _next_unresolved(self) -> Optional[Tuple[int, int]]:
-        for state, edges in self.transitions.items():
-            for c in range(self.alphabet_size):
-                if c not in edges:
-                    return (state, c)
-        return None
-
-    def drain(self, resolve) -> int:
-        """
-        Resolve edges via resolve(state, symbol) until every one is filled; return
-        how many were resolved.
-
-        resolve() is allowed to call split_state() on this, which adds more work,
-        so this is not guaranteed to terminate unless resolve() is well-behaved.
-        """
-        resolved = 0
-        while (edge := self._next_unresolved()) is not None:
-            resolve(*edge)
-            resolved += 1
-        return resolved
 
     def split_state(self, state: int, new_state: int) -> None:
         """

--- a/orthogonal_dfa/l_star/partial_dfa.py
+++ b/orthogonal_dfa/l_star/partial_dfa.py
@@ -1,34 +1,19 @@
-"""The partial transition function the resolver builds alongside its tree.
+"""
+The partial transition function the resolver builds alongside its tree.
 
-``delta`` under construction: the edges resolved so far and the witness prefix
-that justified each one.  Keeping it here is what lets a split invalidate
-*precisely* the edges it made ambiguous instead of rebuilding the hypothesis: an
-edge that does not touch the split leaf keeps a valid witness, because its sift
-path never passed through that leaf.
-
-The object owns bookkeeping only.  *Deciding* where an edge points needs the
-oracle, so the caller supplies ``resolve(state, symbol)`` when draining and
-``decisive_target(state, symbol)`` when totalising.  Neither the edges pointing at
-a state nor the edges still to resolve are indexed: a split needs the former only
-~once per state, and an unresolved edge is just one missing from ``transitions``
--- both are scanned on demand.
+Also contains methods for splitting states and a loop for resolving unresolved edges.
 """
 
 from typing import Dict, List, Optional, Tuple
 
 
 class PartialDFA:
-    """See the module docstring."""
-
     def __init__(self, alphabet_size: int, *, num_states: int):
         self.alphabet_size = alphabet_size
-        #: ``transitions[s][c]`` -- the current best guess for ``delta(s, c)``.
+        #: transitions[s][c] = s'
         self.transitions: Dict[int, Dict[int, int]] = {s: {} for s in range(num_states)}
-        #: A prefix that provably reaches ``s`` and whose one-symbol extension by
-        #: ``c`` reaches ``transitions[s][c]``.
+        #: witnesses[s, c] = A prefix x such that dfa(x) = s and dfa(x + [c]) = transitions[s][c]
         self.witnesses: Dict[Tuple[int, int], List[int]] = {}
-
-    # -- edges --------------------------------------------------------------
 
     def target(self, state: int, c: int) -> Optional[int]:
         return self.transitions[state].get(c)
@@ -74,11 +59,9 @@ class PartialDFA:
                     return (state, c)
         return None
 
-    # -- resolving ----------------------------------------------------------
-
     def pending_probes(self, representative) -> List[List[int]]:
-        """``representative(s) + [c]`` for every unresolved edge -- the strings the
-        next :meth:`drain` will sift, so a caller can warm them in one batch."""
+        """representative(s) + [c] for every unresolved edge -- the strings a drain
+        will sift, exposed so a caller can warm them in one batch."""
         probes = []
         for s, c in self.unresolved_edges():
             rep = representative(s)
@@ -87,12 +70,12 @@ class PartialDFA:
         return probes
 
     def drain(self, resolve) -> int:
-        """Resolve edges via ``resolve(state, symbol)`` until every one is filled;
-        returns the number resolved.
+        """
+        Resolve edges via resolve(state, symbol) until every one is filled; return
+        how many were resolved.
 
-        ``resolve`` is allowed to call :meth:`split_state`, which clears edges the
-        next scan picks back up, so this loops until no edge is missing rather than
-        iterating a fixed list.
+        resolve() is allowed to call split_state() on this, which adds more work,
+        so this is not guaranteed to terminate unless resolve() is well-behaved.
         """
         resolved = 0
         while (edge := self._next_unresolved()) is not None:
@@ -100,30 +83,27 @@ class PartialDFA:
             resolved += 1
         return resolved
 
-    # -- splitting ----------------------------------------------------------
-
     def split_state(self, state: int, new_state: int) -> None:
-        """Account for ``state`` having bifurcated into ``state`` and ``new_state``.
+        """
+        Account for state bifurcating into (state, new_state).
 
-        Only edges incident to the old leaf become ambiguous: its outgoing edges
-        vanish (the source is now two states) and every edge into it must be
-        re-classified.  Both sets are dropped; they and the new leaf's edges then
-        read as unresolved and get re-resolved."""
+        All relevant edges are removed, both outgoing from and incoming to state.
+        """
         self.transitions[new_state] = {}
         for c in range(self.alphabet_size):
             self.clear_edge(state, c)
         for src, c in self.edges_into(state):
             self.clear_edge(src, c)
 
-    # -- export -------------------------------------------------------------
-
     def totalise(self, states, decisive_target):
-        """A total copy of ``delta``.  An edge resolution left open is filled from
-        ``decisive_target(state, symbol)``; where that fails too the edge
-        self-loops and is reported in the second return value.
+        """
+        A "total" copy this partial DFA. An open edge is filled from
+            decisive_target(state, symbol),
+        or self-looped and reported in the second return value where that
+        fails too.
 
-        Does not mutate ``transitions`` -- unresolved edges stay open so a later
-        round can still close them."""
+        Does not mutate transitions, so a later round can still close the open edges.
+        """
         complete: Dict[int, Dict[int, int]] = {}
         unresolved: List[Tuple[int, int]] = []
         for state in states:

--- a/orthogonal_dfa/l_star/sifting.py
+++ b/orthogonal_dfa/l_star/sifting.py
@@ -1,0 +1,49 @@
+"""Classifying strings against the current discrimination tree.
+
+The tree knows which midfix cuts where; the family knows how to answer a midfix.
+Putting them together is what "sift" means, and both the probe loop and the edge
+resolver need it, so it lives here rather than in either of them.
+"""
+
+from typing import Optional, Tuple
+
+
+class Sifter:
+    """Routes strings through ``tree``, classifying with ``family``."""
+
+    def __init__(self, tree, family):
+        self.tree = tree
+        self.family = family
+
+    def sift_and_boundary(self, seq) -> Tuple[Optional[int], Optional[tuple]]:
+        """Route ``seq`` to a leaf: ``(state, None)``, or ``(None, boundary)``
+        when some node cannot place it."""
+        return self.tree.sift(seq, self.family.is_accept)
+
+    def sift(self, seq) -> Optional[int]:
+        leaf, _ = self.sift_and_boundary(seq)
+        return leaf
+
+    def prefill(self, seqs) -> None:
+        """Warm the cache for sifting all of ``seqs``, one batched call per tree
+        level rather than one per node visited.
+
+        Uses ``classify_many`` purely for its per-level walk: each level's
+        ``decide`` first warms the whole level's family cells in one batched call,
+        then reads them back (now cached) to descend.  The returned leaves are
+        discarded -- only the warmed cache matters."""
+
+        def warm(pairs):
+            self.family.prefill([list(s) + list(m) for s, m in pairs])
+            return [self.family.is_accept(s, m) for s, m in pairs]
+
+        self.tree.classify_many(seqs, warm)
+
+    def disagreement(self, s, sprime, prefix) -> Optional[tuple]:
+        """A midfix separating ``s`` and ``sprime`` (see
+        :meth:`MidfixTree.first_disagreement`), or ``None``.
+
+        This only *proposes* a distinguisher; whether the split fires is decided
+        by the population evidence, so the pair need only clear the ordinary
+        decisive band, not a wide split margin."""
+        return self.tree.first_disagreement(s, sprime, self.family.is_accept, prefix)

--- a/orthogonal_dfa/l_star/sifting.py
+++ b/orthogonal_dfa/l_star/sifting.py
@@ -20,10 +20,6 @@ class Sifter:
         when some node cannot place it."""
         return self.tree.sift(seq, self.family.is_accept)
 
-    def sift(self, seq) -> Optional[int]:
-        leaf, _ = self.sift_and_boundary(seq)
-        return leaf
-
     def prefill(self, seqs) -> None:
         """Warm the cache for sifting all of ``seqs``, one batched call per tree
         level rather than one per node visited.

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -4,17 +4,20 @@ Builds the discrimination tree (states) and the transition function together.
 
 The tree starts as the initial distinguisher family v_eps, partitioning the
 prefix pool into accept / reject -- two leaves, the initial two states.  Each
-(state, symbol) edge is then resolved by sifting a member of the state extended
-by the symbol: the leaf it lands on is the target, and the member is kept as the
-edge's witness (the tree is consistent, so any member resolves it the same way).
+(state, symbol) edge is resolved by sifting a member of the state extended by the
+symbol: the leaf it lands on is the target, and the member is kept as the edge's
+witness (the tree is consistent, so any member resolves it the same way).  A leaf
+every one of whose members is indecisive, or that no prefix reaches, leaves its
+edge open; the export totalises those -- self-looping them and feeding their
+boundary strings back so the next round's family resolves them (see EdgeResolver).
 
 States beyond the initial two are found by the counterexample pass: random probe
-strings are walked through the resolved transition function and re-sifted, and
-where the walk and the sift disagree the probe has exhibited two prefixes that
-reach one leaf yet behave differently under one more symbol -- a Myhill-Nerode
-counterexample -- so that leaf is split (see SplitEvidence).  A split drops the
-edges it made ambiguous; both they and the new leaf's edges then read as
-unresolved and are refilled on the next resolve pass.
+strings are walked through a *totalised* copy of the transition function and
+re-sifted, and where the walk and the sift disagree the probe has exhibited two
+prefixes that reach one leaf yet behave differently under one more symbol -- a
+Myhill-Nerode counterexample -- so that leaf is split (see SplitEvidence).  A
+split drops the edges it made ambiguous; both they and the new leaf's edges then
+read as unresolved and are refilled on the next resolve pass.
 
 Each state's prefixes -- the pool prefixes that sift to its leaf -- live in a
 :class:`~orthogonal_dfa.l_star.leaf_population.LeafPopulation`.  The split keeps
@@ -26,6 +29,7 @@ remapping on export.
 from automata.fa.dfa import DFA
 
 from .cluster import sample_suffix_family
+from .edge_resolver import EdgeResolver
 from .leaf_population import LeafPopulation
 from .midfix_tree import MidfixTree, oracle_decider
 from .partial_dfa import PartialDFA
@@ -51,6 +55,7 @@ class TransitionResolver:
         self.splits = None
         self.population = None  # pool prefixes, per leaf
         self.dfa = None  # the partial transition function
+        self.edges = None  # resolves (leaf, symbol) edges against the population
         self.indecisive = set()  # boundary strings the family could not place
 
     # -- membership / population -------------------------------------------
@@ -60,12 +65,6 @@ class TransitionResolver:
         between the thresholds returns None and drops out of the population."""
         self.family.prefill([list(s) + list(midfix) for s in strings])
         return [self.family.is_accept(s, midfix) for s in strings]
-
-    def _members(self, state_id):
-        """The pool prefixes that sift to leaf ``state_id``."""
-        return self.population.members(
-            self.tree.path_of(state_id), self.pst.num_prefixes
-        )
 
     def _sift(self, seq):
         """The leaf ``seq`` sifts to, or ``None`` when a node cannot place it.
@@ -78,36 +77,6 @@ class TransitionResolver:
             self.indecisive.add(boundary)
         return leaf
 
-    # -- the resolution step ------------------------------------------------
-
-    def _resolve(self, state_id, c):
-        members = self._members(state_id)
-        target, witness = self._edge_target(c, members)
-        self.dfa.set_edge(state_id, c, target, witness)
-
-    def _tally(self, members, distinguisher):
-        """Accept/reject counts of ``members`` classified against ``distinguisher``.
-        Means are memoized, so the split-detection and edge-target descents that
-        both call this share every read."""
-        self.family.prefill([list(m) + distinguisher for m in members])
-        votes = [self.family.is_accept(m, distinguisher) for m in members]
-        return sum(v is True for v in votes), sum(v is False for v in votes)
-
-    def _edge_target(self, c, members):
-        """Where the ``(leaf, c)`` edge points and the member that witnesses it:
-        the first decisive member's ``c``-successor, or the whole-population
-        majority (witnessed by any member) when every member is indecisive."""
-        for m in members:
-            target = self._sift(list(m) + [c])
-            if target is not None:
-                return target, list(m)
-        node = self.tree.root
-        while not isinstance(node, int):
-            midfix, lookup = node
-            n_acc, n_rej = self._tally(members, [c] + list(midfix))
-            node = lookup[True] if n_acc >= n_rej else lookup[False]
-        return node, (list(members[0]) if members else [])
-
     def _split(self, state_id, midfix):
         # The population re-sifts state_id's prefixes on the next members() call.
         new_id = self.tree.split(state_id, midfix)
@@ -118,23 +87,36 @@ class TransitionResolver:
     def counterexample_pass(self, *, max_probes, patience):
         """Split in place on DFA-vs-tree disagreements until they dry up.
 
-        Each probe is walked through the resolved delta and re-sifted; where they
+        Each probe is walked through a totalised delta and re-sifted; where they
         disagree, the probe has exhibited two prefixes reaching one leaf that
         behave differently under one more symbol, so the leaf is split -- the same
         counterexample the outer loop used to defer by adding a prefix and
         rebuilding. Stops after ``patience`` consecutive clean probes."""
         since_split = 0
+        delta = self._total_delta()
         for w in self._probe_blocks(max_probes):
-            status = self._process(w)
+            status = self._process(w, delta)
             if status == _SPLIT:
                 since_split = 0
-                self.dfa.drain(self._resolve)  # the split dropped edges; refill
+                self.edges.close()  # the split dropped edges; refill
+                delta = self._total_delta()  # the split rewrote the state set
             elif status == _UNDECIDED:
                 since_split = 0
             else:
                 since_split += 1
             if since_split >= patience:
                 break
+
+    def _total_delta(self):
+        """A total transition function to walk.  Edge resolution cannot always
+        close an edge -- a leaf every one of whose members is indecisive has no
+        successor the family can name -- so the remainder is filled here, once,
+        rather than every probe that passes through it re-sifting."""
+        delta, _ = self.dfa.totalise(
+            range(self.tree.num_states),
+            lambda s, c: self.edges.decisive_target(s, c)[0],
+        )
+        return delta
 
     def _probe_blocks(self, max_probes):
         drawn = 0
@@ -147,9 +129,9 @@ class TransitionResolver:
             self.sifter.prefill(block)
             yield from block
 
-    def _process(self, w):
-        """Anchor at the shortest prefix the tree places, follow the resolved
-        delta, then act on where the walk and a fresh sift disagree."""
+    def _process(self, w, delta):
+        """Anchor at the shortest prefix the tree places, follow the total delta,
+        then act on where the walk and a fresh sift disagree."""
         w = list(w)
         state = None
         start = 0
@@ -166,32 +148,40 @@ class TransitionResolver:
         self.population.add(w[:start], at=self.tree.path_of(state))
         states = [None] * start + [state]
         for c in w[start:]:
-            state = self.dfa.target(state, c)
+            state = delta[state][c]
             states.append(state)
         return self._act_on_disagreement(w, states, start)
 
     def _act_on_disagreement(self, w, states, agree_point):
+        state = states[-1]
         actual = self._sift(w)
-        if actual is None or actual == states[-1]:
+        if actual is None or state is None or actual == state:
             return _RESOLVED
         fd = self._first_bad_edge(w, states, agree_point, len(w))
         if fd is None:
             return _RESOLVED
-        # The walk follows resolved edges over a total delta, so s1, its
-        # c-successor and the edge's witness are all present, and sprime reaches s1
-        # (the sift agrees up to fd - 1). Only a majority-fallback witness (from an
-        # empty-membered leaf) can miss s1, which the sift below screens out.
-        s1, c = states[fd - 1], w[fd - 1]
-        sprime = w[: fd - 1]
+        s1, c, s2 = states[fd - 1], w[fd - 1], states[fd]
+        if s1 is None or s2 is None:
+            return _RESOLVED
+        # The walk follows a totalised delta, so the followed edge s1 -(c)-> s2 can
+        # be a gap the totaliser self-looped rather than a resolved DFA edge -- then
+        # the DFA holds no such edge, there is no witness to separate on, and the
+        # re-sifts need not reach s1.  Any of those means the disagreement is not
+        # one we can act on.
+        if self.dfa.target(s1, c) != s2:
+            return _RESOLVED
         witness = self.dfa.witness(s1, c)
-        if self._sift(witness) != s1:
+        if witness is None:
+            return _RESOLVED
+        sprime = w[: fd - 1]
+        if self._sift(witness) != s1 or self._sift(sprime) != s1:
             return _RESOLVED
         distinguisher = self.sifter.disagreement(witness, sprime, [c])
         if distinguisher is None:
             return _RESOLVED
-        verdict = self.splits.verdict(s1, tuple(distinguisher))
+        verdict = self.splits.verdict(s1, distinguisher)
         if verdict == SPLIT:
-            self._apply_split(s1, list(distinguisher), witness, sprime)
+            self._apply_split(s1, distinguisher, witness, sprime)
             return _SPLIT
         return _RESOLVED if verdict == NO_SPLIT else _UNDECIDED
 
@@ -236,7 +226,10 @@ class TransitionResolver:
             tree=self.tree,
         )
         self.dfa = PartialDFA(pst.alphabet_size, num_states=self.tree.num_states)
-        self.dfa.drain(self._resolve)
+        self.edges = EdgeResolver(
+            self.dfa, self.sifter, self.indecisive, population=self.population
+        )
+        self.edges.close()
 
     # -- output -------------------------------------------------------------
 
@@ -244,7 +237,14 @@ class TransitionResolver:
         pst = self.pst
         n = self.tree.num_states
 
-        transitions = {i: dict(self.dfa.transitions[i]) for i in range(n)}
+        transitions, unresolved = self.dfa.totalise(
+            range(n), lambda s, c: self.edges.decisive_target(s, c)[0]
+        )
+        for state, c in unresolved:
+            print(
+                f"transition_resolver: no decisive edge for (state {state}, symbol "
+                f"{c}); falling back to a self-loop"
+            )
 
         accepting = self.tree.accepting_leaves()
 

--- a/orthogonal_dfa/l_star/transition_resolver.py
+++ b/orthogonal_dfa/l_star/transition_resolver.py
@@ -29,6 +29,7 @@ from .cluster import sample_suffix_family
 from .leaf_population import LeafPopulation
 from .midfix_tree import MidfixTree, oracle_decider
 from .partial_dfa import PartialDFA
+from .sifting import Sifter
 from .split_evidence import NO_SPLIT, SPLIT, SplitEvidence
 from .suffix_family import SuffixFamily
 
@@ -46,6 +47,7 @@ class TransitionResolver:
         self.pst = pst
         self.tree = None
         self.family = None
+        self.sifter = None
         self.splits = None
         self.population = None  # pool prefixes, per leaf
         self.dfa = None  # the partial transition function
@@ -71,7 +73,7 @@ class TransitionResolver:
         Every string the tree cannot place is harvested into ``indecisive``: it is
         a boundary string the current family straddles, and the driver feeds these
         back so the next family is forced to resolve them."""
-        leaf, boundary = self.tree.sift(list(seq), self.family.is_accept)
+        leaf, boundary = self.sifter.sift_and_boundary(list(seq))
         if leaf is None:
             self.indecisive.add(boundary)
         return leaf
@@ -142,19 +144,8 @@ class TransitionResolver:
                 for _ in range(min(_PROBE_BLOCK, max_probes - drawn))
             ]
             drawn += len(block)
-            self._prefill_sifts(block)
+            self.sifter.prefill(block)
             yield from block
-
-    def _prefill_sifts(self, seqs):
-        """Warm the whole block's sifts one tree level at a time -- one batched
-        family read per level over every probe still descending, rather than one
-        per node per probe -- so :meth:`_process` then re-reads a warm cache."""
-
-        def decide_level(pairs):
-            self.family.prefill([list(s) + list(m) for s, m in pairs])
-            return [self.family.is_accept(s, m) for s, m in pairs]
-
-        self.tree.classify_many(seqs, decide_level)
 
     def _process(self, w):
         """Anchor at the shortest prefix the tree places, follow the resolved
@@ -195,9 +186,7 @@ class TransitionResolver:
         witness = self.dfa.witness(s1, c)
         if self._sift(witness) != s1:
             return _RESOLVED
-        distinguisher = self.tree.first_disagreement(
-            witness, sprime, self.family.is_accept, [c]
-        )
+        distinguisher = self.sifter.disagreement(witness, sprime, [c])
         if distinguisher is None:
             return _RESOLVED
         verdict = self.splits.verdict(s1, tuple(distinguisher))
@@ -236,6 +225,7 @@ class TransitionResolver:
         pst.decision_boundary = boundary
         self.family = SuffixFamily(pst, vs)
         self.tree = MidfixTree([pst.table.suffix(i) for i in vs])
+        self.sifter = Sifter(self.tree, self.family)
         self.population = LeafPopulation(self.tree, self._classify)
         for p in pst.table.prefixes:
             self.population.add(list(p))

--- a/tests/test_leaf_population.py
+++ b/tests/test_leaf_population.py
@@ -84,6 +84,18 @@ class TestLeafPopulation(unittest.TestCase):
         # Only two strings reach (True,); asking for more just returns those two.
         self.assertEqual(sorted(pop.members((True,), 50)), [[1, 0], [1, 1]])
 
+    def test_representative_is_the_shortest_member(self):
+        classify, _ = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        for s in ([3, 3, 3], [7], [1, 2]):
+            pop.add(s, at=(True,))
+        self.assertEqual(pop.representative((True,), 10), [7])
+
+    def test_representative_is_none_when_no_members_reach_the_leaf(self):
+        classify, _ = _classifier()
+        pop = LeafPopulation(_StubTree(), classify, chunk=16)
+        self.assertIsNone(pop.representative((True,), 10))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_leaf_population.py
+++ b/tests/test_leaf_population.py
@@ -84,18 +84,6 @@ class TestLeafPopulation(unittest.TestCase):
         # Only two strings reach (True,); asking for more just returns those two.
         self.assertEqual(sorted(pop.members((True,), 50)), [[1, 0], [1, 1]])
 
-    def test_representative_is_the_shortest_member(self):
-        classify, _ = _classifier()
-        pop = LeafPopulation(_StubTree(), classify, chunk=16)
-        for s in ([3, 3, 3], [7], [1, 2]):
-            pop.add(s, at=(True,))
-        self.assertEqual(pop.representative((True,), 10), [7])
-
-    def test_representative_is_none_when_no_members_reach_the_leaf(self):
-        classify, _ = _classifier()
-        pop = LeafPopulation(_StubTree(), classify, chunk=16)
-        self.assertIsNone(pop.representative((True,), 10))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_partial_dfa.py
+++ b/tests/test_partial_dfa.py
@@ -29,33 +29,6 @@ class TestPartialDFA(unittest.TestCase):
         d.set_edge(0, 0, 1, [])
         self.assertEqual(set(d.unresolved_edges()), {(0, 1), (1, 0), (1, 1)})
 
-    def test_drain_resolves_every_edge_and_counts_them(self):
-        d = self._dfa()
-        resolved = []
-
-        def resolve(s, c):
-            resolved.append((s, c))
-            d.set_edge(s, c, 0, [s])
-
-        self.assertEqual(d.drain(resolve), 4)
-        self.assertEqual(d.unresolved_edges(), [])
-
-    def test_drain_loops_until_no_edge_is_missing(self):
-        # A resolve that splits on its first call reopens edges; drain must pick
-        # them up rather than stopping at the initial set.
-        d = PartialDFA(alphabet_size=2, num_states=1)
-        calls = []
-
-        def resolve(s, c):
-            calls.append((s, c))
-            d.set_edge(s, c, 0, [])
-            if len(calls) == 1:
-                d.split_state(0, 1)
-
-        count = d.drain(resolve)
-        self.assertEqual(d.unresolved_edges(), [])
-        self.assertGreater(count, 2)  # more than the initial 2 edges, due to the split
-
     def test_split_state_reopens_incident_edges(self):
         d = self._dfa()
         d.set_edge(0, 0, 1, [0])  # into 1

--- a/tests/test_partial_dfa.py
+++ b/tests/test_partial_dfa.py
@@ -1,0 +1,96 @@
+import unittest
+
+from orthogonal_dfa.l_star.partial_dfa import PartialDFA
+
+
+class TestPartialDFA(unittest.TestCase):
+    def _dfa(self, num_states=2):
+        return PartialDFA(alphabet_size=2, num_states=num_states)
+
+    def test_set_and_read_edge(self):
+        d = self._dfa()
+        d.set_edge(0, 1, 1, [0, 1])
+        self.assertEqual(d.target(0, 1), 1)
+        self.assertEqual(d.witness(0, 1), [0, 1])
+        self.assertTrue(d.has_edge(0, 1))
+        self.assertFalse(d.has_edge(0, 0))
+
+    def test_clear_edge_removes_target_and_witness(self):
+        d = self._dfa()
+        d.set_edge(0, 1, 1, [3])
+        d.clear_edge(0, 1)
+        self.assertIsNone(d.target(0, 1))
+        self.assertIsNone(d.witness(0, 1))
+        self.assertFalse(d.has_edge(0, 1))
+
+    def test_unresolved_edges_shrinks_as_edges_are_set(self):
+        d = self._dfa()  # 2 states x 2 symbols = 4 edges
+        self.assertEqual(len(d.unresolved_edges()), 4)
+        d.set_edge(0, 0, 1, [])
+        self.assertEqual(set(d.unresolved_edges()), {(0, 1), (1, 0), (1, 1)})
+
+    def test_drain_resolves_every_edge_and_counts_them(self):
+        d = self._dfa()
+        resolved = []
+
+        def resolve(s, c):
+            resolved.append((s, c))
+            d.set_edge(s, c, 0, [s])
+
+        self.assertEqual(d.drain(resolve), 4)
+        self.assertEqual(d.unresolved_edges(), [])
+
+    def test_drain_loops_until_no_edge_is_missing(self):
+        # A resolve that splits on its first call reopens edges; drain must pick
+        # them up rather than stopping at the initial set.
+        d = PartialDFA(alphabet_size=2, num_states=1)
+        calls = []
+
+        def resolve(s, c):
+            calls.append((s, c))
+            d.set_edge(s, c, 0, [])
+            if len(calls) == 1:
+                d.split_state(0, 1)
+
+        count = d.drain(resolve)
+        self.assertEqual(d.unresolved_edges(), [])
+        self.assertGreater(count, 2)  # more than the initial 2 edges, due to the split
+
+    def test_pending_probes_extends_each_representative_by_its_symbol(self):
+        d = self._dfa()
+        d.set_edge(0, 0, 1, [])  # leaves (0,1), (1,0), (1,1) open
+        reps = {0: [9], 1: [8, 8]}
+        probes = d.pending_probes(lambda s: reps[s])
+        self.assertEqual(sorted(probes), sorted([[9, 1], [8, 8, 0], [8, 8, 1]]))
+
+    def test_pending_probes_skips_edges_without_a_representative(self):
+        d = self._dfa()
+        probes = d.pending_probes(lambda s: [s] if s == 0 else None)
+        self.assertEqual(sorted(probes), sorted([[0, 0], [0, 1]]))
+
+    def test_split_state_reopens_incident_edges(self):
+        d = self._dfa()
+        d.set_edge(0, 0, 1, [0])  # into 1
+        d.set_edge(1, 0, 0, [1])  # out of 1
+        d.split_state(1, 2)
+        self.assertFalse(d.has_edge(0, 0))
+        self.assertFalse(d.has_edge(1, 0))
+        self.assertEqual(d.transitions[2], {})
+
+    def test_totalise_fills_open_edges_and_reports_the_unfillable(self):
+        d = self._dfa()
+        d.set_edge(0, 0, 1, [])
+
+        def decisive_target(s, c):
+            return 0 if (s, c) == (0, 1) else None
+
+        complete, unresolved = d.totalise([0, 1], decisive_target)
+        self.assertEqual(complete[0], {0: 1, 1: 0})
+        self.assertEqual(complete[1], {0: 1, 1: 1})  # unfillable edges self-loop
+        self.assertEqual(sorted(unresolved), [(1, 0), (1, 1)])
+        # totalise does not mutate: the edges stay open for a later round
+        self.assertEqual(set(d.unresolved_edges()), {(0, 1), (1, 0), (1, 1)})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_partial_dfa.py
+++ b/tests/test_partial_dfa.py
@@ -56,18 +56,6 @@ class TestPartialDFA(unittest.TestCase):
         self.assertEqual(d.unresolved_edges(), [])
         self.assertGreater(count, 2)  # more than the initial 2 edges, due to the split
 
-    def test_pending_probes_extends_each_representative_by_its_symbol(self):
-        d = self._dfa()
-        d.set_edge(0, 0, 1, [])  # leaves (0,1), (1,0), (1,1) open
-        reps = {0: [9], 1: [8, 8]}
-        probes = d.pending_probes(lambda s: reps[s])
-        self.assertEqual(sorted(probes), sorted([[9, 1], [8, 8, 0], [8, 8, 1]]))
-
-    def test_pending_probes_skips_edges_without_a_representative(self):
-        d = self._dfa()
-        probes = d.pending_probes(lambda s: [s] if s == 0 else None)
-        self.assertEqual(sorted(probes), sorted([[0, 0], [0, 1]]))
-
     def test_split_state_reopens_incident_edges(self):
         d = self._dfa()
         d.set_edge(0, 0, 1, [0])  # into 1


### PR DESCRIPTION
## What

Moves edge resolution out of `TransitionResolver` into an `EdgeResolver`. For a `(leaf, symbol)` edge it sifts the members the leaf already has and takes the **first successor the family can place**; if none can, it **leaves the edge open** rather than fabricating a whole-population majority guess. The export `totalise`s the open edges (self-loop) and each unplaceable `member + symbol` feeds back so the next round's family resolves it.

Because an edge can now be open, the probe walk follows a **totalised** copy of `delta` (so a gap doesn't stop the walk), and `close()` is a single pass over the open edges — a resolve-until-none `drain` would spin on an edge it must leave open.

- `edge_resolver.py` (new) — `EdgeResolver`: `decisive_target` (sift members, first placeable, harvest the rest), `resolve` (set it or leave open), `close` (one pass).
- `transition_resolver.py` — walks the totalised delta, totalises at export, delegates to `EdgeResolver`; `_members`/`_resolve`/`_tally`/`_edge_target` gone.
- `partial_dfa.py` — adds `clear_edge`, `unresolved_edges`, `totalise`; removes `drain`/`_next_unresolved` (no callers).
- `leaf_population.py` — removes `representative` (added in #183 for a shortest-access-string resolver that this design doesn't use).

## Why this is safe

**Byte-identical to main in oracle-query count**, across seeds:

| target | main | this |
|---|---|---|
| subseq | 660 · 8 | 660 · 8 |
| modulo | 487 · 9 | 487 · 9 |
| poor_case 1 | 5092 · 10 | 5092 · 10 |
| poor_case 2 | 1384 · 10 | 1384 · 10 |

`poor_case` accuracy tests and `test_transient_states_terminate` pass; `test_boundary_near_zero` still `xfails`. Lint clean (pylint 10.00/10).

This folds together what were the #184/#185 stack (the `partial_dfa` bookkeeping is only used by the resolver here, so it lands with it rather than a layer below) and removes `representative`, which the simplified resolver made dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Query count — `edge-resolver-v2` vs `main`

|   | task | queries `main` | queries `edge-resolver-v2` | ratio | acc `main` | acc `edge-resolver-v2` | states |
|---|---|---:|---:|---:|---:|---:|---:|
| ⚪ | modulo | 380,342 | 380,342 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | subseq | 424,300 | 424,300 | 1.00x | 1.000 | 1.000 | 8 |
| ⚪ | two_subseq | 477,526 | 477,526 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | poor_case | 634,782 | 634,782 | 1.00x | 1.000 | 1.000 | 10 |
| ⚪ | modulo_hard | 1,072,934 | 1,072,934 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | modulo_asym | 2,275,354 | 2,275,354 | 1.00x | 1.000 | 1.000 | 9 |
| ⚪ | **geomean** |  |  | **1.00x** |  |  |  |

**✅ no regressions** (accuracy held, no task's queries rose beyond band)

### Forward passes — `edge-resolver-v2` vs `main` (neural passes at each batch cap; `base → pr (ratio, pr packing)`)

*Packing is `ceil(pr queries / cap) / pr fp` — the floor if every call filled its batch. Below 100% the remaining passes are under-filled calls, i.e. headroom from co-batching more call sites, not irreducible work.*

| task | fp@32 | fp@128 | fp@1024 |
|---|---:|---:|---:|
| modulo | 12,026 → 12,026 (1.00x, 99% packed) | 3,208 → 3,208 (1.00x, 93% packed) | 676 → 676 (1.00x, 55% packed) |
| subseq | 13,438 → 13,438 (1.00x, 99% packed) | 3,658 → 3,658 (1.00x, 91% packed) | 872 → 872 (1.00x, 48% packed) |
| two_subseq | 15,174 → 15,174 (1.00x, 98% packed) | 4,306 → 4,306 (1.00x, 87% packed) | 1,401 → 1,401 (1.00x, 33% packed) |
| poor_case | 20,110 → 20,110 (1.00x, 99% packed) | 5,611 → 5,611 (1.00x, 88% packed) | 1,723 → 1,723 (1.00x, 36% packed) |
| modulo_hard | 33,708 → 33,708 (1.00x, 99% packed) | 8,683 → 8,683 (1.00x, 97% packed) | 1,399 → 1,399 (1.00x, 75% packed) |
| modulo_asym | 71,333 → 71,333 (1.00x, 100% packed) | 18,099 → 18,099 (1.00x, 98% packed) | 2,531 → 2,531 (1.00x, 88% packed) |
